### PR TITLE
feat(edi-834): X834FileEmitter — implement the edi-core seam (ADR-0313)

### DIFF
--- a/edi-834/pom.xml
+++ b/edi-834/pom.xml
@@ -25,6 +25,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fastchickenshr</groupId>
+            <artifactId>edi-core</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/edi-834/src/main/java/com/fastChickensHR/edi/x834/emit/X834FileEmitter.java
+++ b/edi-834/src/main/java/com/fastChickensHR/edi/x834/emit/X834FileEmitter.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.emit;
+
+import com.fastChickensHR.edi.core.FileEmitter;
+import com.fastChickensHR.edi.core.Placement;
+import com.fastChickensHR.edi.core.PlannedFile;
+import com.fastChickensHR.edi.core.PlannedRecord;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.header.Header;
+import com.fastChickensHR.edi.x834.loop2000.BaseMember;
+import com.fastChickensHR.edi.x834.loop2000.DependentMember;
+import com.fastChickensHR.edi.x834.loop2000.Member;
+import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
+import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
+import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.loop2000.loop3000.HealthCoverage;
+import com.fastChickensHR.edi.x834.segments.RefSegment;
+import com.fastChickensHR.edi.x834.segments.Segment;
+import com.fastChickensHR.edi.x834.trailer.Trailer;
+import com.fastChickensHR.edi.x834.x834Context;
+import com.fastChickensHR.edi.x834.x834Document;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * The 834 implementation of the {@link FileEmitter} seam (ADR-0313): serializes a format-neutral
+ * {@link PlannedFile} into an X12 834 document. It holds no domain logic — every Value has already
+ * been resolved upstream by the app's requirements engine. It only interprets each
+ * {@link com.fastChickensHR.edi.core.Position} (via {@link X834Location}) onto the library's own typed
+ * builders (`x834Context`, `Header`, `Member`, `HealthCoverage`, `RefSegment`), so the emitted bytes
+ * match the legacy converter path by construction.
+ *
+ * <p>Structure produced: the header/envelope (from file placements), then one {@link Member} per
+ * Record (dependents attached as child members), then — after all members, in Record order — each
+ * Record's custom REF extensions followed by its HD coverage segment, then the trailer. Control
+ * numbers, segment counts and SE/GE/IEA are generated internally by the library.
+ */
+public final class X834FileEmitter implements FileEmitter {
+
+    @Override
+    public String emit(PlannedFile file) {
+        try {
+            Map<String, String> fileLoc = byLocation(file.filePlacements());
+            x834Context context = buildContext(fileLoc);
+            Header header = buildHeader(fileLoc, context);
+
+            x834Document.Builder document = new x834Document.Builder(context)
+                    .withHeader(header)
+                    .withTrailer(new Trailer.Builder(context));
+
+            for (PlannedRecord record : file.records()) {
+                document.addMember(buildMember(record));
+                // After the members, in Record order: this Record's REF extensions, then its HD.
+                for (Segment ref : refExtensions(record.placements())) {
+                    document.addSegment(ref);
+                }
+                healthCoverage(record.placements()).ifPresent(document::addSegment);
+            }
+
+            return document.build().generateDocument().orElseThrow(() ->
+                    new IllegalStateException("834 generation produced no document (validation failed)"));
+        } catch (ValidationException e) {
+            throw new IllegalStateException("Failed to emit 834: " + e.getMessage(), e);
+        }
+    }
+
+    private x834Context buildContext(Map<String, String> file) {
+        x834Context context = new x834Context();
+        apply(file, X834Location.SENDER_ID, context::setSenderID);
+        apply(file, X834Location.RECEIVER_ID, context::setReceiverID);
+        apply(file, X834Location.INTERCHANGE_CONTROL_NUMBER, context::setInterchangeControlNumber);
+        apply(file, X834Location.GROUP_CONTROL_NUMBER, context::setGroupControlNumber);
+        apply(file, X834Location.TRANSACTION_SET_CONTROL_NUMBER, context::setTransactionSetControlNumber);
+        apply(file, X834Location.DOCUMENT_DATE, v -> context.setDocumentDate(parseDateTime(v)));
+        return context;
+    }
+
+    private Header buildHeader(Map<String, String> file, x834Context context) {
+        Header.Builder header = new Header.Builder(context);
+        apply(file, X834Location.TRANSACTION_SET_ID, header::setTransactionSetIdentifierCode);
+        apply(file, X834Location.REFERENCE_IDENTIFICATION, header::setReferenceIdentification);
+        apply(file, X834Location.MASTER_POLICY_NUMBER, header::setMasterPolicyNumber);
+        apply(file, X834Location.PLAN_SPONSOR_NAME, header::setPlanSponsorName);
+        apply(file, X834Location.PAYER_NAME, header::setPayerName);
+        return header.build();
+    }
+
+    /** Build the subscriber {@link Member} for a Record, attaching each child Record as a dependent. */
+    private Member buildMember(PlannedRecord record) {
+        Member member = new Member();
+        populate(member, byLocation(record.placements()));
+        for (PlannedRecord child : record.children()) {
+            DependentMember dependent = new DependentMember();
+            populate(dependent, byLocation(child.placements()));
+            dependent.setPrimaryMember(member);
+            member.addDependent(dependent);
+        }
+        return member;
+    }
+
+    /** Set the wire-relevant fields shared by subscriber and dependent members. */
+    private void populate(BaseMember member, Map<String, String> loc) {
+        apply(loc, X834Location.MEMBER_INDICATOR, v -> member.setMemberIndicator(MemberIndicator.fromString(v)));
+        apply(loc, X834Location.RELATIONSHIP_CODE, v -> member.setRelationshipCode(IndividualRelationshipCode.fromString(v)));
+        apply(loc, X834Location.MAINTENANCE_TYPE_CODE, v -> member.setMaintenanceTypeCode(MaintenanceTypeCode.fromString(v)));
+        apply(loc, X834Location.POLICY_NUMBER, member::setPolicyNumber);
+        apply(loc, X834Location.MEMBER_ID, member::setMemberId);
+        apply(loc, X834Location.MEMBER_ID_QUALIFIER, member::setMemberIdQualifier);
+        apply(loc, X834Location.SUBSCRIBER_NUMBER, member::setSubscriberNumber);
+        apply(loc, X834Location.ENROLLMENT_DATE, v -> member.setEnrollmentDate(parseDateTime(v)));
+        apply(loc, X834Location.COVERAGE_START_DATE, v -> member.setCoverageStartDate(parseDateTime(v)));
+        apply(loc, X834Location.COVERAGE_END_DATE, v -> member.setCoverageEndDate(parseDateTime(v)));
+    }
+
+    /** Custom REF extensions: any {@code "ref.<qualifier>"} placement becomes a {@code REF} segment. */
+    private List<Segment> refExtensions(List<Placement> placements) throws ValidationException {
+        List<Segment> refs = new java.util.ArrayList<>();
+        for (Placement placement : placements) {
+            String location = placement.position().location();
+            if (placement.isOmitted() || !location.startsWith(X834Location.REF_EXTENSION_PREFIX)) {
+                continue;
+            }
+            String qualifier = location.substring(X834Location.REF_EXTENSION_PREFIX.length());
+            refs.add(new RefSegment.Builder()
+                    .setReferenceIdentificationQualifier(qualifier)
+                    .setReferenceIdentification(placement.value())
+                    .build());
+        }
+        return refs;
+    }
+
+    /** Build the HD coverage segment when the Record carries any {@code "hd."} placement. */
+    private Optional<Segment> healthCoverage(List<Placement> placements) throws ValidationException {
+        Map<String, String> loc = byLocation(placements);
+        boolean anyHd = loc.keySet().stream().anyMatch(k -> k.startsWith(X834Location.HD_PREFIX));
+        if (!anyHd) {
+            return Optional.empty();
+        }
+        HealthCoverage.Builder hd = HealthCoverage.builder();
+        apply(loc, X834Location.HD_MAINTENANCE_TYPE_CODE, hd::setMaintenanceTypeCode);
+        apply(loc, X834Location.HD_MAINTENANCE_REASON_CODE, hd::setMaintenanceReasonCode);
+        apply(loc, X834Location.HD_INSURANCE_LINE_CODE, hd::setInsuranceLineCode);
+        apply(loc, X834Location.HD_PLAN_COVERAGE_DESCRIPTION, hd::setPlanCoverageDescription);
+        apply(loc, X834Location.HD_COVERAGE_LEVEL_CODE, hd::setCoverageLevelCode);
+        apply(loc, X834Location.HD_EMPLOYMENT_STATUS_CODE, hd::setEmploymentStatusCode);
+        return Optional.of(hd.build());
+    }
+
+    /** Index a Record's non-omitted placements by their location (a built-in position is unique). */
+    private static Map<String, String> byLocation(List<Placement> placements) {
+        Map<String, String> map = new LinkedHashMap<>();
+        for (Placement placement : placements) {
+            if (!placement.isOmitted()) {
+                map.put(placement.position().location(), placement.value());
+            }
+        }
+        return map;
+    }
+
+    /** Invoke {@code setter} with the value at {@code key} when present and non-blank. */
+    private static void apply(Map<String, String> source, String key, Consumer<String> setter) {
+        String value = source.get(key);
+        if (value != null && !value.isBlank()) {
+            setter.accept(value);
+        }
+    }
+
+    /** Parse an ISO date ({@code yyyy-MM-dd}) or date-time into a {@link LocalDateTime}. */
+    private static LocalDateTime parseDateTime(String value) {
+        return value.contains("T") ? LocalDateTime.parse(value) : LocalDate.parse(value).atStartOfDay();
+    }
+}

--- a/edi-834/src/main/java/com/fastChickensHR/edi/x834/emit/X834Location.java
+++ b/edi-834/src/main/java/com/fastChickensHR/edi/x834/emit/X834Location.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.emit;
+
+/**
+ * The 834 dialect's {@code Position.location} vocabulary — the contract between the app (which builds
+ * a {@link com.fastChickensHR.edi.core.PlannedFile}) and {@link X834FileEmitter} (which serializes it).
+ * Each constant names <em>where</em> a resolved Value goes; the emitter maps it onto the library's
+ * typed builders so the wire output is identical to the legacy converter path.
+ *
+ * <p>File-level keys feed the envelope/header ({@code filePlacements}); member-level keys feed each
+ * subscriber/dependent Record. Custom REF extensions use the {@link #REF_EXTENSION_PREFIX} + qualifier
+ * (e.g. {@code "ref.ZZ"}); HD (coverage) keys are {@code "hd."}-prefixed.
+ */
+public final class X834Location {
+    private X834Location() {
+    }
+
+    // ---- File level: envelope + control numbers (x834Context) ----
+    public static final String SENDER_ID = "senderId";
+    public static final String RECEIVER_ID = "receiverId";
+    public static final String INTERCHANGE_CONTROL_NUMBER = "interchangeControlNumber";
+    public static final String GROUP_CONTROL_NUMBER = "groupControlNumber";
+    public static final String TRANSACTION_SET_CONTROL_NUMBER = "transactionSetControlNumber";
+    public static final String DOCUMENT_DATE = "documentDate";
+
+    // ---- File level: header data (Header.Builder) ----
+    public static final String TRANSACTION_SET_ID = "transactionSetId";
+    public static final String REFERENCE_IDENTIFICATION = "referenceIdentification"; // BGN02
+    public static final String MASTER_POLICY_NUMBER = "masterPolicyNumber";          // REF*38
+    public static final String PLAN_SPONSOR_NAME = "planSponsorName";                // N1*P5
+    public static final String PAYER_NAME = "payerName";                             // N1*IN
+
+    // ---- Member level: INS / built-in REF / DTP (Member fields) ----
+    public static final String MEMBER_INDICATOR = "memberIndicator";       // INS01
+    public static final String RELATIONSHIP_CODE = "relationshipCode";     // INS02
+    public static final String MAINTENANCE_TYPE_CODE = "maintenanceTypeCode"; // INS03
+    public static final String POLICY_NUMBER = "policyNumber";             // REF*1L
+    public static final String MEMBER_ID = "memberId";                     // REF*<qual>
+    public static final String MEMBER_ID_QUALIFIER = "memberIdQualifier";  // that REF's qualifier
+    public static final String SUBSCRIBER_NUMBER = "subscriberNumber";     // REF*OF
+    public static final String ENROLLMENT_DATE = "enrollmentDate";         // DTP*356
+    public static final String COVERAGE_START_DATE = "coverageStartDate";  // DTP*356
+    public static final String COVERAGE_END_DATE = "coverageEndDate";      // DTP*357
+
+    // ---- Member level: health coverage (HD segment) ----
+    public static final String HD_PREFIX = "hd.";
+    public static final String HD_MAINTENANCE_TYPE_CODE = "hd.maintenanceTypeCode";        // HD01
+    public static final String HD_MAINTENANCE_REASON_CODE = "hd.maintenanceReasonCode";    // HD02
+    public static final String HD_INSURANCE_LINE_CODE = "hd.insuranceLineCode";            // HD03
+    public static final String HD_PLAN_COVERAGE_DESCRIPTION = "hd.planCoverageDescription"; // HD04
+    public static final String HD_COVERAGE_LEVEL_CODE = "hd.coverageLevelCode";            // HD05
+    public static final String HD_EMPLOYMENT_STATUS_CODE = "hd.employmentStatusCode";      // HD09
+
+    /** Custom REF extension: location is {@code "ref." + qualifier}, e.g. {@code "ref.ZZ"}. */
+    public static final String REF_EXTENSION_PREFIX = "ref.";
+}

--- a/edi-834/src/test/java/com/fastChickensHR/edi/x834/emit/X834FileEmitterTest.java
+++ b/edi-834/src/test/java/com/fastChickensHR/edi/x834/emit/X834FileEmitterTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.emit;
+
+import com.fastChickensHR.edi.core.Direction;
+import com.fastChickensHR.edi.core.FileLevel;
+import com.fastChickensHR.edi.core.Placement;
+import com.fastChickensHR.edi.core.PlannedFile;
+import com.fastChickensHR.edi.core.PlannedRecord;
+import com.fastChickensHR.edi.core.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class X834FileEmitterTest {
+
+    private final X834FileEmitter emitter = new X834FileEmitter();
+
+    @Test
+    void emitsAWellFormed834FromAPlannedFile() {
+        List<Placement> envelope = List.of(
+                file(X834Location.SENDER_ID, "SENDER123"),
+                file(X834Location.RECEIVER_ID, "RECV456"),
+                file(X834Location.INTERCHANGE_CONTROL_NUMBER, "000000001"),
+                file(X834Location.GROUP_CONTROL_NUMBER, "1"),
+                file(X834Location.TRANSACTION_SET_CONTROL_NUMBER, "0001"),
+                file(X834Location.DOCUMENT_DATE, "2026-01-15"),
+                file(X834Location.REFERENCE_IDENTIFICATION, "REFID001"),
+                file(X834Location.MASTER_POLICY_NUMBER, "MP-100"),
+                file(X834Location.PLAN_SPONSOR_NAME, "ACME CORP"),
+                file(X834Location.PAYER_NAME, "BLUE CROSS"));
+
+        PlannedRecord dependent = PlannedRecord.of(List.of(
+                dep(X834Location.MEMBER_INDICATOR, "Y"),
+                dep(X834Location.RELATIONSHIP_CODE, "01"),
+                dep(X834Location.MAINTENANCE_TYPE_CODE, "001"),
+                dep(X834Location.MEMBER_ID, "D1"),
+                dep(X834Location.MEMBER_ID_QUALIFIER, "0F"),
+                dep(X834Location.ENROLLMENT_DATE, "2026-01-01")));
+
+        PlannedRecord subscriber = new PlannedRecord(List.of(
+                emp(X834Location.MEMBER_INDICATOR, "Y"),
+                emp(X834Location.RELATIONSHIP_CODE, "20"),
+                emp(X834Location.MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.POLICY_NUMBER, "POL-9"),
+                emp(X834Location.MEMBER_ID, "E12345"),
+                emp(X834Location.MEMBER_ID_QUALIFIER, "0F"),
+                emp(X834Location.SUBSCRIBER_NUMBER, "E12345"),
+                emp(X834Location.ENROLLMENT_DATE, "2026-01-01"),
+                emp(X834Location.COVERAGE_START_DATE, "2026-01-01"),
+                emp(X834Location.HD_MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.HD_MAINTENANCE_REASON_CODE, "AC"),
+                emp(X834Location.HD_INSURANCE_LINE_CODE, "HLT"),
+                emp(X834Location.HD_PLAN_COVERAGE_DESCRIPTION, "ACME CORP Health"),
+                emp(X834Location.HD_COVERAGE_LEVEL_CODE, "ESP"),
+                emp(X834Location.HD_EMPLOYMENT_STATUS_CODE, "1"),
+                emp(X834Location.REF_EXTENSION_PREFIX + "ZZ", "NORTH")),
+                List.of(dependent));
+
+        String out = emitter.emit(new PlannedFile(Direction.OUTBOUND, envelope, List.of(subscriber)));
+
+        assertFalse(out == null || out.isBlank(), "expected a rendered 834");
+        // Envelope + header
+        contains(out, "ISA*00*");
+        contains(out, "SENDER123");
+        contains(out, "RECV456");
+        contains(out, "ST*834*0001*");
+        contains(out, "BGN*00*REFID001*20260115");
+        contains(out, "REF*38*MP-100");
+        contains(out, "N1*P5*ACME CORP*FI");
+        contains(out, "N1*IN*BLUE CROSS*FI");
+        // Subscriber loop
+        contains(out, "INS*Y*20*001**A");
+        contains(out, "REF*1L*POL-9");
+        contains(out, "REF*0F*E12345");
+        contains(out, "REF*OF*E12345");
+        // Dependent loop
+        contains(out, "INS*Y*01*001**A");
+        // Custom REF extension + coverage (HD01-05 exact; trailing empties left to the library)
+        contains(out, "REF*ZZ*NORTH");
+        contains(out, "HD*001*AC*HLT*ACME CORP Health*ESP");
+        // Trailer
+        contains(out, "SE*");
+        contains(out, "GE*1*1");
+        contains(out, "IEA*1*000000001");
+        // HD and REF-extension render AFTER all members (document-level trailing segments)
+        assertTrue(out.indexOf("HD*001") > out.indexOf("INS*Y*01"), "HD must render after the members");
+        assertTrue(out.indexOf("REF*ZZ*NORTH") > out.indexOf("INS*Y*01"), "REF extension must render after the members");
+    }
+
+    private static void contains(String haystack, String needle) {
+        assertTrue(haystack.contains(needle), () -> "expected 834 to contain: " + needle + "\n---\n" + haystack);
+    }
+
+    private static Placement file(String location, String value) {
+        return new Placement(new Position(FileLevel.FILE, location), value);
+    }
+
+    private static Placement emp(String location, String value) {
+        return new Placement(new Position(FileLevel.EMPLOYEE, location), value);
+    }
+
+    private static Placement dep(String location, String value) {
+        return new Placement(new Position(FileLevel.DEPENDENT, location), value);
+    }
+}


### PR DESCRIPTION
Implements `FileEmitter` for 834 (ADR-0313 slice 2).

- `X834FileEmitter` serializes a `PlannedFile` → X12 834, mapping each `Position` onto the library's **typed builders** (`x834Context`, `Header`, `Member`/`DependentMember`, `HealthCoverage`, `RefSegment`) so output is identical to the legacy converter path by construction. Envelope, control numbers, segment counts and SE/GE/IEA are produced internally by the library.
- `X834Location` — the `Position.location` vocabulary (the app↔emitter contract).
- edi-834 now depends on `edi-core`.

Additive — nothing in the app consumes it yet (the app still renders via `OutboundX834RenderService`). Unit test asserts a representative subscriber+dependent+HD+custom-REF `PlannedFile` renders the expected segments in the right order. Full reactor build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)