### PR TITLE
feat(x834-integration): add X834IntegrationConfig with REST, persiste…

### DIFF
--- a/src/main/java/com/fastChickensHR/edi/integration/IntegrationConfig.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/IntegrationConfig.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration;
+
+import java.util.UUID;
+
+/**
+ * Marker interface for format-specific integration configuration objects.
+ *
+ * <p>Each EDI format (X12 834, X12 837, etc.) has its own implementation
+ * carrying the configuration fields required to generate documents for that format.
+ * All implementations are associated with a single {@link Integration} via
+ * {@link #getIntegrationId()}.</p>
+ */
+public interface IntegrationConfig {
+    UUID getIntegrationId();
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/X834IntegrationConfig.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/X834IntegrationConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834;
+
+import com.fastChickensHR.edi.integration.IntegrationConfig;
+import com.fastChickensHR.edi.x834.constants.ElementSeparator;
+import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
+import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Format-specific configuration for an X12 834 Benefit Enrollment integration.
+ *
+ * <p>Captures all static fields needed to construct an 834 document for a given
+ * client integration — the EDI envelope settings, enrollment context, and header
+ * details that are constant across all documents produced by this integration.</p>
+ *
+ * <p>Dynamic per-document values (interchangeControlNumber, groupControlNumber,
+ * documentDate) are not stored here; they are computed at generation time.</p>
+ */
+@Value
+@Builder
+public class X834IntegrationConfig implements IntegrationConfig {
+
+    UUID integrationId;
+
+    // --- EDI envelope ---
+    String senderID;
+    String receiverID;
+    ElementSeparator elementSeparator;
+
+    // --- Enrollment context ---
+    String policyNumber;
+    String memberIdQualifier;
+    MemberIndicator memberIndicator;
+    MaintenanceTypeCode maintenanceTypeCode;
+    LocalDateTime enrollmentDate;
+    LocalDateTime coverageStartDate;
+    LocalDateTime coverageEndDate;
+
+    // --- Header ---
+    String referenceIdentification;
+    String masterPolicyNumber;
+    String planSponsorName;
+    String payerName;
+    String payerIdentification;
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigController.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigController.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/integrations/{integrationId}/config")
+@RequiredArgsConstructor
+public class X834IntegrationConfigController {
+
+    private final X834IntegrationConfigService service;
+    private final X834IntegrationConfigMapper mapper;
+
+    @GetMapping
+    public ResponseEntity<X834IntegrationConfigResponse> findByIntegrationId(
+            @PathVariable UUID integrationId) {
+        return service.findByIntegrationId(integrationId)
+                .map(mapper::toResponse)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public X834IntegrationConfigResponse create(
+            @PathVariable UUID integrationId,
+            @RequestBody X834IntegrationConfigRequest request) {
+        return mapper.toResponse(service.create(integrationId, request));
+    }
+
+    @PutMapping
+    public ResponseEntity<X834IntegrationConfigResponse> update(
+            @PathVariable UUID integrationId,
+            @RequestBody X834IntegrationConfigRequest request) {
+        return service.update(integrationId, request)
+                .map(mapper::toResponse)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> delete(@PathVariable UUID integrationId) {
+        return service.delete(integrationId)
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigMapper.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigMapper.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import com.fastChickensHR.edi.integration.x834.persistence.X834IntegrationConfigEntity;
+import com.fastChickensHR.edi.x834.constants.ElementSeparator;
+import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
+import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Component
+public class X834IntegrationConfigMapper {
+
+    /**
+     * Converts a persisted entity row to a response DTO.
+     */
+    public X834IntegrationConfigResponse toResponse(X834IntegrationConfigEntity entity) {
+        return new X834IntegrationConfigResponse(
+                entity.getIntegrationId(),
+                entity.getSenderID(),
+                entity.getReceiverID(),
+                entity.getElementSeparator(),
+                entity.getPolicyNumber(),
+                entity.getMemberIdQualifier(),
+                entity.getMemberIndicator(),
+                entity.getMaintenanceTypeCode(),
+                entity.getEnrollmentDate(),
+                entity.getCoverageStartDate(),
+                entity.getCoverageEndDate(),
+                entity.getReferenceIdentification(),
+                entity.getMasterPolicyNumber(),
+                entity.getPlanSponsorName(),
+                entity.getPayerName(),
+                entity.getPayerIdentification(),
+                entity.getSysFrom()
+        );
+    }
+
+    /**
+     * Builds a new (open-ended) entity row for a create or update request.
+     */
+    public X834IntegrationConfigEntity toNewEntity(UUID integrationId, X834IntegrationConfigRequest request) {
+        // Validate enum values eagerly so callers get a clear IllegalArgumentException.
+        ElementSeparator.valueOf(request.elementSeparator());
+        MemberIndicator.valueOf(request.memberIndicator());
+        MaintenanceTypeCode.valueOf(request.maintenanceTypeCode());
+
+        Instant now = Instant.now();
+        X834IntegrationConfigEntity entity = new X834IntegrationConfigEntity();
+        entity.setIntegrationId(integrationId);
+        entity.setSysFrom(now);
+        entity.setSysTo(X834IntegrationConfigEntity.TEMPORAL_INFINITY);
+        entity.setValidFrom(now);
+        entity.setValidTo(X834IntegrationConfigEntity.TEMPORAL_INFINITY);
+        entity.setSenderID(request.senderID());
+        entity.setReceiverID(request.receiverID());
+        entity.setElementSeparator(request.elementSeparator());
+        entity.setPolicyNumber(request.policyNumber());
+        entity.setMemberIdQualifier(request.memberIdQualifier());
+        entity.setMemberIndicator(request.memberIndicator());
+        entity.setMaintenanceTypeCode(request.maintenanceTypeCode());
+        entity.setEnrollmentDate(request.enrollmentDate());
+        entity.setCoverageStartDate(request.coverageStartDate());
+        entity.setCoverageEndDate(request.coverageEndDate());
+        entity.setReferenceIdentification(request.referenceIdentification());
+        entity.setMasterPolicyNumber(request.masterPolicyNumber());
+        entity.setPlanSponsorName(request.planSponsorName());
+        entity.setPayerName(request.payerName());
+        entity.setPayerIdentification(request.payerIdentification());
+        return entity;
+    }
+
+    /**
+     * Closes the system-time period of a row, marking it as superseded.
+     */
+    public void closeSysTo(X834IntegrationConfigEntity entity) {
+        entity.setSysTo(Instant.now());
+    }
+
+    /**
+     * Closes the valid-time period of a row, marking it as logically deleted.
+     */
+    public void closeValidTo(X834IntegrationConfigEntity entity) {
+        entity.setValidTo(Instant.now());
+    }
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigRequest.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import java.time.LocalDateTime;
+
+/**
+ * Request body for creating or replacing an X12 834 integration configuration.
+ *
+ * <p>{@code elementSeparator}, {@code memberIndicator}, and {@code maintenanceTypeCode}
+ * are flat enum names, e.g. {@code "PIPE"}, {@code "INSURED"}, {@code "ADDITION"}.</p>
+ */
+public record X834IntegrationConfigRequest(
+        String senderID,
+        String receiverID,
+        String elementSeparator,
+        String policyNumber,
+        String memberIdQualifier,
+        String memberIndicator,
+        String maintenanceTypeCode,
+        LocalDateTime enrollmentDate,
+        LocalDateTime coverageStartDate,
+        LocalDateTime coverageEndDate,
+        String referenceIdentification,
+        String masterPolicyNumber,
+        String planSponsorName,
+        String payerName,
+        String payerIdentification
+) {
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigResponse.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Response body for X12 834 integration configuration endpoints.
+ */
+public record X834IntegrationConfigResponse(
+        UUID integrationId,
+        String senderID,
+        String receiverID,
+        String elementSeparator,
+        String policyNumber,
+        String memberIdQualifier,
+        String memberIndicator,
+        String maintenanceTypeCode,
+        LocalDateTime enrollmentDate,
+        LocalDateTime coverageStartDate,
+        LocalDateTime coverageEndDate,
+        String referenceIdentification,
+        String masterPolicyNumber,
+        String planSponsorName,
+        String payerName,
+        String payerIdentification,
+        Instant createdAt
+) {
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigService.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import com.fastChickensHR.edi.integration.x834.persistence.X834IntegrationConfigEntity;
+import com.fastChickensHR.edi.integration.x834.persistence.X834IntegrationConfigRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class X834IntegrationConfigService {
+
+    private final X834IntegrationConfigRepository repository;
+    private final X834IntegrationConfigMapper mapper;
+
+    @Transactional(readOnly = true)
+    public Optional<X834IntegrationConfigEntity> findByIntegrationId(UUID integrationId) {
+        return repository.findCurrentByIntegrationId(integrationId);
+    }
+
+    public X834IntegrationConfigEntity create(UUID integrationId, X834IntegrationConfigRequest request) {
+        return repository.save(mapper.toNewEntity(integrationId, request));
+    }
+
+    /**
+     * Appends a new config version for an existing integration (append-only, bitemporal).
+     * The current row's sys_to is closed first, then a new row is inserted.
+     * Returns empty if no currently-valid config exists for the given integration id.
+     */
+    public Optional<X834IntegrationConfigEntity> update(UUID integrationId, X834IntegrationConfigRequest request) {
+        return repository.findCurrentByIntegrationId(integrationId)
+                .map(current -> {
+                    mapper.closeSysTo(current);
+                    repository.save(current);
+                    return repository.save(mapper.toNewEntity(integrationId, request));
+                });
+    }
+
+    /**
+     * Logically deletes a config by closing its valid-time period.
+     * Returns false if no currently-valid config exists for the given integration id.
+     */
+    public boolean delete(UUID integrationId) {
+        return repository.findCurrentByIntegrationId(integrationId)
+                .map(current -> {
+                    mapper.closeValidTo(current);
+                    repository.save(current);
+                    return true;
+                })
+                .orElse(false);
+    }
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834IntegrationConfigEntity.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834IntegrationConfigEntity.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.persistence;
+
+import com.fastChickensHR.edi.integration.persistence.IntegrationEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "x834_integration_configs")
+@Getter
+@Setter
+@NoArgsConstructor
+public class X834IntegrationConfigEntity {
+
+    /**
+     * Sentinel value representing an open-ended temporal boundary ("forever").
+     * Matches {@link IntegrationEntity#TEMPORAL_INFINITY}.
+     */
+    public static final Instant TEMPORAL_INFINITY = Instant.parse("9999-12-31T23:59:59Z");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "row_id")
+    private UUID rowId;
+
+    @Column(name = "integration_id", nullable = false)
+    private UUID integrationId;
+
+    /** System time start — when this row was recorded in the database. */
+    @Column(name = "sys_from", nullable = false)
+    private Instant sysFrom;
+
+    /** System time end — {@link #TEMPORAL_INFINITY} until superseded by a correction. */
+    @Column(name = "sys_to", nullable = false)
+    private Instant sysTo;
+
+    /** Valid time start — when this configuration became effective. */
+    @Column(name = "valid_from", nullable = false)
+    private Instant validFrom;
+
+    /** Valid time end — {@link #TEMPORAL_INFINITY} for currently-valid rows. */
+    @Column(name = "valid_to", nullable = false)
+    private Instant validTo;
+
+    // --- EDI envelope ---
+
+    @Column(name = "sender_id", nullable = false)
+    private String senderID;
+
+    @Column(name = "receiver_id", nullable = false)
+    private String receiverID;
+
+    /** Stored as enum name, e.g. {@code "PIPE"}, {@code "ASTERISK"}. */
+    @Column(name = "element_separator", nullable = false)
+    private String elementSeparator;
+
+    // --- Enrollment context ---
+
+    @Column(name = "policy_number", nullable = false)
+    private String policyNumber;
+
+    @Column(name = "member_id_qualifier", nullable = false)
+    private String memberIdQualifier;
+
+    /** Stored as enum name, e.g. {@code "INSURED"}. */
+    @Column(name = "member_indicator", nullable = false)
+    private String memberIndicator;
+
+    /** Stored as enum name, e.g. {@code "ADDITION"}. */
+    @Column(name = "maintenance_type_code", nullable = false)
+    private String maintenanceTypeCode;
+
+    @Column(name = "enrollment_date", nullable = false)
+    private LocalDateTime enrollmentDate;
+
+    @Column(name = "coverage_start_date", nullable = false)
+    private LocalDateTime coverageStartDate;
+
+    @Column(name = "coverage_end_date")
+    private LocalDateTime coverageEndDate;
+
+    // --- Header ---
+
+    @Column(name = "reference_identification")
+    private String referenceIdentification;
+
+    @Column(name = "master_policy_number", nullable = false)
+    private String masterPolicyNumber;
+
+    @Column(name = "plan_sponsor_name", nullable = false)
+    private String planSponsorName;
+
+    @Column(name = "payer_name", nullable = false)
+    private String payerName;
+
+    @Column(name = "payer_identification", nullable = false)
+    private String payerIdentification;
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834IntegrationConfigRepository.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834IntegrationConfigRepository.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface X834IntegrationConfigRepository extends JpaRepository<X834IntegrationConfigEntity, UUID> {
+
+    /**
+     * Returns the currently-valid, currently-known config row for a given integration.
+     *
+     * <p>"Currently known" = sys_to is open (TEMPORAL_INFINITY).
+     * "Currently valid" = valid_from ≤ now() < valid_to.</p>
+     */
+    @Query(value = """
+            SELECT * FROM x834_integration_configs
+            WHERE integration_id = :integrationId
+              AND sys_to   = '9999-12-31 23:59:59+00'
+              AND valid_from <= now()
+              AND valid_to   >  now()
+            ORDER BY valid_from DESC
+            LIMIT 1
+            """, nativeQuery = true)
+    Optional<X834IntegrationConfigEntity> findCurrentByIntegrationId(@Param("integrationId") UUID integrationId);
+}

--- a/src/test/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigServiceTest.java
+++ b/src/test/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigServiceTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import com.fastChickensHR.edi.integration.x834.persistence.X834IntegrationConfigEntity;
+import com.fastChickensHR.edi.integration.x834.persistence.X834IntegrationConfigRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class X834IntegrationConfigServiceTest {
+
+    @Mock
+    private X834IntegrationConfigRepository repository;
+
+    @Mock
+    private X834IntegrationConfigMapper mapper;
+
+    @InjectMocks
+    private X834IntegrationConfigService service;
+
+    private static final UUID INTEGRATION_ID = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+
+    private static X834IntegrationConfigRequest sampleRequest() {
+        return new X834IntegrationConfigRequest(
+                "FASTCHKN",
+                "MICHGVEDI",
+                "PIPE",
+                "MIPA2023",
+                "34",
+                "INSURED",
+                "ADDITION",
+                LocalDateTime.of(2023, 8, 1, 0, 0),
+                LocalDateTime.of(2023, 8, 1, 0, 0),
+                null,
+                "220701MI834",
+                "MIHHS-EMP-2023",
+                "FASTCHKN",
+                "FASTCHKN INSURANCE",
+                "123456789"
+        );
+    }
+
+    // --- findByIntegrationId ---
+
+    @Test
+    void findByIntegrationId_returnsPresentWhenFound() {
+        X834IntegrationConfigEntity entity = new X834IntegrationConfigEntity();
+        when(repository.findCurrentByIntegrationId(INTEGRATION_ID)).thenReturn(Optional.of(entity));
+
+        Optional<X834IntegrationConfigEntity> result = service.findByIntegrationId(INTEGRATION_ID);
+
+        assertTrue(result.isPresent());
+        assertSame(entity, result.get());
+    }
+
+    @Test
+    void findByIntegrationId_returnsEmptyWhenNotFound() {
+        when(repository.findCurrentByIntegrationId(INTEGRATION_ID)).thenReturn(Optional.empty());
+
+        assertTrue(service.findByIntegrationId(INTEGRATION_ID).isEmpty());
+    }
+
+    // --- create ---
+
+    @Test
+    void create_savesEntityWithIntegrationId() {
+        X834IntegrationConfigRequest request = sampleRequest();
+        X834IntegrationConfigEntity mapped = new X834IntegrationConfigEntity();
+        X834IntegrationConfigEntity saved = new X834IntegrationConfigEntity();
+        when(mapper.toNewEntity(eq(INTEGRATION_ID), eq(request))).thenReturn(mapped);
+        when(repository.save(mapped)).thenReturn(saved);
+
+        X834IntegrationConfigEntity result = service.create(INTEGRATION_ID, request);
+
+        assertSame(saved, result);
+        verify(repository).save(mapped);
+    }
+
+    // --- update ---
+
+    @Test
+    void update_returnsEmptyWhenConfigNotFound() {
+        when(repository.findCurrentByIntegrationId(INTEGRATION_ID)).thenReturn(Optional.empty());
+
+        Optional<X834IntegrationConfigEntity> result = service.update(INTEGRATION_ID, sampleRequest());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void update_closesSysThenInsertsNewRowAndReturnsItWhenFound() {
+        X834IntegrationConfigRequest request = sampleRequest();
+        X834IntegrationConfigEntity current = new X834IntegrationConfigEntity();
+        X834IntegrationConfigEntity updated = new X834IntegrationConfigEntity();
+        when(repository.findCurrentByIntegrationId(INTEGRATION_ID)).thenReturn(Optional.of(current));
+        when(mapper.toNewEntity(INTEGRATION_ID, request)).thenReturn(updated);
+        when(repository.save(current)).thenReturn(current);
+        when(repository.save(updated)).thenReturn(updated);
+
+        Optional<X834IntegrationConfigEntity> result = service.update(INTEGRATION_ID, request);
+
+        assertTrue(result.isPresent());
+        assertSame(updated, result.get());
+        verify(mapper).closeSysTo(current);
+        verify(repository).save(current);
+        verify(repository).save(updated);
+    }
+
+    // --- delete ---
+
+    @Test
+    void delete_returnsFalseWhenConfigNotFound() {
+        when(repository.findCurrentByIntegrationId(INTEGRATION_ID)).thenReturn(Optional.empty());
+
+        assertFalse(service.delete(INTEGRATION_ID));
+    }
+
+    @Test
+    void delete_closesValidToAndReturnsTrueWhenFound() {
+        X834IntegrationConfigEntity current = new X834IntegrationConfigEntity();
+        when(repository.findCurrentByIntegrationId(INTEGRATION_ID)).thenReturn(Optional.of(current));
+
+        assertTrue(service.delete(INTEGRATION_ID));
+        verify(mapper).closeValidTo(current);
+        verify(repository).save(current);
+    }
+}


### PR DESCRIPTION
…nce, and service layers

- Introduced `X834IntegrationConfig` model for X12 834 integrations.
- Added REST controller with endpoints for creating, reading, updating, and deleting configurations.
- Implemented persistence layer with bitemporal handling for `x834_integration_configs` table.
- Developed service layer for integration logic.
- Added mapper, request, and response DTOs for configuration endpoints.
- Created unit tests for service methods.