### PR TITLE
feat(edi-core): format-neutral file kernel + emit/parse seam (ADR-0313)

### DIFF
--- a/edi-core/pom.xml
+++ b/edi-core/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+
+    This file is part of the FastChickensHR project.
+
+    For license information see the LICENSE file in the root of this project.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.fastchickenshr</groupId>
+        <artifactId>edi</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>edi-core</artifactId>
+    <name>FastChickensHR EDI Core</name>
+    <description>Format-neutral file kernel (File / Record / Line / Position / Value) and the emit/parse seam</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/edi-core/src/main/java/com/fastChickensHR/edi/core/Direction.java
+++ b/edi-core/src/main/java/com/fastChickensHR/edi/core/Direction.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.core;
+
+/** Whether a {@link PlannedFile} flows into fastChickens (parsed) or out to a vendor (emitted). */
+public enum Direction {
+    INBOUND,
+    OUTBOUND
+}

--- a/edi-core/src/main/java/com/fastChickensHR/edi/core/FileEmitter.java
+++ b/edi-core/src/main/java/com/fastChickensHR/edi/core/FileEmitter.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.core;
+
+/**
+ * The outbound seam: a format's pure serializer. Given a fully-resolved {@link PlannedFile}, produce
+ * the file's text in that format's dialect — interpreting each {@link Position} into its own tokens
+ * (834: Position &rarr; loop/segment/element; CSV: Position &rarr; column). Implementations hold no
+ * domain logic; all resolution happened upstream in the app's requirements engine. The kernel
+ * <em>programs to</em> this interface; the format modules (edi-834, edi-csv) implement it.
+ */
+public interface FileEmitter {
+    String emit(PlannedFile file);
+}

--- a/edi-core/src/main/java/com/fastChickensHR/edi/core/FileLevel.java
+++ b/edi-core/src/main/java/com/fastChickensHR/edi/core/FileLevel.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.core;
+
+/**
+ * Depth in a File's ordered tree — where a {@link Position} sits.
+ *
+ * <ul>
+ *   <li>{@code FILE} — header/trailer lines, once per file;</li>
+ *   <li>{@code EMPLOYEE} — a subject {@link PlannedRecord}'s own lines (and its coverage);</li>
+ *   <li>{@code DEPENDENT} — a dependent child-group's lines within a Record.</li>
+ * </ul>
+ */
+public enum FileLevel {
+    FILE,
+    EMPLOYEE,
+    DEPENDENT
+}

--- a/edi-core/src/main/java/com/fastChickensHR/edi/core/FileParser.java
+++ b/edi-core/src/main/java/com/fastChickensHR/edi/core/FileParser.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.core;
+
+/**
+ * The inbound seam: a format's parser — the dual of {@link FileEmitter}. Reads a file's text in a
+ * format's dialect into a format-neutral {@link PlannedFile}. Defined now to keep the kernel
+ * bidirectional; implemented when the inbound (CSV) convergence lands (ADR-0313, decision 8).
+ */
+public interface FileParser {
+    PlannedFile parse(String raw);
+}

--- a/edi-core/src/main/java/com/fastChickensHR/edi/core/Placement.java
+++ b/edi-core/src/main/java/com/fastChickensHR/edi/core/Placement.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.core;
+
+import java.util.Optional;
+
+/**
+ * One resolved Value at a {@link Position}. A {@code null} value means <b>OMIT</b> — the position is
+ * described, but nothing is emitted for this subject (e.g. a situational REF with no value).
+ */
+public record Placement(Position position, String value) {
+    public Placement {
+        if (position == null) {
+            throw new IllegalArgumentException("position is required");
+        }
+    }
+
+    /** {@code true} when this placement emits nothing (OMIT). */
+    public boolean isOmitted() {
+        return value == null;
+    }
+
+    public Optional<String> valueIfPresent() {
+        return Optional.ofNullable(value);
+    }
+}

--- a/edi-core/src/main/java/com/fastChickensHR/edi/core/PlannedFile.java
+++ b/edi-core/src/main/java/com/fastChickensHR/edi/core/PlannedFile.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.core;
+
+import java.util.List;
+
+/**
+ * The format-neutral, fully-resolved file a {@link FileEmitter} serializes (or a {@link FileParser}
+ * produces). An ordered tree: file-level {@code filePlacements} (header/trailer, once per file) plus
+ * one {@link PlannedRecord} per subject. This is the pivot between the app's requirements engine and a
+ * format's dialect — the app speaks only this, and each format interprets the {@link Position}s.
+ */
+public record PlannedFile(Direction direction, List<Placement> filePlacements, List<PlannedRecord> records) {
+    public PlannedFile {
+        if (direction == null) {
+            throw new IllegalArgumentException("direction is required");
+        }
+        filePlacements = filePlacements == null ? List.of() : List.copyOf(filePlacements);
+        records = records == null ? List.of() : List.copyOf(records);
+    }
+}

--- a/edi-core/src/main/java/com/fastChickensHR/edi/core/PlannedRecord.java
+++ b/edi-core/src/main/java/com/fastChickensHR/edi/core/PlannedRecord.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.core;
+
+import java.util.List;
+
+/**
+ * One subject's data on a File (a Subscriber). {@code placements} are the subject's own
+ * Values-at-Positions (its EMPLOYEE-level lines plus coverage); {@code children} are the nested
+ * dependent Records (DEPENDENT-level child-groups). In a Flat File a Record collapses to a single
+ * line; in a Grouped File it spans many.
+ */
+public record PlannedRecord(List<Placement> placements, List<PlannedRecord> children) {
+    public PlannedRecord {
+        placements = placements == null ? List.of() : List.copyOf(placements);
+        children = children == null ? List.of() : List.copyOf(children);
+    }
+
+    /** A leaf Record with no nested dependents. */
+    public static PlannedRecord of(List<Placement> placements) {
+        return new PlannedRecord(placements, List.of());
+    }
+}

--- a/edi-core/src/main/java/com/fastChickensHR/edi/core/Position.java
+++ b/edi-core/src/main/java/com/fastChickensHR/edi/core/Position.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.core;
+
+/**
+ * A spec-anchored token address on a File. The format spec owns the <b>structural</b> tokens (segment
+ * identifier, delimiters) and they are never overridable; {@code location} carries only the
+ * <b>configurable</b> token(s) — an 834 REF qualifier, a CSV column — interpreted by the format's own
+ * dialect below the kernel. {@code level} is the tree depth the address sits at.
+ */
+public record Position(FileLevel level, String location) {
+    public Position {
+        if (level == null) {
+            throw new IllegalArgumentException("level is required");
+        }
+        if (location == null || location.isBlank()) {
+            throw new IllegalArgumentException("location is required");
+        }
+    }
+}

--- a/edi-core/src/test/java/com/fastChickensHR/edi/core/PlannedFileTest.java
+++ b/edi-core/src/test/java/com/fastChickensHR/edi/core/PlannedFileTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PlannedFileTest {
+
+    @Test
+    void buildsAnOrderedTreeAndDefendsItsCollections() {
+        Placement ssn = new Placement(new Position(FileLevel.EMPLOYEE, "REF*34"), "123456789");
+        Placement depName = new Placement(new Position(FileLevel.DEPENDENT, "NM1*03"), "Doe");
+        PlannedRecord dependent = PlannedRecord.of(List.of(depName));
+        PlannedRecord subscriber = new PlannedRecord(List.of(ssn), List.of(dependent));
+        PlannedFile file = new PlannedFile(Direction.OUTBOUND, List.of(), List.of(subscriber));
+
+        assertEquals(Direction.OUTBOUND, file.direction());
+        assertEquals(1, file.records().size());
+        assertEquals(1, file.records().get(0).children().size());
+        assertThrows(UnsupportedOperationException.class,
+                () -> file.records().get(0).placements().add(ssn));
+    }
+
+    @Test
+    void nullValueMeansOmit() {
+        Placement omit = new Placement(new Position(FileLevel.EMPLOYEE, "REF*1L"), null);
+        assertTrue(omit.isOmitted());
+        assertTrue(omit.valueIfPresent().isEmpty());
+    }
+
+    @Test
+    void positionRequiresLevelAndLocation() {
+        assertThrows(IllegalArgumentException.class, () -> new Position(null, "x"));
+        assertThrows(IllegalArgumentException.class, () -> new Position(FileLevel.FILE, "  "));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <description>Open-source toolkit for generating X12 EDI benefit enrollment documents</description>
 
     <modules>
+        <module>edi-core</module>
         <module>edi-834</module>
         <module>edi-csv</module>
     </modules>


### PR DESCRIPTION
Adds **`edi-core`** — the format-neutral file kernel from ADR-0313 (FastChickensHR/mono#313).

- `Direction`, `FileLevel` (tree depth)
- `Position` (spec-anchored token address; `location` = configurable tokens), `Placement` (Value at a Position; `null` = OMIT)
- `PlannedRecord` (subject + nested dependents), `PlannedFile` (the resolved tree the app hands the serializer)
- **Seam**: `FileEmitter` (outbound, pure serializer) + `FileParser` (inbound, defined for the bidirectional design; implemented with the later CSV arc)

Additive — `edi-834`/`edi-csv` don't implement it yet and nothing consumes it. Full `edi` build + all `edi-834` tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)