### PR TITLE
test(x834): add unit tests for x834Context and IEASegment validation

### DIFF
--- a/src/main/java/com/fastChickensHR/edi/x834/segments/IEASegment.java
+++ b/src/main/java/com/fastChickensHR/edi/x834/segments/IEASegment.java
@@ -20,12 +20,22 @@ import lombok.experimental.Accessors;
 @Getter
 abstract public class IEASegment extends Segment {
     public static final String SEGMENT_ID = "IEA";
-    protected final String iea01;
-    protected final String iea02;
+    protected final String iea01; // Number of Included Functional Groups
+    protected final String iea02; // Interchange Control Number
 
     protected IEASegment(IEASegment.AbstractBuilder<?> builder) throws ValidationException {
         this.iea01 = builder.iea01;
         this.iea02 = builder.iea02;
+        validateRequiredFields();
+    }
+
+    private void validateRequiredFields() throws ValidationException {
+        if (iea01 == null || iea01.isBlank()) {
+            throw new ValidationException("IEA01 (Number of Included Functional Groups) cannot be blank");
+        }
+        if (iea02 == null || iea02.isBlank()) {
+            throw new ValidationException("IEA02 (Interchange Control Number) cannot be blank");
+        }
     }
 
     @Override

--- a/src/main/java/com/fastChickensHR/edi/x834/trailer/InterchangeControlTrailer.java
+++ b/src/main/java/com/fastChickensHR/edi/x834/trailer/InterchangeControlTrailer.java
@@ -21,6 +21,7 @@ import lombok.experimental.Accessors;
  */
 @Getter
 public class InterchangeControlTrailer extends IEASegment {
+    public static final String DEFAULT_NUMBER_OF_INCLUDED_GROUPS = "1";
 
     private InterchangeControlTrailer(Builder builder) throws ValidationException {
         super(builder);

--- a/src/main/java/com/fastChickensHR/edi/x834/trailer/Trailer.java
+++ b/src/main/java/com/fastChickensHR/edi/x834/trailer/Trailer.java
@@ -112,7 +112,7 @@ public class Trailer {
         private String numberOfIncludedSegments = "10";
         private String numberOfTransactionSetsIncluded = "1";
         private String groupControlNumber;
-        private String numberOfIncludedFunctionalGroups = "1";
+        private String numberOfIncludedFunctionalGroups = InterchangeControlTrailer.DEFAULT_NUMBER_OF_INCLUDED_GROUPS;
         private String interchangeControlNumber;
 
         // Custom builders for advanced configuration

--- a/src/main/java/com/fastChickensHR/edi/x834/x834Context.java
+++ b/src/main/java/com/fastChickensHR/edi/x834/x834Context.java
@@ -77,6 +77,9 @@ public class x834Context {
         if (interchangeControlNumber == null || interchangeControlNumber.isEmpty()) {
             throw new ValidationException("Interchange Control Number is required on x834Context");
         }
+        if (!interchangeControlNumber.matches("\\d{9}")) {
+            throw new ValidationException("Interchange Control Number must be exactly 9 numeric digits");
+        }
         if (groupControlNumber == null || groupControlNumber.isEmpty()) {
             throw new ValidationException("Group Control Number is required on x834Context");
         }

--- a/src/test/java/com/fastChickensHR/edi/x834/segments/IEASegmentTest.java
+++ b/src/test/java/com/fastChickensHR/edi/x834/segments/IEASegmentTest.java
@@ -109,11 +109,27 @@ class IEASegmentTest {
     }
 
     @Test
-    void testNullValues() throws ValidationException {
-        TestIEASegment segment = TestIEASegment.builder()
-                .build();
+    void testBlankIea01ThrowsValidationException() {
+        assertThrows(ValidationException.class, () ->
+                TestIEASegment.builder()
+                        .setIea02("000000001")
+                        .build()
+        );
+    }
 
-        assertNull(segment.getIea01());
-        assertNull(segment.getIea02());
+    @Test
+    void testBlankIea02ThrowsValidationException() {
+        assertThrows(ValidationException.class, () ->
+                TestIEASegment.builder()
+                        .setIea01("1")
+                        .build()
+        );
+    }
+
+    @Test
+    void testBothFieldsNullThrowsValidationException() {
+        assertThrows(ValidationException.class, () ->
+                TestIEASegment.builder().build()
+        );
     }
 }

--- a/src/test/java/com/fastChickensHR/edi/x834/trailer/TrailerTest.java
+++ b/src/test/java/com/fastChickensHR/edi/x834/trailer/TrailerTest.java
@@ -110,6 +110,7 @@ class TrailerTest {
         functionalBuilder.setGroupControlNumber("8888");
 
         InterchangeControlTrailer.Builder interchangeBuilder = new InterchangeControlTrailer.Builder();
+        interchangeBuilder.setNumberOfIncludedGroups("1");
         interchangeBuilder.setInterchangeControlNumber("7777777");
 
         Trailer trailer = new Trailer.Builder(context)

--- a/src/test/java/com/fastChickensHR/edi/x834/x834ContextTest.java
+++ b/src/test/java/com/fastChickensHR/edi/x834/x834ContextTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class x834ContextTest {
+
+    private x834Context validContext() {
+        return new x834Context()
+                .setInterchangeControlNumber("000000001")
+                .setGroupControlNumber("1");
+    }
+
+    @Test
+    void testValidContextPassesValidation() {
+        assertDoesNotThrow(() -> validContext().validate());
+    }
+
+    @Test
+    void testNullInterchangeControlNumberThrows() {
+        x834Context ctx = validContext().setInterchangeControlNumber(null);
+        assertThrows(ValidationException.class, ctx::validate);
+    }
+
+    @Test
+    void testEmptyInterchangeControlNumberThrows() {
+        x834Context ctx = validContext().setInterchangeControlNumber("");
+        assertThrows(ValidationException.class, ctx::validate);
+    }
+
+    @Test
+    void testShortInterchangeControlNumberThrows() {
+        x834Context ctx = validContext().setInterchangeControlNumber("123");
+        ValidationException ex = assertThrows(ValidationException.class, ctx::validate);
+        assertTrue(ex.getMessage().contains("9 numeric digits"));
+    }
+
+    @Test
+    void testNonNumericInterchangeControlNumberThrows() {
+        x834Context ctx = validContext().setInterchangeControlNumber("ABC123456");
+        ValidationException ex = assertThrows(ValidationException.class, ctx::validate);
+        assertTrue(ex.getMessage().contains("9 numeric digits"));
+    }
+
+    @Test
+    void testTenDigitInterchangeControlNumberThrows() {
+        x834Context ctx = validContext().setInterchangeControlNumber("0000000001");
+        ValidationException ex = assertThrows(ValidationException.class, ctx::validate);
+        assertTrue(ex.getMessage().contains("9 numeric digits"));
+    }
+
+    @Test
+    void testNullGroupControlNumberThrows() {
+        x834Context ctx = validContext().setGroupControlNumber(null);
+        assertThrows(ValidationException.class, ctx::validate);
+    }
+
+    @Test
+    void testEmptyGroupControlNumberThrows() {
+        x834Context ctx = validContext().setGroupControlNumber("");
+        assertThrows(ValidationException.class, ctx::validate);
+    }
+}


### PR DESCRIPTION
- Added `x834ContextTest` to validate `x834Context` behavior, including interchange and group control number constraints.
- Enhanced `IEASegment` with mandatory field validations and updated related unit tests.
- Introduced `DEFAULT_NUMBER_OF_INCLUDED_GROUPS` constant in `InterchangeControlTrailer`.
- Adjusted `Trailer` builder to use the new default group constant.