### PR TITLE
ci: add Maven unit-test workflow (unblock edi merges)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,46 @@
+name: Java CI with Maven
+
+# The edi library is a published dependency of FastChickensHR/mono; its master is
+# guarded by the `protectMaster` ruleset, which requires the checks "Run Unit Tests"
+# and "JUnit Test Report". This workflow produces both. The build is small, so —
+# unlike the app — there is no path fast-exit guard: the suite always runs, which
+# guarantees both required checks always post.
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+permissions:
+  checks: write
+  contents: read
+
+# A newer commit on the same ref supersedes an in-flight run.
+concurrency:
+  group: maven-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven and run tests
+        run: mvn -B test
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          check_name: 'JUnit Test Report'
+          report_paths: '**/target/surefire-reports/TEST-*.xml'


### PR DESCRIPTION
`edi` master's `protectMaster` ruleset requires the checks **Run Unit Tests** and **JUnit Test Report**, but the repo had **no workflow** producing them — so every PR sat BLOCKED and could only land via admin bypass.

This adds a minimal Maven CI workflow producing both checks (`mvn -B test` + `mikepenz/action-junit-report`). This PR self-triggers it, so it merges on genuine green.

Follow-up context: `edi` is a published dependency of FastChickensHR/mono (its CI clones + installs edi); giving it real unit CI closes the "app depends on an untested library" gap. Unblocks ADR-0313's edi-core + edi-834 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)