### PR TITLE
Complete the 834 member loop: 2100A/2100C, HD nesting, multi-address, validations

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -13,6 +13,8 @@ import com.fastChickensHR.edi.core.FileContent;
 import com.fastChickensHR.edi.core.Record;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.header.Header;
+import com.fastChickensHR.edi.x834.loop2000.Address;
+import com.fastChickensHR.edi.x834.loop2000.AddressType;
 import com.fastChickensHR.edi.x834.loop2000.BaseMember;
 import com.fastChickensHR.edi.x834.loop2000.DependentMember;
 import com.fastChickensHR.edi.x834.loop2000.Member;
@@ -137,6 +139,21 @@ public final class X834FileGenerator implements FileGenerator {
         apply(loc, X834Location.CITY, member::setCity);
         apply(loc, X834Location.STATE, member::setState);
         apply(loc, X834Location.ZIP_CODE, member::setZipCode);
+
+        // Loop 2100C mailing address (optional, when the member's mailing address differs).
+        mailingAddress(loc).ifPresent(member::addAddress);
+    }
+
+    /** Build the member's {@link AddressType#MAILING} address from the {@code mailing*} fields. */
+    private static Optional<Address> mailingAddress(Map<String, String> loc) {
+        Address mailing = new Address();
+        mailing.setType(AddressType.MAILING);
+        apply(loc, X834Location.MAILING_ADDRESS_LINE_1, mailing::setLine1);
+        apply(loc, X834Location.MAILING_ADDRESS_LINE_2, mailing::setLine2);
+        apply(loc, X834Location.MAILING_CITY, mailing::setCity);
+        apply(loc, X834Location.MAILING_STATE, mailing::setState);
+        apply(loc, X834Location.MAILING_ZIP_CODE, mailing::setZipCode);
+        return mailing.hasStreet() ? Optional.of(mailing) : Optional.empty();
     }
 
     /** Custom REF extensions: any {@code "ref.<qualifier>"} field becomes a {@code REF} segment. */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -61,12 +61,14 @@ public final class X834FileGenerator implements FileGenerator {
                     .withTrailer(new Trailer.Builder(context));
 
             for (Record record : file.records()) {
-                document.addMember(buildMember(record));
-                // After the members, in Record order: this Record's REF extensions, then its HD.
+                Member member = buildMember(record);
+                // This Record's REF extensions then its HD (Loop 2300) attach to the member, so
+                // they are emitted inside that member's own loop rather than after every member.
                 for (Segment ref : refExtensions(record.fields())) {
-                    document.addSegment(ref);
+                    member.addSegment(ref);
                 }
-                healthCoverage(record.fields()).ifPresent(document::addSegment);
+                healthCoverage(record.fields()).ifPresent(member::addSegment);
+                document.addMember(member);
             }
 
             return document.build().generateDocument().orElseThrow(() ->

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -122,6 +122,19 @@ public final class X834FileGenerator implements FileGenerator {
         apply(loc, X834Location.ENROLLMENT_DATE, v -> member.setEnrollmentDate(parseDateTime(v)));
         apply(loc, X834Location.COVERAGE_START_DATE, v -> member.setCoverageStartDate(parseDateTime(v)));
         apply(loc, X834Location.COVERAGE_END_DATE, v -> member.setCoverageEndDate(parseDateTime(v)));
+
+        // Loop 2100A name / demographics / residence address. The writer emits the
+        // matching NM1/DMG/N3/N4 only when these are present, so absent fields change nothing.
+        apply(loc, X834Location.LAST_NAME, member::setLastName);
+        apply(loc, X834Location.FIRST_NAME, member::setFirstName);
+        apply(loc, X834Location.MIDDLE_NAME, member::setMiddleName);
+        apply(loc, X834Location.BIRTH_DATE, v -> member.setBirthDate(parseDateTime(v)));
+        apply(loc, X834Location.GENDER, member::setGender);
+        apply(loc, X834Location.ADDRESS_LINE_1, member::setAddressLine1);
+        apply(loc, X834Location.ADDRESS_LINE_2, member::setAddressLine2);
+        apply(loc, X834Location.CITY, member::setCity);
+        apply(loc, X834Location.STATE, member::setState);
+        apply(loc, X834Location.ZIP_CODE, member::setZipCode);
     }
 
     /** Custom REF extensions: any {@code "ref.<qualifier>"} field becomes a {@code REF} segment. */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
@@ -48,6 +48,18 @@ public final class X834Location {
     public static final String COVERAGE_START_DATE = "coverageStartDate";  // DTP*356
     public static final String COVERAGE_END_DATE = "coverageEndDate";      // DTP*357
 
+    // ---- Member level: Loop 2100A name / demographics / residence address ----
+    public static final String LAST_NAME = "lastName";        // NM103
+    public static final String FIRST_NAME = "firstName";      // NM104
+    public static final String MIDDLE_NAME = "middleName";    // NM105
+    public static final String BIRTH_DATE = "birthDate";      // DMG02 (D8)
+    public static final String GENDER = "gender";             // DMG03
+    public static final String ADDRESS_LINE_1 = "addressLine1"; // N301
+    public static final String ADDRESS_LINE_2 = "addressLine2"; // N302
+    public static final String CITY = "city";                 // N401
+    public static final String STATE = "state";               // N402
+    public static final String ZIP_CODE = "zipCode";          // N403
+
     // ---- Member level: health coverage (HD segment) ----
     public static final String HD_PREFIX = "hd.";
     public static final String HD_MAINTENANCE_TYPE_CODE = "hd.maintenanceTypeCode";        // HD01

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
@@ -60,6 +60,13 @@ public final class X834Location {
     public static final String STATE = "state";               // N402
     public static final String ZIP_CODE = "zipCode";          // N403
 
+    // ---- Member level: Loop 2100C mailing address ----
+    public static final String MAILING_ADDRESS_LINE_1 = "mailingAddressLine1"; // 2100C N301
+    public static final String MAILING_ADDRESS_LINE_2 = "mailingAddressLine2"; // 2100C N302
+    public static final String MAILING_CITY = "mailingCity";                   // 2100C N401
+    public static final String MAILING_STATE = "mailingState";                 // 2100C N402
+    public static final String MAILING_ZIP_CODE = "mailingZipCode";            // 2100C N403
+
     // ---- Member level: health coverage (HD segment) ----
     public static final String HD_PREFIX = "hd.";
     public static final String HD_MAINTENANCE_TYPE_CODE = "hd.maintenanceTypeCode";        // HD01

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/Header.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/Header.java
@@ -139,9 +139,12 @@ public class Header {
      * Builder for Header class
      */
     public static class Builder {
+        /** Default transaction set identifier code for an 834 (ST01 / BGN transaction set). */
+        private static final String DEFAULT_TRANSACTION_SET_IDENTIFIER_CODE = "834";
+
         private final X834Context context;
 
-        private String transactionSetIdentifierCode = "834";
+        private String transactionSetIdentifierCode = DEFAULT_TRANSACTION_SET_IDENTIFIER_CODE;
         private String referenceIdentification;
         private String masterPolicyNumber;
         private String planSponsorName;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/Address.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/Address.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A single typed postal address for a member (residence, mailing, work, ...).
+ * <p>
+ * This is a pure domain object; how (and whether) a given {@link AddressType} is serialized into
+ * the X12 834 wire format is decided by the writer — see {@link AddressType} for the mapping.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Address {
+    private AddressType type;
+    private String line1;
+    private String line2;
+    private String city;
+    private String state;
+    private String zipCode;
+
+    /** @return true when this address carries a street line (the minimum needed to emit an N3). */
+    public boolean hasStreet() {
+        return line1 != null && !line1.isEmpty();
+    }
+
+    /** @return true when city, state and postal code are all present (the minimum to emit an N4). */
+    public boolean hasCityStateZip() {
+        return city != null && !city.isEmpty()
+                && state != null && !state.isEmpty()
+                && zipCode != null && !zipCode.isEmpty();
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/AddressType.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/AddressType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000;
+
+/**
+ * The kind of postal address a member can carry.
+ * <p>
+ * A member may have more than one address of different kinds. Which kinds the X12 834
+ * (005010X220A1) can actually serialize is limited by the transaction's structure:
+ * <ul>
+ *   <li>{@link #RESIDENCE} — the member's residence address, emitted as Loop 2100A N3/N4.</li>
+ *   <li>{@link #MAILING} — the member's mailing address, emitted as Loop 2100C (NM1*31, N3, N4).</li>
+ *   <li>{@link #WORK}, {@link #BILLING} — accepted on the domain model for completeness, but the
+ *       834 member structure has no loop for them, so they are not serialized.</li>
+ * </ul>
+ */
+public enum AddressType {
+    /** Residence / home address — Loop 2100A. */
+    RESIDENCE,
+    /** Mailing address — Loop 2100C. */
+    MAILING,
+    /** Work address — accepted but not serialized (no 834 member loop). */
+    WORK,
+    /** Billing address — accepted but not serialized (no 834 member loop). */
+    BILLING
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -45,13 +45,62 @@ public abstract class BaseMember {
     protected LocalDateTime coverageStartDate;
     protected LocalDateTime coverageEndDate;
     protected IndividualRelationshipCode relationshipCode;
-    protected String addressLine1;
-    protected String addressLine2;
-    protected String city;
-    protected String state;
-    protected String zipCode;
     protected String phoneNumber;
     protected String email;
+
+    /**
+     * All of this member's postal addresses, keyed by {@link AddressType}. A member may carry a
+     * residence, a mailing address, and others; the writer serializes the types the 834 supports
+     * (residence → Loop 2100A, mailing → Loop 2100C).
+     */
+    private final List<Address> addresses = new ArrayList<>();
+
+    /**
+     * Adds a typed address to this member. Multiple types may coexist; adding a second address of
+     * a type that already exists replaces the previous one so a member has at most one of each kind.
+     *
+     * @param address the address to add (ignored if null or has no {@link AddressType})
+     */
+    public void addAddress(Address address) {
+        if (address == null || address.getType() == null) {
+            return;
+        }
+        addresses.removeIf(existing -> existing.getType() == address.getType());
+        addresses.add(address);
+    }
+
+    /**
+     * @param type the address kind to look up
+     * @return this member's address of that type, if any
+     */
+    public java.util.Optional<Address> getAddress(AddressType type) {
+        return addresses.stream().filter(a -> a.getType() == type).findFirst();
+    }
+
+    private Address residenceOrCreate() {
+        return getAddress(AddressType.RESIDENCE).orElseGet(() -> {
+            Address residence = new Address();
+            residence.setType(AddressType.RESIDENCE);
+            addresses.add(residence);
+            return residence;
+        });
+    }
+
+    // --- Backward-compatible flat accessors for the residence address (Loop 2100A) ---
+    // Retained so existing callers (setAddressLine1/setCity/...) keep working; each reads/writes
+    // the member's RESIDENCE address within {@link #addresses}.
+
+    public String getAddressLine1() { return getAddress(AddressType.RESIDENCE).map(Address::getLine1).orElse(null); }
+    public String getAddressLine2() { return getAddress(AddressType.RESIDENCE).map(Address::getLine2).orElse(null); }
+    public String getCity() { return getAddress(AddressType.RESIDENCE).map(Address::getCity).orElse(null); }
+    public String getState() { return getAddress(AddressType.RESIDENCE).map(Address::getState).orElse(null); }
+    public String getZipCode() { return getAddress(AddressType.RESIDENCE).map(Address::getZipCode).orElse(null); }
+
+    public void setAddressLine1(String value) { residenceOrCreate().setLine1(value); }
+    public void setAddressLine2(String value) { residenceOrCreate().setLine2(value); }
+    public void setCity(String value) { residenceOrCreate().setCity(value); }
+    public void setState(String value) { residenceOrCreate().setState(value); }
+    public void setZipCode(String value) { residenceOrCreate().setZipCode(value); }
 
     /**
      * Loop 2300 (and other trailing) segments that belong to <em>this</em> member — most

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -11,10 +11,13 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.segments.Segment;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Base domain class for both primary members and dependents.
@@ -49,6 +52,24 @@ public abstract class BaseMember {
     protected String zipCode;
     protected String phoneNumber;
     protected String email;
+
+    /**
+     * Loop 2300 (and other trailing) segments that belong to <em>this</em> member — most
+     * notably health coverage (HD) and any custom REF extensions. They are emitted by
+     * {@link X834MemberWriter} at the end of this member's own segment stream, so a member's
+     * coverage stays nested inside its own loop rather than being batched after every member.
+     */
+    private final List<Segment> additionalSegments = new ArrayList<>();
+
+    /**
+     * Appends a trailing (Loop 2300) segment to this member — e.g. an HD coverage segment
+     * or a custom REF extension. Order is preserved.
+     *
+     * @param segment the segment to emit within this member's loop
+     */
+    public void addSegment(Segment segment) {
+        additionalSegments.add(segment);
+    }
 
     /**
      * Validates this member has the minimum required fields.

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/MemberPolicyNumber.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/MemberPolicyNumber.java
@@ -11,7 +11,14 @@ import com.fastChickensHR.edi.x834.segments.RefSegment;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.experimental.Accessors;
 
+/**
+ * Member policy number as a REF segment in Loop 2000 of the X12 834 (005010X220A1).
+ * <p>
+ * Renders {@code REF*1L*<policy number>}: REF01 is fixed to the qualifier {@code 1L}
+ * ("Group or Policy Number") and REF02 carries the member's group/policy number.
+ */
 public class MemberPolicyNumber extends RefSegment {
+    /** REF01 qualifier {@code 1L} — Group or Policy Number. */
     public static final String DEFAULT_ENTITY_IDENTIFIER_CODE = "1L";
 
     private MemberPolicyNumber(MemberPolicyNumber.Builder builder) throws ValidationException {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -103,6 +103,11 @@ public class X834MemberWriter {
         appendMemberName(segments, member);
         appendResidenceAddress(segments, member);
         appendDemographics(segments, member);
+
+        // Loop 2300: this member's own trailing segments (health coverage HD, REF extensions).
+        // Emitting them here keeps a member's coverage nested inside its own loop, before any
+        // dependent's loop begins.
+        segments.addAll(member.getAdditionalSegments());
     }
 
     /** Loop 2100A NM1 (member name). Emitted when a last name is present. */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -18,6 +18,9 @@ import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberDemographics;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberName;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceCityStateZipCode;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceStreetAddress;
+import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingAddress;
+import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingCityStateZipCode;
+import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingStreetAddress;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -104,6 +107,10 @@ public class X834MemberWriter {
         appendResidenceAddress(segments, member);
         appendDemographics(segments, member);
 
+        // Loop 2100C (member mailing address), emitted after the 2100A block when the member
+        // carries a distinct mailing address.
+        appendMailingAddress(segments, member);
+
         // Loop 2300: this member's own trailing segments (health coverage HD, REF extensions).
         // Emitting them here keeps a member's coverage nested inside its own loop, before any
         // dependent's loop begins.
@@ -139,6 +146,30 @@ public class X834MemberWriter {
                     .setCityName(member.getCity())
                     .setStateOrProvinceCode(member.getState())
                     .setPostalCode(member.getZipCode())
+                    .build());
+        }
+    }
+
+    /**
+     * Loop 2100C (member mailing address): NM1*31 postal-address marker, then N3/N4. Emitted only
+     * when the member carries a {@link AddressType#MAILING} address with a street line; the N4 is
+     * added when city/state/zip are all present.
+     */
+    private void appendMailingAddress(List<Segment> segments, BaseMember member) throws ValidationException {
+        Address mailing = member.getAddress(AddressType.MAILING).orElse(null);
+        if (mailing == null || !mailing.hasStreet()) {
+            return;
+        }
+        segments.add(MemberMailingAddress.builder().build());
+        segments.add(MemberMailingStreetAddress.builder()
+                .setAddressLine1(mailing.getLine1())
+                .setAddressLine2(emptyToNull(mailing.getLine2()))
+                .build());
+        if (mailing.hasCityStateZip()) {
+            segments.add(MemberMailingCityStateZipCode.builder()
+                    .setCityName(mailing.getCity())
+                    .setStateOrProvinceCode(mailing.getState())
+                    .setPostalCode(mailing.getZipCode())
                     .build());
         }
     }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -7,11 +7,17 @@
  */
 package com.fastChickensHR.edi.x834.loop2000;
 
+import com.fastChickensHR.edi.x834.dates.DateFormat;
+import com.fastChickensHR.edi.x834.dates.DateFormatter;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import com.fastChickensHR.edi.x834.X834Context;
 import com.fastChickensHR.edi.x834.loop2000.data.BenefitStatusCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberDateQualifier;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberDemographics;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberName;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceCityStateZipCode;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceStreetAddress;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -90,6 +96,66 @@ public class X834MemberWriter {
         addDateSegment(segments, MemberDateQualifier.COVERAGE_BEGIN, member.getEnrollmentDate());
         addDateSegment(segments, MemberDateQualifier.COVERAGE_BEGIN, member.getCoverageStartDate());
         addDateSegment(segments, MemberDateQualifier.COVERAGE_END, member.getCoverageEndDate());
+
+        // Loop 2100A (member detail): NM1 name, N3/N4 residence address, DMG demographics —
+        // in the order required by the 834 spec. Each is emitted only when its source data is
+        // present, so a member carrying only INS-level data renders exactly as before.
+        appendMemberName(segments, member);
+        appendResidenceAddress(segments, member);
+        appendDemographics(segments, member);
+    }
+
+    /** Loop 2100A NM1 (member name). Emitted when a last name is present. */
+    private void appendMemberName(List<Segment> segments, BaseMember member) throws ValidationException {
+        if (isBlank(member.getLastName())) {
+            return;
+        }
+        segments.add(MemberName.builder()
+                .setLastName(member.getLastName())
+                .setFirstName(emptyToNull(member.getFirstName()))
+                .setMiddleName(emptyToNull(member.getMiddleName()))
+                .build());
+    }
+
+    /**
+     * Loop 2100A N3/N4 (member residence address). The N3 is emitted when a street address is
+     * present; the N4 requires city, state and postal code together (per the segment's own
+     * validation), so a partial address emits only the N3.
+     */
+    private void appendResidenceAddress(List<Segment> segments, BaseMember member) throws ValidationException {
+        if (!isBlank(member.getAddressLine1())) {
+            segments.add(MemberResidenceStreetAddress.builder()
+                    .setAddressLine1(member.getAddressLine1())
+                    .setAddressLine2(emptyToNull(member.getAddressLine2()))
+                    .build());
+        }
+        if (!isBlank(member.getCity()) && !isBlank(member.getState()) && !isBlank(member.getZipCode())) {
+            segments.add(MemberResidenceCityStateZipCode.builder()
+                    .setCityName(member.getCity())
+                    .setStateOrProvinceCode(member.getState())
+                    .setPostalCode(member.getZipCode())
+                    .build());
+        }
+    }
+
+    /** Loop 2100A DMG (member demographics). Emitted when a birth date is present. */
+    private void appendDemographics(List<Segment> segments, BaseMember member) throws ValidationException {
+        if (member.getBirthDate() == null) {
+            return;
+        }
+        segments.add(new MemberDemographics.Builder()
+                .setDateTimePeriodFormatQualifier(DateFormat.D8.getFormat())
+                .setBirthDate(DateFormatter.formatDate(DateFormat.D8, member.getBirthDate()))
+                .setGenderCode(emptyToNull(member.getGender()))
+                .build());
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isEmpty();
+    }
+
+    private static String emptyToNull(String value) {
+        return isBlank(value) ? null : value;
     }
 
     private void addDateSegment(List<Segment> segments, MemberDateQualifier qualifier, LocalDateTime date)

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberName.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberName.java
@@ -55,6 +55,21 @@ public class MemberName extends NM1Segment {
             if (nm102 == null || nm102.isEmpty()) {
                 throw new ValidationException("Entity Type Qualifier (NM102) is required");
             }
+
+            // Conditional requirement: a person (NM102 = 1) must carry a last/family name (NM103).
+            if (PERSON_ENTITY_TYPE.equals(nm102) && (nm103 == null || nm103.isEmpty())) {
+                throw new ValidationException(
+                        "Last Name (NM103) is required when the Entity Type Qualifier (NM102) is a person (1)");
+            }
+
+            // Mutual pairing (X12 syntax rule P0809): the identification code qualifier (NM108) and
+            // the identification code (NM109) must either both be present or both be absent.
+            boolean hasQualifier = nm108 != null && !nm108.isEmpty();
+            boolean hasCode = nm109 != null && !nm109.isEmpty();
+            if (hasQualifier != hasCode) {
+                throw new ValidationException(
+                        "Identification Code Qualifier (NM108) and Identification Code (NM109) must be provided together");
+            }
         }
     }
 }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberResidenceCityStateZipCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberResidenceCityStateZipCode.java
@@ -33,6 +33,20 @@ public class MemberResidenceCityStateZipCode extends N4Segment {
         if (n403 == null || n403.trim().isEmpty()) {
             throw new ValidationException("Postal Code (N403) is required for Member Residence City State Zip Code");
         }
+        requireLocationQualifierAndIdentifierTogether(n405, n406);
+    }
+
+    /**
+     * Mutual pairing (X12 N4 syntax rule P0506): Location Qualifier (N405) and Location
+     * Identifier (N406) must either both be present or both be absent.
+     */
+    private static void requireLocationQualifierAndIdentifierTogether(String n405, String n406) throws ValidationException {
+        boolean hasQualifier = n405 != null && !n405.trim().isEmpty();
+        boolean hasIdentifier = n406 != null && !n406.trim().isEmpty();
+        if (hasQualifier != hasIdentifier) {
+            throw new ValidationException(
+                    "Location Qualifier (N405) and Location Identifier (N406) must be provided together");
+        }
     }
 
     /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100C/MemberMailingCityStateZipCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100C/MemberMailingCityStateZipCode.java
@@ -12,14 +12,22 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.Getter;
 
 /**
- * Represents a Member Residence City, State, and Zip Code segment in X834 EDI format
- * Implements city name (N401), state/province code (N402), and postal code (N403)
+ * Represents a Member Mailing City, State, and Zip Code (N4) segment in Loop 2100C of the X834 format.
+ * Implements city name (N401), state/province code (N402), and postal code (N403).
  */
 @Getter
 public class MemberMailingCityStateZipCode extends N4Segment {
 
     private MemberMailingCityStateZipCode(Builder builder) throws ValidationException {
         super(builder);
+        // Mutual pairing (X12 N4 syntax rule P0506): Location Qualifier (N405) and Location
+        // Identifier (N406) must either both be present or both be absent.
+        boolean hasQualifier = n405 != null && !n405.trim().isEmpty();
+        boolean hasIdentifier = n406 != null && !n406.trim().isEmpty();
+        if (hasQualifier != hasIdentifier) {
+            throw new ValidationException(
+                    "Location Qualifier (N405) and Location Identifier (N406) must be provided together");
+        }
     }
 
     /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/NM1Segment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/NM1Segment.java
@@ -10,6 +10,15 @@ package com.fastChickensHR.edi.x834.segments;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.Getter;
 
+/**
+ * Represents the NM1 (Individual or Organizational Name) segment in the X12 834 (005010X220A1).
+ * <p>
+ * Element positions: NM101 entity identifier code, NM102 entity type qualifier
+ * (1 = person, 2 = non-person), NM103 last name / organization name, NM104 first name,
+ * NM105 middle name, NM106 name prefix, NM107 name suffix, NM108 identification code
+ * qualifier, NM109 identification code. Concrete subclasses (e.g. member/sponsor/payer name)
+ * fix the qualifier elements and supply the loop-specific defaults.
+ */
 @Getter
 public abstract class NM1Segment extends Segment {
     public static final String SEGMENT_ID = "NM1";

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/Trailer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/Trailer.java
@@ -105,12 +105,20 @@ public class Trailer {
      * Builder for the Trailer class
      */
     public static class Builder {
+        /**
+         * Fallback SE01 segment count used only if the document never sets a computed count.
+         * In normal generation {@code X834Document} overwrites this with the real count.
+         */
+        private static final String DEFAULT_NUMBER_OF_INCLUDED_SEGMENTS = "10";
+        /** Default GE01 — number of transaction sets in the functional group. */
+        private static final String DEFAULT_NUMBER_OF_TRANSACTION_SETS = "1";
+
         @Getter
         private final X834Context context;
 
         private String transactionSetControlNumber;
-        private String numberOfIncludedSegments = "10";
-        private String numberOfTransactionSetsIncluded = "1";
+        private String numberOfIncludedSegments = DEFAULT_NUMBER_OF_INCLUDED_SEGMENTS;
+        private String numberOfTransactionSetsIncluded = DEFAULT_NUMBER_OF_TRANSACTION_SETS;
         private String groupControlNumber;
         private String numberOfIncludedFunctionalGroups = InterchangeControlTrailer.DEFAULT_NUMBER_OF_INCLUDED_GROUPS;
         private String interchangeControlNumber;

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/data/AuthorizationInformationQualifierTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/data/AuthorizationInformationQualifierTest.java
@@ -24,22 +24,12 @@ class AuthorizationInformationQualifierTest {
     void testEnumValues() {
         assertEquals(7, AuthorizationInformationQualifier.values().length);
         assertEquals("00", AuthorizationInformationQualifier.NO_AUTHORIZATION_INFORMATION.getCode());
-        assertEquals("01", AuthorizationInformationQualifier.UCS_COMMUNICATIONS_ID.getCode());
-        assertEquals("02", AuthorizationInformationQualifier.EDX_COMMUNICATIONS_ID.getCode());
-        assertEquals("03", AuthorizationInformationQualifier.ADDITIONAL_DATA_ID.getCode());
-        assertEquals("04", AuthorizationInformationQualifier.RAIL_COMMUNICATIONS_ID.getCode());
-        assertEquals("05", AuthorizationInformationQualifier.DOD_COMMUNICATION_ID.getCode());
         assertEquals("06", AuthorizationInformationQualifier.US_FEDERAL_GOVT_COMM_ID.getCode());
     }
 
     @Test
     void testEnumProperties() {
         assertEquals("No Authorization", AuthorizationInformationQualifier.NO_AUTHORIZATION_INFORMATION.getDescription());
-        assertEquals("UCS Communications ID", AuthorizationInformationQualifier.UCS_COMMUNICATIONS_ID.getDescription());
-        assertEquals("EDX Communications ID", AuthorizationInformationQualifier.EDX_COMMUNICATIONS_ID.getDescription());
-        assertEquals("Additional Data Identification", AuthorizationInformationQualifier.ADDITIONAL_DATA_ID.getDescription());
-        assertEquals("Rail Communications ID", AuthorizationInformationQualifier.RAIL_COMMUNICATIONS_ID.getDescription());
-        assertEquals("Department of Defense (DoD) Communication Identifier", AuthorizationInformationQualifier.DOD_COMMUNICATION_ID.getDescription());
         assertEquals("United States Federal Government Communication Identifier", AuthorizationInformationQualifier.US_FEDERAL_GOVT_COMM_ID.getDescription());
     }
 

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
@@ -91,9 +91,56 @@ class X834FileGeneratorTest {
         contains(out, "SE*");
         contains(out, "GE*1*1");
         contains(out, "IEA*1*000000001");
-        // HD and REF-extension render AFTER all members (document-level trailing segments)
-        assertTrue(out.indexOf("HD*001") > out.indexOf("INS*Y*01"), "HD must render after the members");
-        assertTrue(out.indexOf("REF*ZZ*NORTH") > out.indexOf("INS*Y*01"), "REF extension must render after the members");
+        // HD and REF-extension belong to the subscriber (INS*Y*20) and render inside that
+        // subscriber's own loop (Loop 2300): after its INS, but BEFORE the dependent's loop
+        // (INS*Y*01) begins — not batched after every member.
+        assertTrue(out.indexOf("HD*001") > out.indexOf("INS*Y*20"), "HD must render after its subscriber's INS");
+        assertTrue(out.indexOf("HD*001") < out.indexOf("INS*Y*01"), "HD must render before the dependent loop");
+        assertTrue(out.indexOf("REF*ZZ*NORTH") > out.indexOf("INS*Y*20"), "REF extension renders inside the subscriber loop");
+        assertTrue(out.indexOf("REF*ZZ*NORTH") < out.indexOf("INS*Y*01"), "REF extension renders before the dependent loop");
+    }
+
+    @Test
+    void eachSubscribersHdNestsInsideItsOwnLoopForMultiMemberFiles() {
+        List<Field> envelope = List.of(
+                file(X834Location.SENDER_ID, "SENDER123"),
+                file(X834Location.RECEIVER_ID, "RECV456"),
+                file(X834Location.INTERCHANGE_CONTROL_NUMBER, "000000001"),
+                file(X834Location.GROUP_CONTROL_NUMBER, "1"),
+                file(X834Location.TRANSACTION_SET_CONTROL_NUMBER, "0001"),
+                file(X834Location.DOCUMENT_DATE, "2026-01-15"),
+                file(X834Location.REFERENCE_IDENTIFICATION, "REFID001"),
+                file(X834Location.MASTER_POLICY_NUMBER, "MP-100"),
+                file(X834Location.PLAN_SPONSOR_NAME, "ACME CORP"),
+                file(X834Location.PAYER_NAME, "BLUE CROSS"));
+
+        Record sub1 = Record.of(List.of(
+                emp(X834Location.MEMBER_INDICATOR, "Y"),
+                emp(X834Location.RELATIONSHIP_CODE, "18"),
+                emp(X834Location.MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.SUBSCRIBER_NUMBER, "SUB1"),
+                emp(X834Location.HD_MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.HD_INSURANCE_LINE_CODE, "HLT"),
+                emp(X834Location.HD_PLAN_COVERAGE_DESCRIPTION, "PLAN-ONE")));
+        Record sub2 = Record.of(List.of(
+                emp(X834Location.MEMBER_INDICATOR, "Y"),
+                emp(X834Location.RELATIONSHIP_CODE, "18"),
+                emp(X834Location.MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.SUBSCRIBER_NUMBER, "SUB2"),
+                emp(X834Location.HD_MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.HD_INSURANCE_LINE_CODE, "DEN"),
+                emp(X834Location.HD_PLAN_COVERAGE_DESCRIPTION, "PLAN-TWO")));
+
+        String out = generator.generate(new FileContent(Direction.OUTBOUND, envelope, List.of(sub1, sub2)));
+
+        // Each subscriber's HD sits between its own REF*OF and the next subscriber's REF*OF —
+        // i.e. HD is nested in its member's loop, not batched at the end of the transaction.
+        int sub1Ref = out.indexOf("REF*OF*SUB1");
+        int sub1Hd = out.indexOf("PLAN-ONE");
+        int sub2Ref = out.indexOf("REF*OF*SUB2");
+        int sub2Hd = out.indexOf("PLAN-TWO");
+        assertTrue(sub1Ref < sub1Hd && sub1Hd < sub2Ref, "subscriber 1's HD must precede subscriber 2's loop");
+        assertTrue(sub2Ref < sub2Hd, "subscriber 2's HD must follow subscriber 2's INS/REF");
     }
 
     @Test

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
@@ -187,6 +187,45 @@ class X834FileGeneratorTest {
         assertTrue(out.indexOf("DMG*D8") > out.indexOf("N4*SPRING"), "DMG after N4");
     }
 
+    @Test
+    void emitsMailingAddressLoop2100CFromKernelFields() {
+        List<Field> envelope = List.of(
+                file(X834Location.SENDER_ID, "SENDER123"),
+                file(X834Location.RECEIVER_ID, "RECV456"),
+                file(X834Location.INTERCHANGE_CONTROL_NUMBER, "000000001"),
+                file(X834Location.GROUP_CONTROL_NUMBER, "1"),
+                file(X834Location.TRANSACTION_SET_CONTROL_NUMBER, "0001"),
+                file(X834Location.DOCUMENT_DATE, "2026-01-15"),
+                file(X834Location.REFERENCE_IDENTIFICATION, "REFID001"),
+                file(X834Location.MASTER_POLICY_NUMBER, "MP-100"),
+                file(X834Location.PLAN_SPONSOR_NAME, "ACME CORP"),
+                file(X834Location.PAYER_NAME, "BLUE CROSS"));
+
+        Record subscriber = Record.of(List.of(
+                emp(X834Location.MEMBER_INDICATOR, "Y"),
+                emp(X834Location.RELATIONSHIP_CODE, "18"),
+                emp(X834Location.MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.LAST_NAME, "DOE"),
+                emp(X834Location.ADDRESS_LINE_1, "123 MAIN ST"),
+                emp(X834Location.CITY, "SPRINGFIELD"),
+                emp(X834Location.STATE, "IL"),
+                emp(X834Location.ZIP_CODE, "62704"),
+                emp(X834Location.MAILING_ADDRESS_LINE_1, "PO BOX 99"),
+                emp(X834Location.MAILING_CITY, "SPRINGFIELD"),
+                emp(X834Location.MAILING_STATE, "IL"),
+                emp(X834Location.MAILING_ZIP_CODE, "62705")));
+
+        String out = generator.generate(new FileContent(Direction.OUTBOUND, envelope, List.of(subscriber)));
+
+        contains(out, "N3*123 MAIN ST~");     // residence 2100A
+        contains(out, "N4*SPRINGFIELD*IL*62704~");
+        contains(out, "NM1*31~");             // mailing 2100C marker
+        contains(out, "N3*PO BOX 99~");
+        contains(out, "N4*SPRINGFIELD*IL*62705~");
+        assertTrue(out.indexOf("NM1*31") > out.indexOf("N4*SPRINGFIELD*IL*62704"),
+                "mailing 2100C must render after residence 2100A");
+    }
+
     private static void contains(String haystack, String needle) {
         assertTrue(haystack.contains(needle), () -> "expected 834 to contain: " + needle + "\n---\n" + haystack);
     }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
@@ -96,6 +96,50 @@ class X834FileGeneratorTest {
         assertTrue(out.indexOf("REF*ZZ*NORTH") > out.indexOf("INS*Y*01"), "REF extension must render after the members");
     }
 
+    @Test
+    void emitsFullMemberLoopWhenNameDemographicsAndAddressPresent() {
+        List<Field> envelope = List.of(
+                file(X834Location.SENDER_ID, "SENDER123"),
+                file(X834Location.RECEIVER_ID, "RECV456"),
+                file(X834Location.INTERCHANGE_CONTROL_NUMBER, "000000001"),
+                file(X834Location.GROUP_CONTROL_NUMBER, "1"),
+                file(X834Location.TRANSACTION_SET_CONTROL_NUMBER, "0001"),
+                file(X834Location.DOCUMENT_DATE, "2026-01-15"),
+                file(X834Location.REFERENCE_IDENTIFICATION, "REFID001"),
+                file(X834Location.MASTER_POLICY_NUMBER, "MP-100"),
+                file(X834Location.PLAN_SPONSOR_NAME, "ACME CORP"),
+                file(X834Location.PAYER_NAME, "BLUE CROSS"));
+
+        Record subscriber = Record.of(List.of(
+                emp(X834Location.MEMBER_INDICATOR, "Y"),
+                emp(X834Location.RELATIONSHIP_CODE, "18"),
+                emp(X834Location.MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.SUBSCRIBER_NUMBER, "E12345"),
+                emp(X834Location.LAST_NAME, "DOE"),
+                emp(X834Location.FIRST_NAME, "JANE"),
+                emp(X834Location.MIDDLE_NAME, "Q"),
+                emp(X834Location.BIRTH_DATE, "1980-01-15"),
+                emp(X834Location.GENDER, "F"),
+                emp(X834Location.ADDRESS_LINE_1, "123 MAIN ST"),
+                emp(X834Location.ADDRESS_LINE_2, "APT 4"),
+                emp(X834Location.CITY, "SPRINGFIELD"),
+                emp(X834Location.STATE, "IL"),
+                emp(X834Location.ZIP_CODE, "62704")));
+
+        String out = generator.generate(new FileContent(Direction.OUTBOUND, envelope, List.of(subscriber)));
+
+        contains(out, "INS*Y*18*001**A");
+        contains(out, "NM1*IL*1*DOE*JANE*Q~");
+        contains(out, "N3*123 MAIN ST*APT 4~");
+        contains(out, "N4*SPRINGFIELD*IL*62704~");
+        contains(out, "DMG*D8*19800115*F~");
+        // Loop 2100A order: NM1 -> N3 -> N4 -> DMG, all after the INS.
+        assertTrue(out.indexOf("NM1*IL") > out.indexOf("INS*Y*18"), "NM1 after INS");
+        assertTrue(out.indexOf("N3*123") > out.indexOf("NM1*IL"), "N3 after NM1");
+        assertTrue(out.indexOf("N4*SPRING") > out.indexOf("N3*123"), "N4 after N3");
+        assertTrue(out.indexOf("DMG*D8") > out.indexOf("N4*SPRING"), "DMG after N4");
+    }
+
     private static void contains(String haystack, String needle) {
         assertTrue(haystack.contains(needle), () -> "expected 834 to contain: " + needle + "\n---\n" + haystack);
     }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000;
+
+import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
+import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
+import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.segments.Segment;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class X834MemberWriterTest {
+
+    private final X834Context context = new X834Context()
+            .setInterchangeControlNumber("000000001")
+            .setGroupControlNumber("1");
+    private final X834MemberWriter writer = new X834MemberWriter(context);
+
+    private Member baseSubscriber() {
+        Member member = new Member();
+        member.setMemberIndicator(MemberIndicator.INSURED);
+        member.setRelationshipCode(IndividualRelationshipCode.SELF);
+        member.setMaintenanceTypeCode(MaintenanceTypeCode.ADDITION);
+        return member;
+    }
+
+    private String render(List<Segment> segments) {
+        StringBuilder sb = new StringBuilder();
+        for (Segment segment : segments) {
+            segment.setContext(context);
+            sb.append(segment.render());
+        }
+        return sb.toString();
+    }
+
+    @Test
+    void emitsMemberNameNM1WhenLastNamePresent() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.setFirstName("JANE");
+        member.setMiddleName("Q");
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("NM1*IL*1*DOE*JANE*Q~"),
+                () -> "expected member-name NM1 loop 2100A; got:\n" + out);
+    }
+
+    @Test
+    void emitsDemographicsDMGWhenBirthDatePresent() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
+        member.setGender("M");
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("DMG*D8*19800115*M~"),
+                () -> "expected member demographics DMG; got:\n" + out);
+    }
+
+    @Test
+    void emitsResidenceAddressN3N4WhenAddressPresent() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.setAddressLine1("123 MAIN ST");
+        member.setAddressLine2("APT 4");
+        member.setCity("SPRINGFIELD");
+        member.setState("IL");
+        member.setZipCode("62704");
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("N3*123 MAIN ST*APT 4~"), () -> "expected residence N3; got:\n" + out);
+        assertTrue(out.contains("N4*SPRINGFIELD*IL*62704~"), () -> "expected residence N4; got:\n" + out);
+    }
+
+    @Test
+    void emitsMember2100ASegmentsInSpecOrder() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setSubscriberNumber("E12345");
+        member.setLastName("DOE");
+        member.setFirstName("JANE");
+        member.setAddressLine1("123 MAIN ST");
+        member.setCity("SPRINGFIELD");
+        member.setState("IL");
+        member.setZipCode("62704");
+        member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
+        member.setGender("F");
+
+        String out = render(writer.toSegments(member));
+
+        // Loop 2000 -> Loop 2100A order: INS, REF, [DTP], NM1, N3, N4, DMG
+        int ins = out.indexOf("INS*");
+        int nm1 = out.indexOf("NM1*IL");
+        int n3 = out.indexOf("N3*");
+        int n4 = out.indexOf("N4*");
+        int dmg = out.indexOf("DMG*");
+        assertTrue(ins >= 0 && nm1 > ins, () -> "NM1 must follow INS; got:\n" + out);
+        assertTrue(n3 > nm1, () -> "N3 must follow NM1; got:\n" + out);
+        assertTrue(n4 > n3, () -> "N4 must follow N3; got:\n" + out);
+        assertTrue(dmg > n4, () -> "DMG must follow N4; got:\n" + out);
+    }
+
+    @Test
+    void omitsAll2100ASegmentsWhenNoNameOrAddressOrDemographics() throws ValidationException {
+        // A member with only the INS-level data must render byte-for-byte as before:
+        // no NM1/N3/N4/DMG appear unless their source data is present.
+        Member member = baseSubscriber();
+        member.setSubscriberNumber("E12345");
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("INS*"), "INS should always be present");
+        assertTrue(out.contains("REF*OF*E12345~"), "subscriber number REF should be present");
+        assertFalse(out.contains("NM1"), () -> "no NM1 without a name; got:\n" + out);
+        assertFalse(out.contains("N3"), () -> "no N3 without an address; got:\n" + out);
+        assertFalse(out.contains("N4"), () -> "no N4 without an address; got:\n" + out);
+        assertFalse(out.contains("DMG"), () -> "no DMG without demographics; got:\n" + out);
+    }
+
+    @Test
+    void emitsResidenceN4OnlyWhenCityStateZipAllPresent() throws ValidationException {
+        // N4 (MemberResidenceCityStateZipCode) requires city+state+zip; a partial address
+        // must not blow up generation — the N4 is simply skipped.
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.setAddressLine1("123 MAIN ST");
+        member.setCity("SPRINGFIELD");
+        // no state, no zip
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("N3*123 MAIN ST~"), () -> "N3 should still render; got:\n" + out);
+        assertFalse(out.contains("N4"), () -> "N4 must be skipped when state/zip missing; got:\n" + out);
+    }
+
+    @Test
+    void dependentsAlsoGet2100ASegments() throws ValidationException {
+        Member subscriber = baseSubscriber();
+        subscriber.setLastName("DOE");
+        subscriber.setFirstName("JANE");
+
+        DependentMember dependent = new DependentMember();
+        dependent.setMemberIndicator(MemberIndicator.NOT_INSURED);
+        dependent.setRelationshipCode(IndividualRelationshipCode.SPOUSE);
+        dependent.setMaintenanceTypeCode(MaintenanceTypeCode.ADDITION);
+        dependent.setLastName("DOE");
+        dependent.setFirstName("JOHN");
+        subscriber.addDependent(dependent);
+
+        String out = render(writer.toSegments(subscriber));
+
+        assertTrue(out.contains("NM1*IL*1*DOE*JANE~"), () -> "subscriber name; got:\n" + out);
+        assertTrue(out.contains("NM1*IL*1*DOE*JOHN~"), () -> "dependent name; got:\n" + out);
+        assertEquals(out.indexOf("JANE") < out.indexOf("JOHN"), true,
+                "subscriber loop must precede dependent loop");
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
@@ -149,6 +149,62 @@ class X834MemberWriterTest {
     }
 
     @Test
+    void emitsMailingAddress2100CWhenMailingAddressPresent() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        // residence (2100A)
+        member.setAddressLine1("123 MAIN ST");
+        member.setCity("SPRINGFIELD");
+        member.setState("IL");
+        member.setZipCode("62704");
+        // mailing (2100C) — a distinct PO box
+        member.addAddress(Address.builder()
+                .type(AddressType.MAILING)
+                .line1("PO BOX 99")
+                .city("SPRINGFIELD")
+                .state("IL")
+                .zipCode("62705")
+                .build());
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("NM1*31~"), () -> "expected 2100C postal-address marker NM1*31; got:\n" + out);
+        assertTrue(out.contains("N3*PO BOX 99~"), () -> "expected mailing N3; got:\n" + out);
+        assertTrue(out.contains("N4*SPRINGFIELD*IL*62705~"), () -> "expected mailing N4; got:\n" + out);
+        // 2100C must come after the 2100A residence (N4*...*62704) block.
+        assertTrue(out.indexOf("NM1*31") > out.indexOf("N4*SPRINGFIELD*IL*62704"),
+                () -> "mailing loop must follow residence loop; got:\n" + out);
+    }
+
+    @Test
+    void omitsMailingAddressWhenNoMailingType() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.setAddressLine1("123 MAIN ST");
+        member.setCity("SPRINGFIELD");
+        member.setState("IL");
+        member.setZipCode("62704");
+
+        String out = render(writer.toSegments(member));
+
+        assertFalse(out.contains("NM1*31"), () -> "no 2100C without a mailing address; got:\n" + out);
+    }
+
+    @Test
+    void workAddressIsAcceptedButNotSerialized() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.addAddress(Address.builder()
+                .type(AddressType.WORK)
+                .line1("500 OFFICE PKWY").city("SPRINGFIELD").state("IL").zipCode("62704")
+                .build());
+
+        String out = render(writer.toSegments(member));
+
+        assertFalse(out.contains("500 OFFICE PKWY"), () -> "WORK address must not be serialized; got:\n" + out);
+    }
+
+    @Test
     void dependentsAlsoGet2100ASegments() throws ValidationException {
         Member subscriber = baseSubscriber();
         subscriber.setLastName("DOE");

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/AmountQualifierCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/AmountQualifierCodeTest.java
@@ -32,9 +32,6 @@ class AmountQualifierCodeTest {
         assertEquals("B9", AmountQualifierCode.COINSURANCE_ACTUAL.getCode());
         assertEquals("Co-Insurance - Actual", AmountQualifierCode.COINSURANCE_ACTUAL.getDescription());
 
-        assertEquals("D2", AmountQualifierCode.DEDUCTIBLE_AMOUNT.getCode());
-        assertEquals("FK", AmountQualifierCode.PREMIUM_AMOUNT.getCode());
-        assertEquals("P3", AmountQualifierCode.SPEND_DOWN.getCode());
         assertEquals("R", AmountQualifierCode.EXPECTED_EXPENDITURE_AMOUNT.getCode());
     }
 

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/BenefitStatusCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/BenefitStatusCodeTest.java
@@ -27,10 +27,6 @@ class BenefitStatusCodeTest {
         assertEquals(6, values.length, "Expected 6 benefit status codes");
 
         assertTrue(Arrays.asList(values).contains(BenefitStatusCode.ACTIVE), "ACTIVE status is missing");
-        assertTrue(Arrays.asList(values).contains(BenefitStatusCode.COBRA), "COBRA status is missing");
-        assertTrue(Arrays.asList(values).contains(BenefitStatusCode.DISABLED), "DISABLED status is missing");
-        assertTrue(Arrays.asList(values).contains(BenefitStatusCode.RETIREE), "RETIREE status is missing");
-        assertTrue(Arrays.asList(values).contains(BenefitStatusCode.SURVIVING_INSURED), "SURVIVING_INSURED status is missing");
         assertTrue(Arrays.asList(values).contains(BenefitStatusCode.TERMINATED), "TERMINATED status is missing");
     }
 
@@ -38,18 +34,6 @@ class BenefitStatusCodeTest {
     void testEnumProperties() {
         assertEquals("A", BenefitStatusCode.ACTIVE.getCode());
         assertEquals("Active", BenefitStatusCode.ACTIVE.getDescription());
-
-        assertEquals("C", BenefitStatusCode.COBRA.getCode());
-        assertEquals("COBRA", BenefitStatusCode.COBRA.getDescription());
-
-        assertEquals("D", BenefitStatusCode.DISABLED.getCode());
-        assertEquals("Disabled", BenefitStatusCode.DISABLED.getDescription());
-
-        assertEquals("R", BenefitStatusCode.RETIREE.getCode());
-        assertEquals("Retiree", BenefitStatusCode.RETIREE.getDescription());
-
-        assertEquals("S", BenefitStatusCode.SURVIVING_INSURED.getCode());
-        assertEquals("Surviving Insured", BenefitStatusCode.SURVIVING_INSURED.getDescription());
 
         assertEquals("T", BenefitStatusCode.TERMINATED.getCode());
         assertEquals("Terminated", BenefitStatusCode.TERMINATED.getDescription());

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/COBRAQualifyingEventCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/COBRAQualifyingEventCodeTest.java
@@ -27,13 +27,6 @@ class COBRAQualifyingEventCodeTest {
         assertEquals(9, COBRAQualifyingEventCode.values().length);
 
         assertTrue(Arrays.asList(COBRAQualifyingEventCode.values()).contains(COBRAQualifyingEventCode.TERMINATION_OF_EMPLOYMENT));
-        assertTrue(Arrays.asList(COBRAQualifyingEventCode.values()).contains(COBRAQualifyingEventCode.REDUCTION_IN_HOURS));
-        assertTrue(Arrays.asList(COBRAQualifyingEventCode.values()).contains(COBRAQualifyingEventCode.DEATH_OF_EMPLOYEE));
-        assertTrue(Arrays.asList(COBRAQualifyingEventCode.values()).contains(COBRAQualifyingEventCode.DIVORCE_LEGAL_SEPARATION));
-        assertTrue(Arrays.asList(COBRAQualifyingEventCode.values()).contains(COBRAQualifyingEventCode.MEDICARE_ENTITLEMENT));
-        assertTrue(Arrays.asList(COBRAQualifyingEventCode.values()).contains(COBRAQualifyingEventCode.DEPENDENT_CHILD_CEASES_TO_BE_DEPENDENT));
-        assertTrue(Arrays.asList(COBRAQualifyingEventCode.values()).contains(COBRAQualifyingEventCode.BANKRUPTCY));
-        assertTrue(Arrays.asList(COBRAQualifyingEventCode.values()).contains(COBRAQualifyingEventCode.LAYOFF));
         assertTrue(Arrays.asList(COBRAQualifyingEventCode.values()).contains(COBRAQualifyingEventCode.LEAVE_OF_ABSENCE));
     }
 
@@ -41,27 +34,6 @@ class COBRAQualifyingEventCodeTest {
     void testEnumProperties() {
         assertEquals("1", COBRAQualifyingEventCode.TERMINATION_OF_EMPLOYMENT.getCode());
         assertEquals("Termination of Employment", COBRAQualifyingEventCode.TERMINATION_OF_EMPLOYMENT.getDescription());
-
-        assertEquals("2", COBRAQualifyingEventCode.REDUCTION_IN_HOURS.getCode());
-        assertEquals("Reduction in Hours", COBRAQualifyingEventCode.REDUCTION_IN_HOURS.getDescription());
-
-        assertEquals("3", COBRAQualifyingEventCode.DEATH_OF_EMPLOYEE.getCode());
-        assertEquals("Death of Employee", COBRAQualifyingEventCode.DEATH_OF_EMPLOYEE.getDescription());
-
-        assertEquals("4", COBRAQualifyingEventCode.DIVORCE_LEGAL_SEPARATION.getCode());
-        assertEquals("Divorce or Legal Separation", COBRAQualifyingEventCode.DIVORCE_LEGAL_SEPARATION.getDescription());
-
-        assertEquals("5", COBRAQualifyingEventCode.MEDICARE_ENTITLEMENT.getCode());
-        assertEquals("Medicare Entitlement", COBRAQualifyingEventCode.MEDICARE_ENTITLEMENT.getDescription());
-
-        assertEquals("6", COBRAQualifyingEventCode.DEPENDENT_CHILD_CEASES_TO_BE_DEPENDENT.getCode());
-        assertEquals("Dependent Child Ceases to be Dependent", COBRAQualifyingEventCode.DEPENDENT_CHILD_CEASES_TO_BE_DEPENDENT.getDescription());
-
-        assertEquals("7", COBRAQualifyingEventCode.BANKRUPTCY.getCode());
-        assertEquals("Bankruptcy (Retirees and Dependents)", COBRAQualifyingEventCode.BANKRUPTCY.getDescription());
-
-        assertEquals("8", COBRAQualifyingEventCode.LAYOFF.getCode());
-        assertEquals("Layoff", COBRAQualifyingEventCode.LAYOFF.getDescription());
 
         assertEquals("9", COBRAQualifyingEventCode.LEAVE_OF_ABSENCE.getCode());
         assertEquals("Leave of Absence", COBRAQualifyingEventCode.LEAVE_OF_ABSENCE.getDescription());

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/ConfidentialityCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/ConfidentialityCodeTest.java
@@ -27,12 +27,6 @@ class ConfidentialityCodeTest {
         assertEquals(8, ConfidentialityCode.values().length);
 
         assertTrue(Arrays.asList(ConfidentialityCode.values()).contains(ConfidentialityCode.UNRESTRICTED));
-        assertTrue(Arrays.asList(ConfidentialityCode.values()).contains(ConfidentialityCode.RESTRICTED));
-        assertTrue(Arrays.asList(ConfidentialityCode.values()).contains(ConfidentialityCode.CONFIDENTIAL));
-        assertTrue(Arrays.asList(ConfidentialityCode.values()).contains(ConfidentialityCode.VERY_RESTRICTED));
-        assertTrue(Arrays.asList(ConfidentialityCode.values()).contains(ConfidentialityCode.NORMAL));
-        assertTrue(Arrays.asList(ConfidentialityCode.values()).contains(ConfidentialityCode.LOW));
-        assertTrue(Arrays.asList(ConfidentialityCode.values()).contains(ConfidentialityCode.MEDIUM));
         assertTrue(Arrays.asList(ConfidentialityCode.values()).contains(ConfidentialityCode.HIGH));
     }
 
@@ -41,24 +35,6 @@ class ConfidentialityCodeTest {
         // Test code and description for each enum value
         assertEquals("U", ConfidentialityCode.UNRESTRICTED.getCode());
         assertEquals("Unrestricted", ConfidentialityCode.UNRESTRICTED.getDescription());
-
-        assertEquals("R", ConfidentialityCode.RESTRICTED.getCode());
-        assertEquals("Restricted", ConfidentialityCode.RESTRICTED.getDescription());
-
-        assertEquals("C", ConfidentialityCode.CONFIDENTIAL.getCode());
-        assertEquals("Confidential", ConfidentialityCode.CONFIDENTIAL.getDescription());
-
-        assertEquals("V", ConfidentialityCode.VERY_RESTRICTED.getCode());
-        assertEquals("Very Restricted", ConfidentialityCode.VERY_RESTRICTED.getDescription());
-
-        assertEquals("N", ConfidentialityCode.NORMAL.getCode());
-        assertEquals("Normal", ConfidentialityCode.NORMAL.getDescription());
-
-        assertEquals("L", ConfidentialityCode.LOW.getCode());
-        assertEquals("Low", ConfidentialityCode.LOW.getDescription());
-
-        assertEquals("M", ConfidentialityCode.MEDIUM.getCode());
-        assertEquals("Medium", ConfidentialityCode.MEDIUM.getDescription());
 
         assertEquals("H", ConfidentialityCode.HIGH.getCode());
         assertEquals("High", ConfidentialityCode.HIGH.getDescription());

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/CoverageLevelCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/CoverageLevelCodeTest.java
@@ -33,20 +33,8 @@ class CoverageLevelCodeTest {
 
     @Test
     void testEnumProperties() {
-        assertEquals("FAM", CoverageLevelCode.FAMILY.getCode());
-        assertEquals("Family", CoverageLevelCode.FAMILY.getDescription());
-
-        assertEquals("EMP", CoverageLevelCode.EMPLOYEE_ONLY.getCode());
-        assertEquals("Employee Only", CoverageLevelCode.EMPLOYEE_ONLY.getDescription());
-
-        assertEquals("IND", CoverageLevelCode.INDIVIDUAL.getCode());
-        assertEquals("ECH", CoverageLevelCode.EMPLOYEE_AND_CHILDREN.getCode());
-        assertEquals("ESP", CoverageLevelCode.EMPLOYEE_AND_SPOUSE.getCode());
-        assertEquals("SPC", CoverageLevelCode.SPOUSE_AND_CHILDREN.getCode());
-        assertEquals("SPO", CoverageLevelCode.SPOUSE_ONLY.getCode());
         assertEquals("TWO", CoverageLevelCode.TWO_PARTY.getCode());
         assertEquals("CHD", CoverageLevelCode.CHILDREN_ONLY.getCode());
-        assertEquals("DEP", CoverageLevelCode.DEPENDENTS_ONLY.getCode());
     }
 
     @Test

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/EmploymentStatusCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/EmploymentStatusCodeTest.java
@@ -26,17 +26,6 @@ class EmploymentStatusCodeTest {
         assertEquals(13, EmploymentStatusCode.values().length);
 
         assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.ACTIVE));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.FULL_TIME));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.PART_TIME));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.RETIRED));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.TERMINATED));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.LEAVE_OF_ABSENCE));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.DISABLED));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.MILITARY_DUTY));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.COBRA));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.SURVIVING_INSURED));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.CONTRACT_EMPLOYEE));
-        assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.ON_CALL_EMPLOYEE));
         assertTrue(Arrays.asList(EmploymentStatusCode.values()).contains(EmploymentStatusCode.SEASONAL_EMPLOYEE));
     }
 
@@ -45,39 +34,6 @@ class EmploymentStatusCodeTest {
         // Test code and description for each enum value
         assertEquals("1", EmploymentStatusCode.ACTIVE.getCode());
         assertEquals("Active", EmploymentStatusCode.ACTIVE.getDescription());
-
-        assertEquals("2", EmploymentStatusCode.FULL_TIME.getCode());
-        assertEquals("Full-time", EmploymentStatusCode.FULL_TIME.getDescription());
-
-        assertEquals("3", EmploymentStatusCode.PART_TIME.getCode());
-        assertEquals("Part-time", EmploymentStatusCode.PART_TIME.getDescription());
-
-        assertEquals("4", EmploymentStatusCode.RETIRED.getCode());
-        assertEquals("Retired", EmploymentStatusCode.RETIRED.getDescription());
-
-        assertEquals("5", EmploymentStatusCode.TERMINATED.getCode());
-        assertEquals("Terminated", EmploymentStatusCode.TERMINATED.getDescription());
-
-        assertEquals("6", EmploymentStatusCode.LEAVE_OF_ABSENCE.getCode());
-        assertEquals("Leave of absence", EmploymentStatusCode.LEAVE_OF_ABSENCE.getDescription());
-
-        assertEquals("7", EmploymentStatusCode.DISABLED.getCode());
-        assertEquals("Disabled", EmploymentStatusCode.DISABLED.getDescription());
-
-        assertEquals("9", EmploymentStatusCode.MILITARY_DUTY.getCode());
-        assertEquals("Military duty", EmploymentStatusCode.MILITARY_DUTY.getDescription());
-
-        assertEquals("20", EmploymentStatusCode.COBRA.getCode());
-        assertEquals("COBRA", EmploymentStatusCode.COBRA.getDescription());
-
-        assertEquals("21", EmploymentStatusCode.SURVIVING_INSURED.getCode());
-        assertEquals("Surviving insured", EmploymentStatusCode.SURVIVING_INSURED.getDescription());
-
-        assertEquals("22", EmploymentStatusCode.CONTRACT_EMPLOYEE.getCode());
-        assertEquals("Contract employee", EmploymentStatusCode.CONTRACT_EMPLOYEE.getDescription());
-
-        assertEquals("23", EmploymentStatusCode.ON_CALL_EMPLOYEE.getCode());
-        assertEquals("On call employee", EmploymentStatusCode.ON_CALL_EMPLOYEE.getDescription());
 
         assertEquals("24", EmploymentStatusCode.SEASONAL_EMPLOYEE.getCode());
         assertEquals("Seasonal employee", EmploymentStatusCode.SEASONAL_EMPLOYEE.getDescription());

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/GenderCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/GenderCodeTest.java
@@ -26,9 +26,6 @@ class GenderCodeTest {
         assertEquals(5, GenderCode.values().length);
 
         assertTrue(Arrays.asList(GenderCode.values()).contains(GenderCode.MALE));
-        assertTrue(Arrays.asList(GenderCode.values()).contains(GenderCode.FEMALE));
-        assertTrue(Arrays.asList(GenderCode.values()).contains(GenderCode.UNKNOWN));
-        assertTrue(Arrays.asList(GenderCode.values()).contains(GenderCode.NON_BINARY));
         assertTrue(Arrays.asList(GenderCode.values()).contains(GenderCode.NOT_SPECIFIED));
     }
 
@@ -36,15 +33,6 @@ class GenderCodeTest {
     void testEnumProperties() {
         assertEquals("M", GenderCode.MALE.getCode());
         assertEquals("Male", GenderCode.MALE.getDescription());
-
-        assertEquals("F", GenderCode.FEMALE.getCode());
-        assertEquals("Female", GenderCode.FEMALE.getDescription());
-
-        assertEquals("U", GenderCode.UNKNOWN.getCode());
-        assertEquals("Unknown", GenderCode.UNKNOWN.getDescription());
-
-        assertEquals("N", GenderCode.NON_BINARY.getCode());
-        assertEquals("Non-Binary", GenderCode.NON_BINARY.getDescription());
 
         assertEquals("X", GenderCode.NOT_SPECIFIED.getCode());
         assertEquals("Not Specified", GenderCode.NOT_SPECIFIED.getDescription());

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/HealthCoverageDateQualifierTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/HealthCoverageDateQualifierTest.java
@@ -26,11 +26,6 @@ class HealthCoverageDateQualifierTest {
         assertEquals(7, HealthCoverageDateQualifier.values().length);
 
         assertTrue(Arrays.asList(HealthCoverageDateQualifier.values()).contains(HealthCoverageDateQualifier.EFFECTIVE_DATE));
-        assertTrue(Arrays.asList(HealthCoverageDateQualifier.values()).contains(HealthCoverageDateQualifier.EXPIRATION_DATE));
-        assertTrue(Arrays.asList(HealthCoverageDateQualifier.values()).contains(HealthCoverageDateQualifier.ELIGIBILITY_BEGIN));
-        assertTrue(Arrays.asList(HealthCoverageDateQualifier.values()).contains(HealthCoverageDateQualifier.ELIGIBILITY_END));
-        assertTrue(Arrays.asList(HealthCoverageDateQualifier.values()).contains(HealthCoverageDateQualifier.COBRA_BEGIN));
-        assertTrue(Arrays.asList(HealthCoverageDateQualifier.values()).contains(HealthCoverageDateQualifier.COBRA_END));
         assertTrue(Arrays.asList(HealthCoverageDateQualifier.values()).contains(HealthCoverageDateQualifier.PREMIUM_PAID_TO_DATE));
     }
 
@@ -38,21 +33,6 @@ class HealthCoverageDateQualifierTest {
     void testEnumProperties() {
         assertEquals("348", HealthCoverageDateQualifier.EFFECTIVE_DATE.getCode());
         assertEquals("Plan Begin Date", HealthCoverageDateQualifier.EFFECTIVE_DATE.getDescription());
-
-        assertEquals("349", HealthCoverageDateQualifier.EXPIRATION_DATE.getCode());
-        assertEquals("Plan End Date", HealthCoverageDateQualifier.EXPIRATION_DATE.getDescription());
-
-        assertEquals("356", HealthCoverageDateQualifier.ELIGIBILITY_BEGIN.getCode());
-        assertEquals("Eligibility Begin Date", HealthCoverageDateQualifier.ELIGIBILITY_BEGIN.getDescription());
-
-        assertEquals("357", HealthCoverageDateQualifier.ELIGIBILITY_END.getCode());
-        assertEquals("Eligibility End Date", HealthCoverageDateQualifier.ELIGIBILITY_END.getDescription());
-
-        assertEquals("343", HealthCoverageDateQualifier.COBRA_BEGIN.getCode());
-        assertEquals("COBRA Begin Date", HealthCoverageDateQualifier.COBRA_BEGIN.getDescription());
-
-        assertEquals("344", HealthCoverageDateQualifier.COBRA_END.getCode());
-        assertEquals("COBRA End Date", HealthCoverageDateQualifier.COBRA_END.getDescription());
 
         assertEquals("309", HealthCoverageDateQualifier.PREMIUM_PAID_TO_DATE.getCode());
         assertEquals("Premium Paid To Date", HealthCoverageDateQualifier.PREMIUM_PAID_TO_DATE.getDescription());

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/HealthCoverageReferenceQualifierTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/HealthCoverageReferenceQualifierTest.java
@@ -34,13 +34,6 @@ class HealthCoverageReferenceQualifierTest {
         assertEquals("Group or Policy Number",
                 HealthCoverageReferenceQualifier.GROUP_OR_POLICY_NUMBER.getDescription());
 
-        assertEquals("17", HealthCoverageReferenceQualifier.CLIENT_REPORTING_CATEGORY.getCode());
-        assertEquals("9V", HealthCoverageReferenceQualifier.PAYMENT_CATEGORY.getCode());
-        assertEquals("CE", HealthCoverageReferenceQualifier.CLASS_OF_CONTRACT_CODE.getCode());
-        assertEquals("E8", HealthCoverageReferenceQualifier.SERVICE_CONTRACT_COVERAGE_NUMBER.getCode());
-        assertEquals("M7", HealthCoverageReferenceQualifier.PLAN_NETWORK_IDENTIFICATION_NUMBER.getCode());
-        assertEquals("RB", HealthCoverageReferenceQualifier.RATE_CODE_NUMBER.getCode());
-        assertEquals("X9", HealthCoverageReferenceQualifier.INTERNAL_CONTROL_NUMBER.getCode());
         assertEquals("ZZ", HealthCoverageReferenceQualifier.MUTUALLY_DEFINED.getCode());
     }
 

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/IdentificationCardTypeCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/IdentificationCardTypeCodeTest.java
@@ -31,14 +31,7 @@ class IdentificationCardTypeCodeTest {
     @Test
     void testEnumProperties() {
         assertEquals("D", IdentificationCardTypeCode.DENTAL.getCode());
-        assertEquals("G", IdentificationCardTypeCode.DRUG.getCode());
-        assertEquals("H", IdentificationCardTypeCode.HEALTH.getCode());
-        assertEquals("L", IdentificationCardTypeCode.LONG_TERM_CARE.getCode());
-        assertEquals("M", IdentificationCardTypeCode.MEDICAL.getCode());
-        assertEquals("P", IdentificationCardTypeCode.PHARMACY.getCode());
         assertEquals("V", IdentificationCardTypeCode.VISION.getCode());
-
-        assertEquals("Health", IdentificationCardTypeCode.HEALTH.getDescription());
     }
 
     @Test

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/IndividualRelationshipCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/IndividualRelationshipCodeTest.java
@@ -26,11 +26,6 @@ class IndividualRelationshipCodeTest {
         assertEquals(7, IndividualRelationshipCode.values().length);
 
         assertTrue(Arrays.asList(IndividualRelationshipCode.values()).contains(IndividualRelationshipCode.SPOUSE));
-        assertTrue(Arrays.asList(IndividualRelationshipCode.values()).contains(IndividualRelationshipCode.CHILD));
-        assertTrue(Arrays.asList(IndividualRelationshipCode.values()).contains(IndividualRelationshipCode.EMPLOYEE));
-        assertTrue(Arrays.asList(IndividualRelationshipCode.values()).contains(IndividualRelationshipCode.DISABLED_DEPENDENT));
-        assertTrue(Arrays.asList(IndividualRelationshipCode.values()).contains(IndividualRelationshipCode.SELF));
-        assertTrue(Arrays.asList(IndividualRelationshipCode.values()).contains(IndividualRelationshipCode.LIFE_PARTNER));
         assertTrue(Arrays.asList(IndividualRelationshipCode.values()).contains(IndividualRelationshipCode.OTHER_RELATED));
     }
 
@@ -39,21 +34,6 @@ class IndividualRelationshipCodeTest {
         // Test code and description for each enum value
         assertEquals("01", IndividualRelationshipCode.SPOUSE.getCode());
         assertEquals("Spouse", IndividualRelationshipCode.SPOUSE.getDescription());
-
-        assertEquals("19", IndividualRelationshipCode.CHILD.getCode());
-        assertEquals("Child", IndividualRelationshipCode.CHILD.getDescription());
-
-        assertEquals("20", IndividualRelationshipCode.EMPLOYEE.getCode());
-        assertEquals("Employee", IndividualRelationshipCode.EMPLOYEE.getDescription());
-
-        assertEquals("22", IndividualRelationshipCode.DISABLED_DEPENDENT.getCode());
-        assertEquals("Disabled Dependent", IndividualRelationshipCode.DISABLED_DEPENDENT.getDescription());
-
-        assertEquals("18", IndividualRelationshipCode.SELF.getCode());
-        assertEquals("Self", IndividualRelationshipCode.SELF.getDescription());
-
-        assertEquals("53", IndividualRelationshipCode.LIFE_PARTNER.getCode());
-        assertEquals("Life Partner", IndividualRelationshipCode.LIFE_PARTNER.getDescription());
 
         assertEquals("29", IndividualRelationshipCode.OTHER_RELATED.getCode());
         assertEquals("Other Related", IndividualRelationshipCode.OTHER_RELATED.getDescription());

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/MaintenanceReasonCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/MaintenanceReasonCodeTest.java
@@ -26,15 +26,6 @@ class MaintenanceReasonCodeTest {
         assertEquals(11, MaintenanceReasonCode.values().length);
 
         assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.ACTIVE));
-        assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.BIRTH));
-        assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.COBRA));
-        assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.DISABILITY));
-        assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.DEATH));
-        assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.RETIREMENT));
-        assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.MARRIAGE));
-        assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.STRIKE));
-        assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.TERMINATION));
-        assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.VOLUNTARY_WITHDRAWAL));
         assertTrue(Arrays.asList(MaintenanceReasonCode.values()).contains(MaintenanceReasonCode.ADMINISTRATIVE_ERROR));
     }
 
@@ -42,33 +33,6 @@ class MaintenanceReasonCodeTest {
     void testEnumProperties() {
         assertEquals("AC", MaintenanceReasonCode.ACTIVE.getCode());
         assertEquals("Active", MaintenanceReasonCode.ACTIVE.getDescription());
-
-        assertEquals("BH", MaintenanceReasonCode.BIRTH.getCode());
-        assertEquals("Birth", MaintenanceReasonCode.BIRTH.getDescription());
-
-        assertEquals("CO", MaintenanceReasonCode.COBRA.getCode());
-        assertEquals("COBRA", MaintenanceReasonCode.COBRA.getDescription());
-
-        assertEquals("DI", MaintenanceReasonCode.DISABILITY.getCode());
-        assertEquals("Disability", MaintenanceReasonCode.DISABILITY.getDescription());
-
-        assertEquals("DN", MaintenanceReasonCode.DEATH.getCode());
-        assertEquals("Death", MaintenanceReasonCode.DEATH.getDescription());
-
-        assertEquals("ET", MaintenanceReasonCode.RETIREMENT.getCode());
-        assertEquals("Retirement", MaintenanceReasonCode.RETIREMENT.getDescription());
-
-        assertEquals("MA", MaintenanceReasonCode.MARRIAGE.getCode());
-        assertEquals("Marriage", MaintenanceReasonCode.MARRIAGE.getDescription());
-
-        assertEquals("ST", MaintenanceReasonCode.STRIKE.getCode());
-        assertEquals("Strike", MaintenanceReasonCode.STRIKE.getDescription());
-
-        assertEquals("TN", MaintenanceReasonCode.TERMINATION.getCode());
-        assertEquals("Termination", MaintenanceReasonCode.TERMINATION.getDescription());
-
-        assertEquals("VO", MaintenanceReasonCode.VOLUNTARY_WITHDRAWAL.getCode());
-        assertEquals("Voluntary Withdrawal", MaintenanceReasonCode.VOLUNTARY_WITHDRAWAL.getDescription());
 
         assertEquals("XN", MaintenanceReasonCode.ADMINISTRATIVE_ERROR.getCode());
         assertEquals("Administrative Error", MaintenanceReasonCode.ADMINISTRATIVE_ERROR.getDescription());

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/MedicarePlanCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/MedicarePlanCodeTest.java
@@ -27,11 +27,6 @@ class MedicarePlanCodeTest {
                 "MedicarePlanCode should have 7 enum values");
 
         assertTrue(Arrays.asList(MedicarePlanCode.values()).contains(MedicarePlanCode.HOSPITAL_ONLY));
-        assertTrue(Arrays.asList(MedicarePlanCode.values()).contains(MedicarePlanCode.MEDICAL_ONLY));
-        assertTrue(Arrays.asList(MedicarePlanCode.values()).contains(MedicarePlanCode.HOSPITAL_AND_MEDICAL));
-        assertTrue(Arrays.asList(MedicarePlanCode.values()).contains(MedicarePlanCode.MEDICARE_ADVANTAGE));
-        assertTrue(Arrays.asList(MedicarePlanCode.values()).contains(MedicarePlanCode.PRESCRIPTION_DRUG));
-        assertTrue(Arrays.asList(MedicarePlanCode.values()).contains(MedicarePlanCode.MEDIGAP));
         assertTrue(Arrays.asList(MedicarePlanCode.values()).contains(MedicarePlanCode.NO_MEDICARE));
     }
 
@@ -39,21 +34,6 @@ class MedicarePlanCodeTest {
     void testEnumProperties() {
         assertEquals("A", MedicarePlanCode.HOSPITAL_ONLY.getCode());
         assertEquals("Hospital Only (Part A)", MedicarePlanCode.HOSPITAL_ONLY.getDescription());
-
-        assertEquals("B", MedicarePlanCode.MEDICAL_ONLY.getCode());
-        assertEquals("Medical Only (Part B)", MedicarePlanCode.MEDICAL_ONLY.getDescription());
-
-        assertEquals("C", MedicarePlanCode.HOSPITAL_AND_MEDICAL.getCode());
-        assertEquals("Hospital and Medical (Parts A and B)", MedicarePlanCode.HOSPITAL_AND_MEDICAL.getDescription());
-
-        assertEquals("D", MedicarePlanCode.MEDICARE_ADVANTAGE.getCode());
-        assertEquals("Medicare Advantage (Part C)", MedicarePlanCode.MEDICARE_ADVANTAGE.getDescription());
-
-        assertEquals("E", MedicarePlanCode.PRESCRIPTION_DRUG.getCode());
-        assertEquals("Prescription Drug (Part D)", MedicarePlanCode.PRESCRIPTION_DRUG.getDescription());
-
-        assertEquals("F", MedicarePlanCode.MEDIGAP.getCode());
-        assertEquals("Medigap (Medicare Supplement)", MedicarePlanCode.MEDIGAP.getDescription());
 
         assertEquals("N", MedicarePlanCode.NO_MEDICARE.getCode());
         assertEquals("No Medicare Coverage", MedicarePlanCode.NO_MEDICARE.getDescription());

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/MemberDateQualifierTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/MemberDateQualifierTest.java
@@ -22,47 +22,12 @@ class MemberDateQualifierTest {
                 "MemberDateQualifier should have 21 enum values");
 
         assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.BENEFIT_BEGIN));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.BENEFIT_END));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.BIRTH));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.COVERAGE_BEGIN));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.COVERAGE_END));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.EFFECTIVE));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.ELIGIBILITY_BEGIN));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.ELIGIBILITY_END));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.ENROLLMENT));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.EXPIRATION));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.HIRE));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.MAINTENANCE_EFFECTIVE));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.RETIREMENT));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.SIGNATURE));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.STATUS_CHANGE));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.TERMINATION));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.COBRA_QUALIFYING_EVENT));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.COBRA_ELECTION));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.COBRA_BEGIN));
-        assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.COBRA_END));
         assertTrue(Arrays.asList(MemberDateQualifier.values()).contains(MemberDateQualifier.PREMIUM_PAID_TO_DATE));
     }
 
     @Test
     void testEnumProperties() {
         assertEquals("348", MemberDateQualifier.BENEFIT_BEGIN.getCode());
-        assertEquals("349", MemberDateQualifier.BENEFIT_END.getCode());
-        assertEquals("007", MemberDateQualifier.BIRTH.getCode());
-        assertEquals("356", MemberDateQualifier.COVERAGE_BEGIN.getCode());
-        assertEquals("357", MemberDateQualifier.COVERAGE_END.getCode());
-        assertEquals("303", MemberDateQualifier.EFFECTIVE.getCode());
-        assertEquals("336", MemberDateQualifier.ELIGIBILITY_BEGIN.getCode());
-        assertEquals("337", MemberDateQualifier.ELIGIBILITY_END.getCode());
-        assertEquals("285", MemberDateQualifier.HIRE.getCode());
-        assertEquals("286", MemberDateQualifier.RETIREMENT.getCode());
-        assertEquals("380", MemberDateQualifier.SIGNATURE.getCode());
-        assertEquals("328", MemberDateQualifier.STATUS_CHANGE.getCode());
-        assertEquals("036", MemberDateQualifier.TERMINATION.getCode());
-        assertEquals("301", MemberDateQualifier.COBRA_QUALIFYING_EVENT.getCode());
-        assertEquals("288", MemberDateQualifier.COBRA_ELECTION.getCode());
-        assertEquals("340", MemberDateQualifier.COBRA_BEGIN.getCode());
-        assertEquals("341", MemberDateQualifier.COBRA_END.getCode());
         assertEquals("289", MemberDateQualifier.PREMIUM_PAID_TO_DATE.getCode());
     }
 }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/StudentStatusCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/StudentStatusCodeTest.java
@@ -25,24 +25,12 @@ class StudentStatusCodeTest {
     void testEnumValues() {
         assertEquals(8, StudentStatusCode.values().length);
         assertEquals("F", StudentStatusCode.FULL_TIME.getCode());
-        assertEquals("P", StudentStatusCode.PART_TIME.getCode());
-        assertEquals("N", StudentStatusCode.NOT_A_STUDENT.getCode());
-        assertEquals("C", StudentStatusCode.CONTINUING_EDUCATION.getCode());
-        assertEquals("G", StudentStatusCode.GRADUATED.getCode());
-        assertEquals("B", StudentStatusCode.ON_BREAK.getCode());
-        assertEquals("L", StudentStatusCode.LEAVE_OF_ABSENCE.getCode());
         assertEquals("U", StudentStatusCode.UNKNOWN.getCode());
     }
 
     @Test
     void testEnumProperties() {
         assertEquals("Full-time Student", StudentStatusCode.FULL_TIME.getDescription());
-        assertEquals("Part-time Student", StudentStatusCode.PART_TIME.getDescription());
-        assertEquals("Not a Student", StudentStatusCode.NOT_A_STUDENT.getDescription());
-        assertEquals("Continuing Education", StudentStatusCode.CONTINUING_EDUCATION.getDescription());
-        assertEquals("Graduated", StudentStatusCode.GRADUATED.getDescription());
-        assertEquals("On School Break/Vacation", StudentStatusCode.ON_BREAK.getDescription());
-        assertEquals("Leave of Absence", StudentStatusCode.LEAVE_OF_ABSENCE.getDescription());
         assertEquals("Unknown", StudentStatusCode.UNKNOWN.getDescription());
     }
 

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberNameTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberNameTest.java
@@ -49,7 +49,8 @@ class MemberNameTest {
 
     @Test
     void testBuilderSetsDefaultValues() throws ValidationException {
-        MemberName memberName = MemberName.builder().build();
+        // A person (default NM102=1) requires a last name (NM103).
+        MemberName memberName = MemberName.builder().setLastName(lastName).build();
 
         assertEquals(MemberName.ENTITY_IDENTIFIER_CODE, memberName.getEntityIdentifierCode());
         assertEquals(MemberName.PERSON_ENTITY_TYPE, memberName.getEntityTypeQualifier());
@@ -58,9 +59,23 @@ class MemberNameTest {
     @Test
     void testOverridingDefaultValues() throws ValidationException {
         String customEntityIdentifierCode = "QD";
-        MemberName memberName = MemberName.builder().setEntityIdentifierCode(customEntityIdentifierCode).setEntityTypeQualifier(entityType).build();
+        MemberName memberName = MemberName.builder().setEntityIdentifierCode(customEntityIdentifierCode).setEntityTypeQualifier(entityType).setLastName(lastName).build();
 
         assertEquals(customEntityIdentifierCode, memberName.getEntityIdentifierCode());
+    }
+
+    @Test
+    void testPersonRequiresLastName() {
+        ValidationException exception = assertThrows(ValidationException.class,
+                () -> MemberName.builder().setFirstName(firstName).build());
+        assertTrue(exception.getMessage().contains("Last Name (NM103)"));
+    }
+
+    @Test
+    void testIdentificationQualifierAndCodeMustBePaired() {
+        ValidationException exception = assertThrows(ValidationException.class,
+                () -> MemberName.builder().setLastName(lastName).setIdentificationCodeQualifier("34").build());
+        assertTrue(exception.getMessage().contains("must be provided together"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Completes the 834 member loop and closes a batch of stale segment issues. Audited every open issue against the code + ran a 5010X220A1 conformance sweep; the building-block segment classes already existed and were unit-tested, but the member-loop assembler only emitted `INS`+`REF`+`DTP` — the `NM1`/`DMG`/`N3`/`N4` wrappers were dead code, so generated members had no name, demographics, or address.

## What changed

- **Loop 2100A** — `X834MemberWriter` now emits `NM1` (member name, required), `N3`/`N4` (residence address), and `DMG` (demographics), in spec order. Each is emitted only when its source data is present, so members without that data render byte-identically to before.
- **Loop 2100C** — new typed multi-address model (`Address`/`AddressType`: residence, mailing, work, billing). Mailing is emitted as `NM1*31`/`N3`/`N4`; work/billing are accepted but not serialized (no 834 member loop). `BaseMember` keeps backward-compatible flat residence accessors.
- **HD Loop-2300 ordering fix** — each member's `HD` (and REF extensions) now nests inside that member's own loop instead of being batched after every member; multi-member files were previously mis-nested. Single-member output is unchanged.
- **Kernel path** — new `X834Location` keys (name/demographics/residence + mailing) threaded through `X834FileGenerator`.
- **#79 validations** — `MemberName` person→last-name conditional + NM108/NM109 pairing; member N4 N405/N406 pairing.
- **Cleanup** — #83 named default literals; #80–82 JavaDoc gaps; #33 enum-test trim (first+last).

## Issues

Closes the wiring/validation of #58–#68, #71-adjacent coverage nesting, #79, #80, #81, #82, #83, #33. (#52–56, #69, #70, #72–77, #11, #23, #34 were already closed as done-on-master.)

## Testing

Full multi-module suite green (x834: 1985 tests). New tests cover the member loop, mailing 2100C, HD nesting for multi-member files, and the new validations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)