### PR TITLE
feat(edi-csv): CsvFileParser — implement the edi-core FileParser seam (ADR-0313)

### DIFF
--- a/edi-csv/pom.xml
+++ b/edi-csv/pom.xml
@@ -21,6 +21,23 @@
 
     <artifactId>edi-csv</artifactId>
     <name>FastChickensHR EDI CSV</name>
-    <description>CSV EDI format support (placeholder — implementation forthcoming)</description>
+    <description>CSV (flat delimited file) support — parses into and emits from the edi-core file kernel</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fastchickenshr</groupId>
+            <artifactId>edi-core</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/edi-csv/src/main/java/com/fastChickensHR/edi/csv/CsvFileParser.java
+++ b/edi-csv/src/main/java/com/fastChickensHR/edi/csv/CsvFileParser.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.csv;
+
+import com.fastChickensHR.edi.core.Direction;
+import com.fastChickensHR.edi.core.FileLevel;
+import com.fastChickensHR.edi.core.FileParser;
+import com.fastChickensHR.edi.core.Placement;
+import com.fastChickensHR.edi.core.PlannedFile;
+import com.fastChickensHR.edi.core.PlannedRecord;
+import com.fastChickensHR.edi.core.Position;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The CSV implementation of the {@link FileParser} seam (ADR-0313): reads a flat, header-row CSV into a
+ * format-neutral {@link PlannedFile}. A CSV is the degenerate <em>Flat</em> delimited file — one line
+ * per record — so each data row becomes one {@link PlannedRecord} and each non-empty cell becomes a
+ * {@link Placement} whose {@link Position} location is the column name.
+ *
+ * <p>The parser is intentionally dumb: it knows columns and cells, not domain meaning. A flat CSV row's
+ * cells carry no inherent tree depth, so every {@code Position} is emitted at {@link FileLevel#EMPLOYEE}
+ * as a neutral placeholder — the inbound Field Map assigns each column's data element (and thus its real
+ * level and whether a row is an employee or a dependent) downstream. Empty cells produce no placement
+ * (absence, not a blank value).
+ */
+public final class CsvFileParser implements FileParser {
+
+    private static final CSVFormat FORMAT = CSVFormat.DEFAULT.builder()
+            .setHeader()
+            .setSkipHeaderRecord(true)
+            .build();
+
+    @Override
+    public PlannedFile parse(String raw) {
+        try (CSVParser parser = CSVParser.parse(raw == null ? "" : raw, FORMAT)) {
+            List<String> headers = parser.getHeaderNames();
+            List<PlannedRecord> records = new ArrayList<>();
+            for (CSVRecord row : parser) {
+                records.add(PlannedRecord.of(rowPlacements(row, headers)));
+            }
+            return new PlannedFile(Direction.INBOUND, List.of(), records);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to parse CSV: " + e.getMessage(), e);
+        }
+    }
+
+    private static List<Placement> rowPlacements(CSVRecord row, List<String> headers) {
+        List<Placement> placements = new ArrayList<>();
+        for (String column : headers) {
+            if (!row.isMapped(column)) {
+                continue;
+            }
+            String value = row.get(column);
+            if (value != null && !value.isEmpty()) {
+                placements.add(new Placement(new Position(FileLevel.EMPLOYEE, column), value));
+            }
+        }
+        return placements;
+    }
+}

--- a/edi-csv/src/test/java/com/fastChickensHR/edi/csv/CsvFileParserTest.java
+++ b/edi-csv/src/test/java/com/fastChickensHR/edi/csv/CsvFileParserTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.csv;
+
+import com.fastChickensHR.edi.core.Direction;
+import com.fastChickensHR.edi.core.Placement;
+import com.fastChickensHR.edi.core.PlannedFile;
+import com.fastChickensHR.edi.core.PlannedRecord;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CsvFileParserTest {
+
+    private final CsvFileParser parser = new CsvFileParser();
+
+    @Test
+    void parsesFlatCsvIntoRecordsOfColumnPlacements() {
+        String csv = "employeeId,firstName,lastName\nE1,Jane,Doe\nE2,John,\n";
+
+        PlannedFile file = parser.parse(csv);
+
+        assertEquals(Direction.INBOUND, file.direction());
+        assertTrue(file.filePlacements().isEmpty());
+        assertEquals(2, file.records().size());
+
+        Map<String, String> row1 = byColumn(file.records().get(0));
+        assertEquals("E1", row1.get("employeeId"));
+        assertEquals("Jane", row1.get("firstName"));
+        assertEquals("Doe", row1.get("lastName"));
+
+        // An empty cell yields no placement (absence, not a blank value).
+        Map<String, String> row2 = byColumn(file.records().get(1));
+        assertEquals("John", row2.get("firstName"));
+        assertFalse(row2.containsKey("lastName"));
+    }
+
+    @Test
+    void honorsCsvQuotingOfEmbeddedDelimiters() {
+        String csv = "id,name,city\n1,\"Doe, Jane\",\"Springfield\"\n";
+
+        PlannedFile file = parser.parse(csv);
+
+        Map<String, String> row = byColumn(file.records().get(0));
+        assertEquals("Doe, Jane", row.get("name"));
+        assertEquals("Springfield", row.get("city"));
+    }
+
+    @Test
+    void emptyInputYieldsNoRecords() {
+        assertEquals(0, parser.parse("").records().size());
+    }
+
+    private static Map<String, String> byColumn(PlannedRecord record) {
+        Map<String, String> map = new LinkedHashMap<>();
+        for (Placement placement : record.placements()) {
+            map.put(placement.position().location(), placement.value());
+        }
+        return map;
+    }
+}


### PR DESCRIPTION
Starts the **inbound CSV convergence** arc (ADR-0313's bidirectional kernel).

- Fills the previously-empty `edi-csv` module with **`CsvFileParser implements FileParser`**: reads a flat, header-row CSV into a format-neutral `PlannedFile` — each data row → a `PlannedRecord`, each non-empty cell → a `Placement` keyed by column name. CSV is the degenerate **Flat** file (one line per record), so no nesting.
- Uses `commons-csv` (1.12.0, matching the app) for correct quoting/escaping.
- edi-csv now depends on `edi-core`.

The parser is intentionally dumb (columns + cells, no domain meaning); the inbound Field Map assigns each column's element and level downstream — so `Position` levels are a neutral `EMPLOYEE` placeholder for now. **Additive** — nothing consumes it yet; the live `HrIngestionService` is untouched (its behavior-preserving rewire is a later slice). Full reactor build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)