### PR TITLE
feat(edi-integration): implement bitemporal schema changes and update…

### DIFF
--- a/src/main/java/com/fastChickensHR/edi/integration/api/IntegrationMapper.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/api/IntegrationMapper.java
@@ -31,21 +31,26 @@ public class IntegrationMapper {
                 entity.getToSystemValue(),
                 entity.getFormat(),
                 domain.direction().name(),
-                entity.getCreatedAt()
+                entity.getSysFrom()
         );
     }
 
     /**
-     * Builds a new (non-deleted) entity row for a create or update request.
+     * Builds a new (open-ended) entity row for a create or update request.
+     * All four temporal fields are set: sys_from and valid_from to now(),
+     * sys_to and valid_to to {@link IntegrationEntity#TEMPORAL_INFINITY}.
      */
     public IntegrationEntity toNewEntity(UUID integrationId, IntegrationRequest request) {
         Partner fromSystem = resolvePartnerFromValue(request.fromSystem());
         Partner toSystem = resolvePartnerFromValue(request.toSystem());
 
+        Instant now = Instant.now();
         IntegrationEntity entity = new IntegrationEntity();
         entity.setIntegrationId(integrationId);
-        entity.setCreatedAt(Instant.now());
-        entity.setDeleted(false);
+        entity.setSysFrom(now);
+        entity.setSysTo(IntegrationEntity.TEMPORAL_INFINITY);
+        entity.setValidFrom(now);
+        entity.setValidTo(IntegrationEntity.TEMPORAL_INFINITY);
         entity.setName(request.name());
         entity.setOwnerId(request.ownerId());
         entity.setFromSystemType(systemType(fromSystem));
@@ -57,21 +62,18 @@ public class IntegrationMapper {
     }
 
     /**
-     * Builds a tombstone (is_deleted = true) row that marks an integration as deleted.
+     * Closes the system-time period of a row, marking it as superseded.
+     * Called before inserting an updated version of the same integration.
      */
-    public IntegrationEntity toTombstoneEntity(UUID integrationId, IntegrationEntity current) {
-        IntegrationEntity tombstone = new IntegrationEntity();
-        tombstone.setIntegrationId(integrationId);
-        tombstone.setCreatedAt(Instant.now());
-        tombstone.setDeleted(true);
-        tombstone.setName(current.getName());
-        tombstone.setOwnerId(current.getOwnerId());
-        tombstone.setFromSystemType(current.getFromSystemType());
-        tombstone.setFromSystemValue(current.getFromSystemValue());
-        tombstone.setToSystemType(current.getToSystemType());
-        tombstone.setToSystemValue(current.getToSystemValue());
-        tombstone.setFormat(current.getFormat());
-        return tombstone;
+    public void closeSysTo(IntegrationEntity entity) {
+        entity.setSysTo(Instant.now());
+    }
+
+    /**
+     * Closes the valid-time period of a row, marking it as logically deleted.
+     */
+    public void closeValidTo(IntegrationEntity entity) {
+        entity.setValidTo(Instant.now());
     }
 
     // --- private helpers ---

--- a/src/main/java/com/fastChickensHR/edi/integration/api/IntegrationService.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/api/IntegrationService.java
@@ -40,24 +40,29 @@ public class IntegrationService {
     }
 
     /**
-     * Appends a new row for an existing integration (full replacement, append-only).
-     * Returns empty if no active integration exists for the given id.
+     * Appends a new version for an existing integration (append-only, bitemporal).
+     * The current row's sys_to is closed first to prevent exclusion-constraint violations,
+     * then the new row is inserted with open-ended temporal boundaries.
+     * Returns empty if no currently-valid integration exists for the given id.
      */
     public Optional<IntegrationEntity> update(UUID integrationId, IntegrationRequest request) {
-        if (repository.findCurrentById(integrationId).isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(repository.save(mapper.toNewEntity(integrationId, request)));
+        return repository.findCurrentById(integrationId)
+                .map(current -> {
+                    mapper.closeSysTo(current);
+                    repository.save(current);
+                    return repository.save(mapper.toNewEntity(integrationId, request));
+                });
     }
 
     /**
-     * Soft-deletes an integration by appending a tombstone row.
-     * Returns false if no active integration exists for the given id.
+     * Logically deletes an integration by closing its valid-time period.
+     * Returns false if no currently-valid integration exists for the given id.
      */
     public boolean delete(UUID integrationId) {
         return repository.findCurrentById(integrationId)
                 .map(current -> {
-                    repository.save(mapper.toTombstoneEntity(integrationId, current));
+                    mapper.closeValidTo(current);
+                    repository.save(current);
                     return true;
                 })
                 .orElse(false);

--- a/src/main/java/com/fastChickensHR/edi/integration/persistence/IntegrationEntity.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/persistence/IntegrationEntity.java
@@ -22,6 +22,12 @@ import java.util.UUID;
 @NoArgsConstructor
 public class IntegrationEntity {
 
+    /**
+     * Sentinel value representing an open-ended temporal boundary ("forever").
+     * Stored as {@code '9999-12-31 23:59:59+00'} in PostgreSQL.
+     */
+    public static final Instant TEMPORAL_INFINITY = Instant.parse("9999-12-31T23:59:59Z");
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "row_id")
@@ -30,11 +36,21 @@ public class IntegrationEntity {
     @Column(name = "integration_id", nullable = false)
     private UUID integrationId;
 
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
+    /** System time start — when this row was recorded in the database. */
+    @Column(name = "sys_from", nullable = false)
+    private Instant sysFrom;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean deleted;
+    /** System time end — {@link #TEMPORAL_INFINITY} until superseded by a correction. */
+    @Column(name = "sys_to", nullable = false)
+    private Instant sysTo;
+
+    /** Valid time start — when this state became effective in the real world. */
+    @Column(name = "valid_from", nullable = false)
+    private Instant validFrom;
+
+    /** Valid time end — {@link #TEMPORAL_INFINITY} for currently-valid rows; set to deletion time when deleted. */
+    @Column(name = "valid_to", nullable = false)
+    private Instant validTo;
 
     @Column(name = "name", nullable = false)
     private String name;

--- a/src/main/java/com/fastChickensHR/edi/integration/persistence/IntegrationRepository.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/persistence/IntegrationRepository.java
@@ -17,19 +17,34 @@ import java.util.UUID;
 
 public interface IntegrationRepository extends JpaRepository<IntegrationEntity, UUID> {
 
-    @Query("""
-            SELECT e FROM IntegrationEntity e
-            WHERE e.integrationId = :integrationId AND e.deleted = false
-            ORDER BY e.createdAt DESC
+    /**
+     * Returns the currently-valid, currently-known row for a given integration.
+     *
+     * <p>"Currently known" = sys_to is open (TEMPORAL_INFINITY).
+     * "Currently valid" = valid_from ≤ now() < valid_to.</p>
+     */
+    @Query(value = """
+            SELECT * FROM integrations
+            WHERE integration_id = :integrationId
+              AND sys_to   = '9999-12-31 23:59:59+00'
+              AND valid_from <= now()
+              AND valid_to   >  now()
+            ORDER BY valid_from DESC
             LIMIT 1
-            """)
+            """, nativeQuery = true)
     Optional<IntegrationEntity> findCurrentById(@Param("integrationId") UUID integrationId);
 
+    /**
+     * Returns one currently-valid, currently-known row per distinct integration_id.
+     *
+     * <p>The exclusion constraint ensures at most one such row exists per integration,
+     * so the result set contains exactly one entry per active integration.</p>
+     */
     @Query(value = """
-            SELECT * FROM (
-                SELECT *, ROW_NUMBER() OVER (PARTITION BY integration_id ORDER BY created_at DESC) AS rn
-                FROM integrations
-            ) t WHERE t.rn = 1 AND t.is_deleted = false
+            SELECT * FROM integrations
+            WHERE sys_to   = '9999-12-31 23:59:59+00'
+              AND valid_from <= now()
+              AND valid_to   >  now()
             """, nativeQuery = true)
     List<IntegrationEntity> findAllCurrent();
 }

--- a/src/main/resources/db/migration/V2__add_bitemporal_columns.sql
+++ b/src/main/resources/db/migration/V2__add_bitemporal_columns.sql
@@ -1,0 +1,55 @@
+-- Enable the GiST extension required for the temporal exclusion constraint.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- Drop rows that were soft-deleted under the old boolean scheme.
+-- These have no reliable valid-time boundary, so they are discarded.
+DELETE FROM integrations WHERE is_deleted = true;
+
+-- Rename transaction-time start column to its canonical bitemporal name.
+ALTER TABLE integrations RENAME COLUMN created_at TO sys_from;
+
+-- Add the three new temporal columns as nullable so we can backfill first.
+ALTER TABLE integrations
+    ADD COLUMN sys_to     TIMESTAMPTZ,
+    ADD COLUMN valid_from TIMESTAMPTZ,
+    ADD COLUMN valid_to   TIMESTAMPTZ;
+
+-- Backfill existing rows: all surviving rows are current and open-ended.
+-- valid_from is approximated as sys_from (earliest known effective date).
+UPDATE integrations
+SET sys_to     = '9999-12-31 23:59:59+00',
+    valid_from = sys_from,
+    valid_to   = '9999-12-31 23:59:59+00';
+
+-- Enforce NOT NULL now that every row has values.
+ALTER TABLE integrations
+    ALTER COLUMN sys_to    SET NOT NULL,
+    ALTER COLUMN valid_from SET NOT NULL,
+    ALTER COLUMN valid_to   SET NOT NULL;
+
+-- Set database-level defaults for future inserts.
+ALTER TABLE integrations
+    ALTER COLUMN sys_to    SET DEFAULT '9999-12-31 23:59:59+00',
+    ALTER COLUMN valid_from SET DEFAULT now(),
+    ALTER COLUMN valid_to   SET DEFAULT '9999-12-31 23:59:59+00';
+
+-- Drop the old soft-delete column — valid_to replaces it.
+ALTER TABLE integrations DROP COLUMN is_deleted;
+
+-- Natural uniqueness: no two rows may share the same (integration_id, sys_from, valid_from).
+ALTER TABLE integrations
+    ADD CONSTRAINT uq_integrations_bitemp
+        UNIQUE (integration_id, sys_from, valid_from);
+
+-- Replace the old lookup index with one covering the new column name.
+DROP INDEX idx_integrations_lookup;
+CREATE INDEX idx_integrations_lookup ON integrations (integration_id, sys_from DESC);
+
+-- Exclusion constraint: among all "currently-known" rows (sys_to = infinity),
+-- no two rows for the same integration may have overlapping valid-time periods.
+ALTER TABLE integrations
+    ADD CONSTRAINT excl_integrations_valid_no_overlap
+        EXCLUDE USING gist (
+            integration_id WITH =,
+            tstzrange(valid_from, valid_to) WITH &&
+        ) WHERE (sys_to = '9999-12-31 23:59:59+00');

--- a/src/test/java/com/fastChickensHR/edi/integration/api/IntegrationMapperTest.java
+++ b/src/test/java/com/fastChickensHR/edi/integration/api/IntegrationMapperTest.java
@@ -32,7 +32,6 @@ class IntegrationMapperTest {
         IntegrationEntity entity = mapper.toNewEntity(INTEGRATION_ID, request);
 
         assertEquals(INTEGRATION_ID, entity.getIntegrationId());
-        assertFalse(entity.isDeleted());
         assertEquals("State of Michigan 834", entity.getName());
         assertEquals(OWNER_ID, entity.getOwnerId());
         assertEquals("INTERNAL", entity.getFromSystemType());
@@ -40,7 +39,10 @@ class IntegrationMapperTest {
         assertEquals("EXTERNAL", entity.getToSystemType());
         assertEquals("STATE_OF_MICHIGAN", entity.getToSystemValue());
         assertEquals("X12_834", entity.getFormat());
-        assertNotNull(entity.getCreatedAt());
+        assertNotNull(entity.getSysFrom());
+        assertEquals(IntegrationEntity.TEMPORAL_INFINITY, entity.getSysTo());
+        assertNotNull(entity.getValidFrom());
+        assertEquals(IntegrationEntity.TEMPORAL_INFINITY, entity.getValidTo());
     }
 
     @Test
@@ -72,35 +74,19 @@ class IntegrationMapperTest {
         assertThrows(IllegalArgumentException.class, () -> mapper.toNewEntity(INTEGRATION_ID, request));
     }
 
-    // --- toTombstoneEntity ---
+    // --- closeValidTo (delete) ---
 
     @Test
-    void toTombstoneEntity_copiesAllFieldsAndSetsDeleted() {
+    void closeValidTo_setsValidToToNowAndLeavesOtherFieldsUnchanged() {
         IntegrationEntity current = buildEntity();
+        Instant before = Instant.now();
 
-        IntegrationEntity tombstone = mapper.toTombstoneEntity(INTEGRATION_ID, current);
+        mapper.closeValidTo(current);
 
-        assertTrue(tombstone.isDeleted());
-        assertEquals(INTEGRATION_ID, tombstone.getIntegrationId());
-        assertEquals(current.getName(), tombstone.getName());
-        assertEquals(current.getOwnerId(), tombstone.getOwnerId());
-        assertEquals(current.getFromSystemType(), tombstone.getFromSystemType());
-        assertEquals(current.getFromSystemValue(), tombstone.getFromSystemValue());
-        assertEquals(current.getToSystemType(), tombstone.getToSystemType());
-        assertEquals(current.getToSystemValue(), tombstone.getToSystemValue());
-        assertEquals(current.getFormat(), tombstone.getFormat());
-        assertNotNull(tombstone.getCreatedAt());
-    }
-
-    @Test
-    void toTombstoneEntity_doesNotReuseRowId() {
-        IntegrationEntity current = buildEntity();
-        current.setIntegrationId(INTEGRATION_ID);
-
-        IntegrationEntity tombstone = mapper.toTombstoneEntity(INTEGRATION_ID, current);
-
-        // rowId is null until JPA assigns it — tombstone must be a distinct row
-        assertNull(tombstone.getRowId());
+        assertFalse(current.getValidTo().isBefore(before));
+        assertTrue(current.getValidTo().isBefore(Instant.now().plusSeconds(1)));
+        assertEquals(INTEGRATION_ID, current.getIntegrationId());
+        assertEquals("Test Integration", current.getName());
     }
 
     // --- toResponse ---
@@ -118,7 +104,7 @@ class IntegrationMapperTest {
         assertEquals("STATE_OF_MICHIGAN", response.toSystem());
         assertEquals("X12_834", response.format());
         assertEquals("OUTBOUND", response.direction());
-        assertNotNull(response.createdAt());
+        assertEquals(entity.getSysFrom(), response.createdAt());
     }
 
     @Test
@@ -141,8 +127,10 @@ class IntegrationMapperTest {
     private IntegrationEntity buildEntity() {
         IntegrationEntity entity = new IntegrationEntity();
         entity.setIntegrationId(INTEGRATION_ID);
-        entity.setCreatedAt(Instant.now());
-        entity.setDeleted(false);
+        entity.setSysFrom(Instant.now());
+        entity.setSysTo(IntegrationEntity.TEMPORAL_INFINITY);
+        entity.setValidFrom(Instant.now());
+        entity.setValidTo(IntegrationEntity.TEMPORAL_INFINITY);
         entity.setName("Test Integration");
         entity.setOwnerId(OWNER_ID);
         entity.setFromSystemType("INTERNAL");

--- a/src/test/java/com/fastChickensHR/edi/integration/api/IntegrationServiceTest.java
+++ b/src/test/java/com/fastChickensHR/edi/integration/api/IntegrationServiceTest.java
@@ -111,18 +111,21 @@ class IntegrationServiceTest {
     }
 
     @Test
-    void update_appendsNewRowAndReturnsItWhenFound() {
+    void update_closesSysThenInsertsNewRowAndReturnsItWhenFound() {
         IntegrationRequest request = sampleRequest();
         IntegrationEntity current = new IntegrationEntity();
         IntegrationEntity updated = new IntegrationEntity();
         when(repository.findCurrentById(INTEGRATION_ID)).thenReturn(Optional.of(current));
         when(mapper.toNewEntity(INTEGRATION_ID, request)).thenReturn(updated);
+        when(repository.save(current)).thenReturn(current);
         when(repository.save(updated)).thenReturn(updated);
 
         Optional<IntegrationEntity> result = service.update(INTEGRATION_ID, request);
 
         assertTrue(result.isPresent());
         assertSame(updated, result.get());
+        verify(mapper).closeSysTo(current);
+        verify(repository).save(current);
         verify(repository).save(updated);
     }
 
@@ -136,13 +139,12 @@ class IntegrationServiceTest {
     }
 
     @Test
-    void delete_savesTombstoneRowAndReturnsTrueWhenFound() {
+    void delete_closesValidToAndReturnsTrueWhenFound() {
         IntegrationEntity current = new IntegrationEntity();
-        IntegrationEntity tombstone = new IntegrationEntity();
         when(repository.findCurrentById(INTEGRATION_ID)).thenReturn(Optional.of(current));
-        when(mapper.toTombstoneEntity(INTEGRATION_ID, current)).thenReturn(tombstone);
 
         assertTrue(service.delete(INTEGRATION_ID));
-        verify(repository).save(tombstone);
+        verify(mapper).closeValidTo(current);
+        verify(repository).save(current);
     }
 }


### PR DESCRIPTION
… integration handling

- Add bitemporal columns (`sys_from`, `sys_to`, `valid_from`, `valid_to`) to the `integrations` table with necessary constraints.
- Remove `is_deleted` column and replace soft-deletes with temporal boundaries.
- Modify `IntegrationMapper` and `IntegrationService` to handle bitemporal logic, including system-time and valid-time closures.
- Update repository queries to support bitemporal filtering.
- Adjust tests to reflect schema and logic changes.