### PR TITLE
feat(x834-integration): add field mapping rule model, REST, persisten…

### DIFF
--- a/src/main/java/com/fastChickensHR/edi/integration/x834/X834FieldMappingRule.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/X834FieldMappingRule.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Domain object representing a single field mapping rule for an X12 834 integration.
+ *
+ * <p>A rule maps an arbitrary HR system payload key ({@code sourceField}) to a
+ * specific EDI field ({@code targetEdiField}). For enum-valued EDI fields,
+ * {@code valueMappings} translates the HR system's raw values to EDI enum names.
+ * For date fields, {@code valueMappings} is empty and the source value passes through.</p>
+ *
+ * <p>Example — mapping employment status to maintenance type code:</p>
+ * <pre>
+ *   sourceField    = "emp_status"
+ *   targetEdiField = MAINTENANCE_TYPE_CODE
+ *   valueMappings  = { "A": "ADDITION", "T": "CANCELLATION", "L": "CHANGE" }
+ * </pre>
+ *
+ * <p>Example — mapping a date field:</p>
+ * <pre>
+ *   sourceField    = "benefit_start_dt"
+ *   targetEdiField = COVERAGE_START_DATE
+ *   valueMappings  = {}
+ * </pre>
+ */
+@Value
+@Builder
+public class X834FieldMappingRule {
+    UUID integrationId;
+    String sourceField;
+    X834MappableField targetEdiField;
+    Map<String, String> valueMappings;
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/X834IntegrationConfig.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/X834IntegrationConfig.java
@@ -9,12 +9,9 @@ package com.fastChickensHR.edi.integration.x834;
 
 import com.fastChickensHR.edi.integration.IntegrationConfig;
 import com.fastChickensHR.edi.x834.constants.ElementSeparator;
-import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
-import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
 import lombok.Builder;
 import lombok.Value;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
@@ -41,11 +38,6 @@ public class X834IntegrationConfig implements IntegrationConfig {
     // --- Enrollment context ---
     String policyNumber;
     String memberIdQualifier;
-    MemberIndicator memberIndicator;
-    MaintenanceTypeCode maintenanceTypeCode;
-    LocalDateTime enrollmentDate;
-    LocalDateTime coverageStartDate;
-    LocalDateTime coverageEndDate;
 
     // --- Header ---
     String referenceIdentification;

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/X834MappableField.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/X834MappableField.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834;
+
+/**
+ * The set of X12 834 EDI fields that can be populated via field mapping rules.
+ *
+ * <p>Each constant names an EDI field whose value varies per member and must be
+ * derived from the HR system's payload at document generation time.
+ * Fields with an associated {@code valueMappings} table are enum lookups;
+ * date fields pass the source value through directly.</p>
+ */
+public enum X834MappableField {
+
+    /** INS/HD segment: the type of enrollment change (e.g. ADDITION, CANCELLATION). */
+    MAINTENANCE_TYPE_CODE,
+
+    /** INS segment: whether the member is insured (INSURED or NOT_INSURED). */
+    MEMBER_INDICATOR,
+
+    /** DTP segment: the date the member enrolled. */
+    ENROLLMENT_DATE,
+
+    /** DTP segment: the date coverage becomes effective. */
+    COVERAGE_START_DATE,
+
+    /** DTP segment: the date coverage ends; absent for open-ended coverage. */
+    COVERAGE_END_DATE
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleController.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleController.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import com.fastChickensHR.edi.integration.x834.X834MappableField;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/integrations/{integrationId}/mappings")
+@RequiredArgsConstructor
+public class X834FieldMappingRuleController {
+
+    private final X834FieldMappingRuleService service;
+    private final X834FieldMappingRuleMapper mapper;
+
+    @GetMapping
+    public List<X834FieldMappingRuleResponse> findAll(@PathVariable UUID integrationId) {
+        return service.findAllByIntegrationId(integrationId).stream()
+                .map(mapper::toResponse)
+                .toList();
+    }
+
+    @GetMapping("/{targetEdiField}")
+    public ResponseEntity<X834FieldMappingRuleResponse> findOne(
+            @PathVariable UUID integrationId,
+            @PathVariable X834MappableField targetEdiField) {
+        return service.findByIntegrationIdAndTargetField(integrationId, targetEdiField)
+                .map(mapper::toResponse)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public X834FieldMappingRuleResponse create(
+            @PathVariable UUID integrationId,
+            @RequestBody X834FieldMappingRuleRequest request) {
+        return mapper.toResponse(service.create(integrationId, request));
+    }
+
+    @PutMapping("/{targetEdiField}")
+    public ResponseEntity<X834FieldMappingRuleResponse> update(
+            @PathVariable UUID integrationId,
+            @PathVariable X834MappableField targetEdiField,
+            @RequestBody X834FieldMappingRuleRequest request) {
+        return service.update(integrationId, request)
+                .map(mapper::toResponse)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{targetEdiField}")
+    public ResponseEntity<Void> delete(
+            @PathVariable UUID integrationId,
+            @PathVariable X834MappableField targetEdiField) {
+        return service.delete(integrationId, targetEdiField)
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleMapper.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleMapper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import com.fastChickensHR.edi.integration.x834.X834MappableField;
+import com.fastChickensHR.edi.integration.x834.persistence.X834FieldMappingRuleEntity;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+public class X834FieldMappingRuleMapper {
+
+    /**
+     * Converts a persisted entity row to a response DTO.
+     */
+    public X834FieldMappingRuleResponse toResponse(X834FieldMappingRuleEntity entity) {
+        return new X834FieldMappingRuleResponse(
+                entity.getIntegrationId(),
+                entity.getSourceField(),
+                entity.getTargetEdiField(),
+                entity.getValueMappings(),
+                entity.getSysFrom()
+        );
+    }
+
+    /**
+     * Builds a new (open-ended) entity row for a create or update request.
+     * Validates {@code targetEdiField} eagerly against {@link X834MappableField}.
+     */
+    public X834FieldMappingRuleEntity toNewEntity(UUID integrationId, X834FieldMappingRuleRequest request) {
+        X834MappableField.valueOf(request.targetEdiField());
+
+        Instant now = Instant.now();
+        X834FieldMappingRuleEntity entity = new X834FieldMappingRuleEntity();
+        entity.setIntegrationId(integrationId);
+        entity.setSysFrom(now);
+        entity.setSysTo(X834FieldMappingRuleEntity.TEMPORAL_INFINITY);
+        entity.setValidFrom(now);
+        entity.setValidTo(X834FieldMappingRuleEntity.TEMPORAL_INFINITY);
+        entity.setSourceField(request.sourceField());
+        entity.setTargetEdiField(request.targetEdiField());
+        entity.setValueMappings(request.valueMappings() != null ? request.valueMappings() : Map.of());
+        return entity;
+    }
+
+    /**
+     * Closes the system-time period of a row, marking it as superseded.
+     */
+    public void closeSysTo(X834FieldMappingRuleEntity entity) {
+        entity.setSysTo(Instant.now());
+    }
+
+    /**
+     * Closes the valid-time period of a row, marking it as logically deleted.
+     */
+    public void closeValidTo(X834FieldMappingRuleEntity entity) {
+        entity.setValidTo(Instant.now());
+    }
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleRequest.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import java.util.Map;
+
+/**
+ * Request body for creating or replacing a field mapping rule.
+ *
+ * <p>{@code targetEdiField} must be a valid {@link com.fastChickensHR.edi.integration.x834.X834MappableField} name.
+ * {@code valueMappings} maps HR system values to EDI enum names; use an empty map for date pass-through rules.</p>
+ */
+public record X834FieldMappingRuleRequest(
+        String sourceField,
+        String targetEdiField,
+        Map<String, String> valueMappings
+) {
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleResponse.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Response body for field mapping rule endpoints.
+ */
+public record X834FieldMappingRuleResponse(
+        UUID integrationId,
+        String sourceField,
+        String targetEdiField,
+        Map<String, String> valueMappings,
+        Instant createdAt
+) {
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleService.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import com.fastChickensHR.edi.integration.x834.X834MappableField;
+import com.fastChickensHR.edi.integration.x834.persistence.X834FieldMappingRuleEntity;
+import com.fastChickensHR.edi.integration.x834.persistence.X834FieldMappingRuleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class X834FieldMappingRuleService {
+
+    private final X834FieldMappingRuleRepository repository;
+    private final X834FieldMappingRuleMapper mapper;
+
+    @Transactional(readOnly = true)
+    public List<X834FieldMappingRuleEntity> findAllByIntegrationId(UUID integrationId) {
+        return repository.findAllCurrentByIntegrationId(integrationId);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<X834FieldMappingRuleEntity> findByIntegrationIdAndTargetField(
+            UUID integrationId, X834MappableField targetEdiField) {
+        return repository.findCurrentByIntegrationIdAndTargetField(integrationId, targetEdiField.name());
+    }
+
+    public X834FieldMappingRuleEntity create(UUID integrationId, X834FieldMappingRuleRequest request) {
+        return repository.save(mapper.toNewEntity(integrationId, request));
+    }
+
+    /**
+     * Appends a new version of a rule (append-only, bitemporal).
+     * Closes the current row for the same target EDI field, then inserts a new row.
+     * Returns empty if no currently-valid rule exists for that target field.
+     */
+    public Optional<X834FieldMappingRuleEntity> update(UUID integrationId, X834FieldMappingRuleRequest request) {
+        X834MappableField targetField = X834MappableField.valueOf(request.targetEdiField());
+        return repository.findCurrentByIntegrationIdAndTargetField(integrationId, targetField.name())
+                .map(current -> {
+                    mapper.closeSysTo(current);
+                    repository.save(current);
+                    return repository.save(mapper.toNewEntity(integrationId, request));
+                });
+    }
+
+    /**
+     * Logically deletes a rule by closing its valid-time period.
+     * Returns false if no currently-valid rule exists for that target field.
+     */
+    public boolean delete(UUID integrationId, X834MappableField targetEdiField) {
+        return repository.findCurrentByIntegrationIdAndTargetField(integrationId, targetEdiField.name())
+                .map(current -> {
+                    mapper.closeValidTo(current);
+                    repository.save(current);
+                    return true;
+                })
+                .orElse(false);
+    }
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigMapper.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigMapper.java
@@ -9,8 +9,6 @@ package com.fastChickensHR.edi.integration.x834.api;
 
 import com.fastChickensHR.edi.integration.x834.persistence.X834IntegrationConfigEntity;
 import com.fastChickensHR.edi.x834.constants.ElementSeparator;
-import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
-import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -30,11 +28,6 @@ public class X834IntegrationConfigMapper {
                 entity.getElementSeparator(),
                 entity.getPolicyNumber(),
                 entity.getMemberIdQualifier(),
-                entity.getMemberIndicator(),
-                entity.getMaintenanceTypeCode(),
-                entity.getEnrollmentDate(),
-                entity.getCoverageStartDate(),
-                entity.getCoverageEndDate(),
                 entity.getReferenceIdentification(),
                 entity.getMasterPolicyNumber(),
                 entity.getPlanSponsorName(),
@@ -48,10 +41,8 @@ public class X834IntegrationConfigMapper {
      * Builds a new (open-ended) entity row for a create or update request.
      */
     public X834IntegrationConfigEntity toNewEntity(UUID integrationId, X834IntegrationConfigRequest request) {
-        // Validate enum values eagerly so callers get a clear IllegalArgumentException.
+        // Validate enum value eagerly so callers get a clear IllegalArgumentException.
         ElementSeparator.valueOf(request.elementSeparator());
-        MemberIndicator.valueOf(request.memberIndicator());
-        MaintenanceTypeCode.valueOf(request.maintenanceTypeCode());
 
         Instant now = Instant.now();
         X834IntegrationConfigEntity entity = new X834IntegrationConfigEntity();
@@ -65,11 +56,6 @@ public class X834IntegrationConfigMapper {
         entity.setElementSeparator(request.elementSeparator());
         entity.setPolicyNumber(request.policyNumber());
         entity.setMemberIdQualifier(request.memberIdQualifier());
-        entity.setMemberIndicator(request.memberIndicator());
-        entity.setMaintenanceTypeCode(request.maintenanceTypeCode());
-        entity.setEnrollmentDate(request.enrollmentDate());
-        entity.setCoverageStartDate(request.coverageStartDate());
-        entity.setCoverageEndDate(request.coverageEndDate());
         entity.setReferenceIdentification(request.referenceIdentification());
         entity.setMasterPolicyNumber(request.masterPolicyNumber());
         entity.setPlanSponsorName(request.planSponsorName());

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigRequest.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigRequest.java
@@ -7,13 +7,10 @@
  */
 package com.fastChickensHR.edi.integration.x834.api;
 
-import java.time.LocalDateTime;
-
 /**
  * Request body for creating or replacing an X12 834 integration configuration.
  *
- * <p>{@code elementSeparator}, {@code memberIndicator}, and {@code maintenanceTypeCode}
- * are flat enum names, e.g. {@code "PIPE"}, {@code "INSURED"}, {@code "ADDITION"}.</p>
+ * <p>{@code elementSeparator} is a flat enum name, e.g. {@code "PIPE"}.</p>
  */
 public record X834IntegrationConfigRequest(
         String senderID,
@@ -21,11 +18,6 @@ public record X834IntegrationConfigRequest(
         String elementSeparator,
         String policyNumber,
         String memberIdQualifier,
-        String memberIndicator,
-        String maintenanceTypeCode,
-        LocalDateTime enrollmentDate,
-        LocalDateTime coverageStartDate,
-        LocalDateTime coverageEndDate,
         String referenceIdentification,
         String masterPolicyNumber,
         String planSponsorName,

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigResponse.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigResponse.java
@@ -8,7 +8,6 @@
 package com.fastChickensHR.edi.integration.x834.api;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
@@ -21,11 +20,6 @@ public record X834IntegrationConfigResponse(
         String elementSeparator,
         String policyNumber,
         String memberIdQualifier,
-        String memberIndicator,
-        String maintenanceTypeCode,
-        LocalDateTime enrollmentDate,
-        LocalDateTime coverageStartDate,
-        LocalDateTime coverageEndDate,
         String referenceIdentification,
         String masterPolicyNumber,
         String planSponsorName,

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834FieldMappingRuleEntity.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834FieldMappingRuleEntity.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.persistence;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+@Entity
+@Table(name = "x834_field_mapping_rules")
+@Getter
+@Setter
+@NoArgsConstructor
+public class X834FieldMappingRuleEntity {
+
+    public static final Instant TEMPORAL_INFINITY = Instant.parse("9999-12-31T23:59:59Z");
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "row_id")
+    private UUID rowId;
+
+    @Column(name = "integration_id", nullable = false)
+    private UUID integrationId;
+
+    /** System time start — when this row was recorded in the database. */
+    @Column(name = "sys_from", nullable = false)
+    private Instant sysFrom;
+
+    /** System time end — {@link #TEMPORAL_INFINITY} until superseded by a correction. */
+    @Column(name = "sys_to", nullable = false)
+    private Instant sysTo;
+
+    /** Valid time start — when this rule became effective. */
+    @Column(name = "valid_from", nullable = false)
+    private Instant validFrom;
+
+    /** Valid time end — {@link #TEMPORAL_INFINITY} for currently-valid rows. */
+    @Column(name = "valid_to", nullable = false)
+    private Instant validTo;
+
+    /** Arbitrary key from the HR system payload, e.g. {@code "emp_status"}. */
+    @Column(name = "source_field", nullable = false)
+    private String sourceField;
+
+    /** The EDI field being populated; stored as {@link com.fastChickensHR.edi.integration.x834.X834MappableField} name. */
+    @Column(name = "target_edi_field", nullable = false)
+    private String targetEdiField;
+
+    /**
+     * HR value → EDI value lookup table.
+     * Empty for date pass-through rules; populated for enum-valued fields.
+     * e.g. {@code {"T": "CANCELLATION", "A": "ADDITION"}}.
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "value_mappings", columnDefinition = "jsonb", nullable = false)
+    private Map<String, String> valueMappings;
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834FieldMappingRuleRepository.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834FieldMappingRuleRepository.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface X834FieldMappingRuleRepository extends JpaRepository<X834FieldMappingRuleEntity, UUID> {
+
+    /**
+     * Returns all currently-valid, currently-known rules for a given integration.
+     */
+    @Query(value = """
+            SELECT * FROM x834_field_mapping_rules
+            WHERE integration_id = :integrationId
+              AND sys_to   = '9999-12-31 23:59:59+00'
+              AND valid_from <= now()
+              AND valid_to   >  now()
+            ORDER BY source_field
+            """, nativeQuery = true)
+    List<X834FieldMappingRuleEntity> findAllCurrentByIntegrationId(@Param("integrationId") UUID integrationId);
+
+    /**
+     * Returns the currently-valid, currently-known rule for a given integration and target EDI field.
+     */
+    @Query(value = """
+            SELECT * FROM x834_field_mapping_rules
+            WHERE integration_id   = :integrationId
+              AND target_edi_field  = :targetEdiField
+              AND sys_to   = '9999-12-31 23:59:59+00'
+              AND valid_from <= now()
+              AND valid_to   >  now()
+            LIMIT 1
+            """, nativeQuery = true)
+    Optional<X834FieldMappingRuleEntity> findCurrentByIntegrationIdAndTargetField(
+            @Param("integrationId") UUID integrationId,
+            @Param("targetEdiField") String targetEdiField);
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834IntegrationConfigEntity.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834IntegrationConfigEntity.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -73,23 +72,6 @@ public class X834IntegrationConfigEntity {
 
     @Column(name = "member_id_qualifier", nullable = false)
     private String memberIdQualifier;
-
-    /** Stored as enum name, e.g. {@code "INSURED"}. */
-    @Column(name = "member_indicator", nullable = false)
-    private String memberIndicator;
-
-    /** Stored as enum name, e.g. {@code "ADDITION"}. */
-    @Column(name = "maintenance_type_code", nullable = false)
-    private String maintenanceTypeCode;
-
-    @Column(name = "enrollment_date", nullable = false)
-    private LocalDateTime enrollmentDate;
-
-    @Column(name = "coverage_start_date", nullable = false)
-    private LocalDateTime coverageStartDate;
-
-    @Column(name = "coverage_end_date")
-    private LocalDateTime coverageEndDate;
 
     // --- Header ---
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,5 @@ spring.jpa.hibernate.ddl-auto=validate
 
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+
+spring.jackson.serialization.write-dates-as-timestamps=false

--- a/src/main/resources/db/migration/V3__create_x834_integration_configs_table.sql
+++ b/src/main/resources/db/migration/V3__create_x834_integration_configs_table.sql
@@ -1,0 +1,44 @@
+-- btree_gist extension already enabled in V2.
+
+CREATE TABLE x834_integration_configs (
+    row_id                  UUID        NOT NULL DEFAULT gen_random_uuid(),
+    integration_id          UUID        NOT NULL,
+
+    -- Bitemporal columns
+    sys_from                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    sys_to                  TIMESTAMPTZ NOT NULL DEFAULT '9999-12-31 23:59:59+00',
+    valid_from              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    valid_to                TIMESTAMPTZ NOT NULL DEFAULT '9999-12-31 23:59:59+00',
+
+    -- EDI envelope
+    sender_id               VARCHAR     NOT NULL,
+    receiver_id             VARCHAR     NOT NULL,
+    element_separator       VARCHAR     NOT NULL,
+
+    -- Enrollment context (per-member fields are handled via field mapping rules)
+    policy_number           VARCHAR     NOT NULL,
+    member_id_qualifier     VARCHAR     NOT NULL,
+
+    -- Header
+    reference_identification VARCHAR,
+    master_policy_number    VARCHAR     NOT NULL,
+    plan_sponsor_name       VARCHAR     NOT NULL,
+    payer_name              VARCHAR     NOT NULL,
+    payer_identification    VARCHAR     NOT NULL,
+
+    CONSTRAINT pk_x834_integration_configs PRIMARY KEY (row_id)
+);
+
+CREATE INDEX idx_x834_configs_lookup
+    ON x834_integration_configs (integration_id, sys_from DESC);
+
+ALTER TABLE x834_integration_configs
+    ADD CONSTRAINT uq_x834_configs_bitemp
+        UNIQUE (integration_id, sys_from, valid_from);
+
+ALTER TABLE x834_integration_configs
+    ADD CONSTRAINT excl_x834_configs_valid_no_overlap
+        EXCLUDE USING gist (
+            integration_id WITH =,
+            tstzrange(valid_from, valid_to) WITH &&
+        ) WHERE (sys_to = '9999-12-31 23:59:59+00');

--- a/src/main/resources/db/migration/V4__create_x834_field_mapping_rules_table.sql
+++ b/src/main/resources/db/migration/V4__create_x834_field_mapping_rules_table.sql
@@ -1,0 +1,35 @@
+CREATE TABLE x834_field_mapping_rules (
+    row_id              UUID        NOT NULL DEFAULT gen_random_uuid(),
+    integration_id      UUID        NOT NULL,
+
+    -- Bitemporal columns
+    sys_from            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    sys_to              TIMESTAMPTZ NOT NULL DEFAULT '9999-12-31 23:59:59+00',
+    valid_from          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    valid_to            TIMESTAMPTZ NOT NULL DEFAULT '9999-12-31 23:59:59+00',
+
+    -- Rule definition
+    source_field        VARCHAR     NOT NULL,
+    target_edi_field    VARCHAR     NOT NULL,
+    value_mappings      JSONB       NOT NULL DEFAULT '{}',
+
+    CONSTRAINT pk_x834_field_mapping_rules PRIMARY KEY (row_id)
+);
+
+CREATE INDEX idx_x834_mapping_rules_lookup
+    ON x834_field_mapping_rules (integration_id, target_edi_field, sys_from DESC);
+
+-- Natural uniqueness: no two rows may share the same (integration_id, target_edi_field, sys_from, valid_from).
+ALTER TABLE x834_field_mapping_rules
+    ADD CONSTRAINT uq_x834_mapping_rules_bitemp
+        UNIQUE (integration_id, target_edi_field, sys_from, valid_from);
+
+-- Exclusion constraint: among all "currently-known" rows (sys_to = infinity),
+-- no two rows for the same integration + target field may have overlapping valid-time periods.
+ALTER TABLE x834_field_mapping_rules
+    ADD CONSTRAINT excl_x834_mapping_rules_valid_no_overlap
+        EXCLUDE USING gist (
+            integration_id   WITH =,
+            target_edi_field WITH =,
+            tstzrange(valid_from, valid_to) WITH &&
+        ) WHERE (sys_to = '9999-12-31 23:59:59+00');

--- a/src/test/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleServiceTest.java
+++ b/src/test/java/com/fastChickensHR/edi/integration/x834/api/X834FieldMappingRuleServiceTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.integration.x834.api;
+
+import com.fastChickensHR.edi.integration.x834.X834MappableField;
+import com.fastChickensHR.edi.integration.x834.persistence.X834FieldMappingRuleEntity;
+import com.fastChickensHR.edi.integration.x834.persistence.X834FieldMappingRuleRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class X834FieldMappingRuleServiceTest {
+
+    @Mock
+    private X834FieldMappingRuleRepository repository;
+
+    @Mock
+    private X834FieldMappingRuleMapper mapper;
+
+    @InjectMocks
+    private X834FieldMappingRuleService service;
+
+    private static final UUID INTEGRATION_ID = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+
+    private static X834FieldMappingRuleRequest maintenanceTypeRequest() {
+        return new X834FieldMappingRuleRequest(
+                "emp_status",
+                "MAINTENANCE_TYPE_CODE",
+                Map.of("A", "ADDITION", "T", "CANCELLATION")
+        );
+    }
+
+    private static X834FieldMappingRuleRequest coverageStartRequest() {
+        return new X834FieldMappingRuleRequest(
+                "benefit_start_dt",
+                "COVERAGE_START_DATE",
+                Map.of()
+        );
+    }
+
+    // --- findAllByIntegrationId ---
+
+    @Test
+    void findAllByIntegrationId_returnsResultsFromRepository() {
+        List<X834FieldMappingRuleEntity> entities = List.of(
+                new X834FieldMappingRuleEntity(), new X834FieldMappingRuleEntity());
+        when(repository.findAllCurrentByIntegrationId(INTEGRATION_ID)).thenReturn(entities);
+
+        List<X834FieldMappingRuleEntity> result = service.findAllByIntegrationId(INTEGRATION_ID);
+
+        assertEquals(entities, result);
+    }
+
+    @Test
+    void findAllByIntegrationId_returnsEmptyWhenNoRules() {
+        when(repository.findAllCurrentByIntegrationId(INTEGRATION_ID)).thenReturn(List.of());
+
+        assertTrue(service.findAllByIntegrationId(INTEGRATION_ID).isEmpty());
+    }
+
+    // --- findByIntegrationIdAndTargetField ---
+
+    @Test
+    void findByIntegrationIdAndTargetField_returnsPresentWhenFound() {
+        X834FieldMappingRuleEntity entity = new X834FieldMappingRuleEntity();
+        when(repository.findCurrentByIntegrationIdAndTargetField(
+                INTEGRATION_ID, "MAINTENANCE_TYPE_CODE")).thenReturn(Optional.of(entity));
+
+        Optional<X834FieldMappingRuleEntity> result =
+                service.findByIntegrationIdAndTargetField(INTEGRATION_ID, X834MappableField.MAINTENANCE_TYPE_CODE);
+
+        assertTrue(result.isPresent());
+        assertSame(entity, result.get());
+    }
+
+    @Test
+    void findByIntegrationIdAndTargetField_returnsEmptyWhenNotFound() {
+        when(repository.findCurrentByIntegrationIdAndTargetField(
+                INTEGRATION_ID, "MAINTENANCE_TYPE_CODE")).thenReturn(Optional.empty());
+
+        assertTrue(service.findByIntegrationIdAndTargetField(
+                INTEGRATION_ID, X834MappableField.MAINTENANCE_TYPE_CODE).isEmpty());
+    }
+
+    // --- create ---
+
+    @Test
+    void create_savesEntityWithIntegrationId() {
+        X834FieldMappingRuleRequest request = maintenanceTypeRequest();
+        X834FieldMappingRuleEntity mapped = new X834FieldMappingRuleEntity();
+        X834FieldMappingRuleEntity saved = new X834FieldMappingRuleEntity();
+        when(mapper.toNewEntity(eq(INTEGRATION_ID), eq(request))).thenReturn(mapped);
+        when(repository.save(mapped)).thenReturn(saved);
+
+        X834FieldMappingRuleEntity result = service.create(INTEGRATION_ID, request);
+
+        assertSame(saved, result);
+        verify(repository).save(mapped);
+    }
+
+    // --- update ---
+
+    @Test
+    void update_returnsEmptyWhenRuleNotFound() {
+        when(repository.findCurrentByIntegrationIdAndTargetField(
+                INTEGRATION_ID, "MAINTENANCE_TYPE_CODE")).thenReturn(Optional.empty());
+
+        Optional<X834FieldMappingRuleEntity> result = service.update(INTEGRATION_ID, maintenanceTypeRequest());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void update_closesSysThenInsertsNewRowAndReturnsItWhenFound() {
+        X834FieldMappingRuleRequest request = maintenanceTypeRequest();
+        X834FieldMappingRuleEntity current = new X834FieldMappingRuleEntity();
+        X834FieldMappingRuleEntity updated = new X834FieldMappingRuleEntity();
+        when(repository.findCurrentByIntegrationIdAndTargetField(
+                INTEGRATION_ID, "MAINTENANCE_TYPE_CODE")).thenReturn(Optional.of(current));
+        when(mapper.toNewEntity(INTEGRATION_ID, request)).thenReturn(updated);
+        when(repository.save(current)).thenReturn(current);
+        when(repository.save(updated)).thenReturn(updated);
+
+        Optional<X834FieldMappingRuleEntity> result = service.update(INTEGRATION_ID, request);
+
+        assertTrue(result.isPresent());
+        assertSame(updated, result.get());
+        verify(mapper).closeSysTo(current);
+        verify(repository).save(current);
+        verify(repository).save(updated);
+    }
+
+    // --- delete ---
+
+    @Test
+    void delete_returnsFalseWhenRuleNotFound() {
+        when(repository.findCurrentByIntegrationIdAndTargetField(
+                INTEGRATION_ID, "MAINTENANCE_TYPE_CODE")).thenReturn(Optional.empty());
+
+        assertFalse(service.delete(INTEGRATION_ID, X834MappableField.MAINTENANCE_TYPE_CODE));
+    }
+
+    @Test
+    void delete_closesValidToAndReturnsTrueWhenFound() {
+        X834FieldMappingRuleEntity current = new X834FieldMappingRuleEntity();
+        when(repository.findCurrentByIntegrationIdAndTargetField(
+                INTEGRATION_ID, "MAINTENANCE_TYPE_CODE")).thenReturn(Optional.of(current));
+
+        assertTrue(service.delete(INTEGRATION_ID, X834MappableField.MAINTENANCE_TYPE_CODE));
+        verify(mapper).closeValidTo(current);
+        verify(repository).save(current);
+    }
+}

--- a/src/test/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigServiceTest.java
+++ b/src/test/java/com/fastChickensHR/edi/integration/x834/api/X834IntegrationConfigServiceTest.java
@@ -15,7 +15,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -46,11 +45,6 @@ class X834IntegrationConfigServiceTest {
                 "PIPE",
                 "MIPA2023",
                 "34",
-                "INSURED",
-                "ADDITION",
-                LocalDateTime.of(2023, 8, 1, 0, 0),
-                LocalDateTime.of(2023, 8, 1, 0, 0),
-                null,
                 "220701MI834",
                 "MIHHS-EMP-2023",
                 "FASTCHKN",


### PR DESCRIPTION
…ce, and service layers

- Introduced `X834FieldMappingRule` for handling per-member field mappings in X12 834 integrations.
- Added REST controller with endpoints to create, read, update, and delete field mapping rules.
- Implemented persistence layer with bitemporal handling for `x834_field_mapping_rules` table and exclusion constraints to prevent overlapping `valid_time` periods.
- Developed service layer for mapping logic, including versioning and temporal updates.
- Added mapper, request, and response DTOs for rule endpoints.
- Created comprehensive unit tests for service methods.
- Updated `X834IntegrationConfig` and related logic to remove per-member flat fields in favor of dynamic mappings.