### PR TITLE
docs: remove internal ADR references from library comments

### DIFF
--- a/core/src/main/java/com/fastChickensHR/edi/core/FileParser.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/FileParser.java
@@ -9,8 +9,7 @@ package com.fastChickensHR.edi.core;
 
 /**
  * The inbound seam: a format's parser — the dual of {@link FileGenerator}. Reads a file's text in a
- * format's dialect into a format-neutral {@link FileContent}. Defined now to keep the kernel
- * bidirectional; implemented when the inbound (CSV) convergence lands (ADR-0313, decision 8).
+ * format's dialect into a format-neutral {@link FileContent}, keeping the kernel bidirectional.
  */
 public interface FileParser {
     FileContent parse(String raw);

--- a/csv/src/main/java/com/fastChickensHR/edi/csv/CsvFileGenerator.java
+++ b/csv/src/main/java/com/fastChickensHR/edi/csv/CsvFileGenerator.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * The CSV implementation of the {@link FileGenerator} seam (ADR-0313): writes a format-neutral
+ * The CSV implementation of the {@link FileGenerator} seam: writes a format-neutral
  * {@link FileContent} out as a flat, header-row CSV. The inverse of {@link CsvFileParser}.
  *
  * <p>Each {@link Record} becomes a row and each {@link Field} a cell under its column (the field's

--- a/csv/src/main/java/com/fastChickensHR/edi/csv/CsvFileParser.java
+++ b/csv/src/main/java/com/fastChickensHR/edi/csv/CsvFileParser.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The CSV implementation of the {@link FileParser} seam (ADR-0313): reads a flat, header-row CSV into a
+ * The CSV implementation of the {@link FileParser} seam: reads a flat, header-row CSV into a
  * format-neutral {@link FileContent}. A CSV is the degenerate <em>Flat</em> delimited file — one line
  * per record — so each data row becomes one {@link Record} and each non-empty cell becomes a
  * {@link Field} whose {@link Location} location is the column name.

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
- * The 834 implementation of the {@link FileGenerator} seam (ADR-0313): serializes a format-neutral
+ * The 834 implementation of the {@link FileGenerator} seam: serializes a format-neutral
  * {@link FileContent} into an X12 834 document. It holds no domain logic — every Value has already
  * been resolved upstream by the app's requirements engine. It only interprets each
  * {@link com.fastChickensHR.edi.core.Location} (via {@link X834Location}) onto the library's own typed


### PR DESCRIPTION
The `ADR-0313` citations in the seam Javadoc point at internal design docs that aren't published with this open-source repo — noise to an external reader. This strips all four (comment-only, no code change).

The `FileParser` comment also carried a now-stale clause ("implemented when the inbound (CSV) convergence lands") — that convergence has landed, so the clause is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)