### PR TITLE
refactor(common): centralize `TEMPORAL_INFINITY` in `TemporalConstant…

### DIFF
--- a/src/main/java/com/fastChickensHR/edi/common/TemporalConstants.java
+++ b/src/main/java/com/fastChickensHR/edi/common/TemporalConstants.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.common;
+
+import java.time.Instant;
+
+/**
+ * Shared temporal sentinel constants used across persistence and EDI layers.
+ */
+public final class TemporalConstants {
+
+    private TemporalConstants() {}
+
+    /**
+     * Sentinel value representing an open-ended temporal boundary ("forever").
+     * Stored as {@code '9999-12-31 23:59:59+00'} in PostgreSQL {@code TIMESTAMPTZ} columns.
+     */
+    public static final Instant TEMPORAL_INFINITY = Instant.parse("9999-12-31T23:59:59Z");
+}

--- a/src/main/java/com/fastChickensHR/edi/integration/persistence/IntegrationEntity.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/persistence/IntegrationEntity.java
@@ -7,6 +7,7 @@
  */
 package com.fastChickensHR.edi.integration.persistence;
 
+import com.fastChickensHR.edi.common.TemporalConstants;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,11 +23,8 @@ import java.util.UUID;
 @NoArgsConstructor
 public class IntegrationEntity {
 
-    /**
-     * Sentinel value representing an open-ended temporal boundary ("forever").
-     * Stored as {@code '9999-12-31 23:59:59+00'} in PostgreSQL.
-     */
-    public static final Instant TEMPORAL_INFINITY = Instant.parse("9999-12-31T23:59:59Z");
+    /** @see TemporalConstants#TEMPORAL_INFINITY */
+    public static final Instant TEMPORAL_INFINITY = TemporalConstants.TEMPORAL_INFINITY;
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834FieldMappingRuleEntity.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834FieldMappingRuleEntity.java
@@ -7,6 +7,7 @@
  */
 package com.fastChickensHR.edi.integration.x834.persistence;
 
+import com.fastChickensHR.edi.common.TemporalConstants;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,7 +26,8 @@ import java.util.UUID;
 @NoArgsConstructor
 public class X834FieldMappingRuleEntity {
 
-    public static final Instant TEMPORAL_INFINITY = Instant.parse("9999-12-31T23:59:59Z");
+    /** @see TemporalConstants#TEMPORAL_INFINITY */
+    public static final Instant TEMPORAL_INFINITY = TemporalConstants.TEMPORAL_INFINITY;
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834IntegrationConfigEntity.java
+++ b/src/main/java/com/fastChickensHR/edi/integration/x834/persistence/X834IntegrationConfigEntity.java
@@ -7,7 +7,7 @@
  */
 package com.fastChickensHR.edi.integration.x834.persistence;
 
-import com.fastChickensHR.edi.integration.persistence.IntegrationEntity;
+import com.fastChickensHR.edi.common.TemporalConstants;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,11 +23,8 @@ import java.util.UUID;
 @NoArgsConstructor
 public class X834IntegrationConfigEntity {
 
-    /**
-     * Sentinel value representing an open-ended temporal boundary ("forever").
-     * Matches {@link IntegrationEntity#TEMPORAL_INFINITY}.
-     */
-    public static final Instant TEMPORAL_INFINITY = Instant.parse("9999-12-31T23:59:59Z");
+    /** @see TemporalConstants#TEMPORAL_INFINITY */
+    public static final Instant TEMPORAL_INFINITY = TemporalConstants.TEMPORAL_INFINITY;
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)


### PR DESCRIPTION
…s` and update references

Centralized temporal boundary constant `TEMPORAL_INFINITY` into a new `TemporalConstants` utility class. Updated all entity references to use this shared constant.