### PR TITLE
834 Loop 2300 coverage-date DTPs (#71) + comprehensive JavaDoc/X12 doc sweep (#80/#81/#82)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
@@ -48,12 +48,18 @@ public class X834Context {
     private String formattedDocumentTime;
 
     // Constants
+    /** Interchange control version (ISA12) for the 5010 release: {@code "00501"}. */
     private static final String EDI_VERSION = "00501";
+    /** Transaction set identifier for benefit enrollment and maintenance: {@code "834"} (ST01). */
     private static final String TRANSACTION_SET_ID = "834";
+    /** Implementation convention reference identifying the 834 guide 005010X220A1 (ST03 / GS08). */
     private static final String IMPLEMENTATION_CONVENTION_REFERENCE = "005010X220A1";
 
     /**
-     * Creates a new X834Context with default values.
+     * Creates a new X834Context with default values: current timestamp as the document
+     * date, {@link DateFormat#DATE}/{@link TimeFormat#TIME} formats, the conventional 834
+     * delimiters ('*' element, '~' segment, '&gt;' sub-element) and LF line terminator,
+     * and a transaction set control number of {@code "0001"}.
      */
     public X834Context() {
         this.documentDate = LocalDateTime.now();
@@ -85,34 +91,61 @@ public class X834Context {
         }
     }
 
+    /**
+     * @return the element separator character (the character value, not the enum)
+     */
     public char getElementSeparator() {
         return elementSeparator.getValue();
     }
 
+    /**
+     * @return the sub-element (component) separator character
+     */
     public char getSubElementSeparator() {
         return subElementSeparator.getValue();
     }
 
+    /**
+     * @return the segment terminator character
+     */
     public char getSegmentTerminator() {
         return segmentTerminator.getValue();
     }
 
+    /**
+     * @return the line terminator string appended after each rendered segment
+     */
     public String getLineTerminator() {
         return lineTerminator.getValue();
     }
 
+    /**
+     * @return the interchange control version number {@value #EDI_VERSION} (ISA12)
+     */
     public String getEdiVersion() {
         return EDI_VERSION;
     }
 
+    /**
+     * @return the transaction set identifier {@value #TRANSACTION_SET_ID}
+     */
     public String getTransactionSetId() {
         return TRANSACTION_SET_ID;
     }
 
+    /**
+     * @return the implementation convention reference {@value #IMPLEMENTATION_CONVENTION_REFERENCE}
+     */
     public String getImplementationConventionReference() {
         return IMPLEMENTATION_CONVENTION_REFERENCE;
     }
 
+    /**
+     * Sets the document date and refreshes the cached formatted document date.
+     *
+     * @param date the document date/time
+     * @return this context instance for chaining
+     */
     public X834Context setDocumentDate(LocalDateTime date) {
         this.documentDate = date;
         this.formattedDocumentDate = formatDate(date);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/constants/ElementSeparator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/constants/ElementSeparator.java
@@ -9,10 +9,17 @@ package com.fastChickensHR.edi.x834.constants;
 
 import lombok.Getter;
 
+/**
+ * Data element separator characters used between elements within an X12 segment.
+ * {@code X834Context} defaults to {@link #ASTERISK} ('*'), the conventional 834 element separator.
+ */
 @Getter
 public enum ElementSeparator {
+    /** Asterisk '*' — the conventional X12 element separator (default). */
     ASTERISK('*'),
+    /** Caret '^'. */
     CARET('^'),
+    /** Pipe '|'. */
     PIPE('|');
 
     private final char value;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/constants/LineTerminator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/constants/LineTerminator.java
@@ -9,10 +9,18 @@ package com.fastChickensHR.edi.x834.constants;
 
 import lombok.Getter;
 
+/**
+ * Optional line terminator appended after each rendered segment for human readability.
+ * This is cosmetic and distinct from the X12 {@link SegmentTerminator}. {@code X834Context}
+ * defaults to {@link #LF}.
+ */
 @Getter
 public enum LineTerminator {
+    /** Line feed "\n" (default). */
     LF("\n"),
+    /** Carriage return + line feed "\r\n". */
     CRLF("\r\n"),
+    /** No line terminator (segments run together). */
     NONE("");
 
     private final String value;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/constants/SegmentTerminator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/constants/SegmentTerminator.java
@@ -9,11 +9,19 @@ package com.fastChickensHR.edi.x834.constants;
 
 import lombok.Getter;
 
+/**
+ * Segment terminator character marking the end of each X12 segment.
+ * {@code X834Context} defaults to {@link #TILDE} ('~'), the conventional 834 segment terminator.
+ */
 @Getter
 public enum SegmentTerminator {
+    /** Tilde '~' — the conventional X12 segment terminator (default). */
     TILDE('~'),
+    /** Line feed '\n'. */
     LINE_FEED('\n'),
+    /** Carriage return '\r'. */
     CARRIAGE_RETURN('\r'),
+    /** Exclamation point '!'. */
     EXCLAMATION_POINT('!');
 
     private final char value;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/constants/SubElementSeparator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/constants/SubElementSeparator.java
@@ -9,10 +9,17 @@ package com.fastChickensHR.edi.x834.constants;
 
 import lombok.Getter;
 
+/**
+ * Sub-element (component) separator character used between components within a composite
+ * data element. {@code X834Context} defaults to {@link #GREATER_THAN} ('>').
+ */
 @Getter
 public enum SubElementSeparator {
+    /** Colon ':'. */
     COLON(':'),
+    /** Backslash '\'. */
     BACKSLASH('\\'),
+    /** Greater-than '&gt;' (default). */
     GREATER_THAN('>');
 
     private final char value;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/AcknowledgmentRequested.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/AcknowledgmentRequested.java
@@ -14,8 +14,14 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Acknowledgment Requested values used in EDI transactions,
- * specifically in the ISA14 segment of the interchange control header.
+ * Code values for the Acknowledgment Requested field (ISA14, X12 data element I13) in the
+ * Interchange Control Header (ISA) of an X12 834 Benefit Enrollment and Maintenance
+ * interchange (005010X220A1). Indicates whether the sender requests a TA1 interchange
+ * acknowledgment.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum AcknowledgmentRequested implements EdiCodeEnum {
@@ -67,6 +73,10 @@ public enum AcknowledgmentRequested implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/ActionCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/ActionCode.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Action Codes used in EDI transactions.
- * These codes define specific actions to be taken on data.
+ * Code values for the X12 Action Code (data element 306), a shared ASC X12 code set that
+ * specifies the action to be taken on the associated data. Exposed by the X12 834
+ * (005010X220A1) library as a reusable code list.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum ActionCode implements EdiCodeEnum {
@@ -228,6 +233,10 @@ public enum ActionCode implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/AuthorizationInformationQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/AuthorizationInformationQualifier.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Authorization Information Qualifiers used in the ISA01 field
- * of the EDI Interchange Control Header (ISA) segment.
+ * Code values for the Authorization Information Qualifier (ISA01, X12 data element I01) in
+ * the Interchange Control Header (ISA) of an X12 834 interchange (005010X220A1). Qualifies
+ * the type of authorization information carried in ISA02.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum AuthorizationInformationQualifier implements EdiCodeEnum {
@@ -69,6 +74,10 @@ public enum AuthorizationInformationQualifier implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/DateTimeQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/DateTimeQualifier.java
@@ -14,8 +14,14 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Date/Time Qualifiers used in EDI transactions.
- * These codes indicate the purpose or context of a date or date/time element.
+ * Code values for the X12 Date/Time Qualifier (data element 374), which states the meaning
+ * of an accompanying date, time, or date/time period. In the X12 834 (005010X220A1) it
+ * appears in DTP segments (DTP01) that carry dates such as coverage, eligibility, and
+ * employment periods.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum DateTimeQualifier implements EdiCodeEnum {
@@ -477,6 +483,10 @@ public enum DateTimeQualifier implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/EntityIdentifierCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/EntityIdentifierCode.java
@@ -14,8 +14,14 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Entity Identifier Codes used in EDI transactions.
- * These codes identify organizational entities, functional groups, or areas of interest.
+ * Code values for the X12 Entity Identifier Code (data element 98), which identifies the
+ * organizational entity, physical location, property, or individual described by a name
+ * loop. In the X12 834 (005010X220A1) it appears as NM101 (and N101) to label parties such
+ * as the sponsor, payer, and insured.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum EntityIdentifierCode implements EdiCodeEnum {
@@ -216,6 +222,10 @@ public enum EntityIdentifierCode implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/FunctionalIdentifierCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/FunctionalIdentifierCode.java
@@ -14,9 +14,14 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Functional Identifier Codes used in the EDI GS segment,
- * specifically in GS01 element. These codes identify the family or business area
- * of the transaction sets in a functional group.
+ * Code values for the Functional Identifier Code (GS01, X12 data element 479) in the
+ * Functional Group Header (GS). It names the business family of the transaction sets in the
+ * group; for the X12 834 Benefit Enrollment and Maintenance transaction the value is
+ * {@link #BENEFIT_ENROLLMENT} ("BE").
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum FunctionalIdentifierCode implements EdiCodeEnum {
@@ -351,6 +356,10 @@ public enum FunctionalIdentifierCode implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/IdentificationCodeQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/IdentificationCodeQualifier.java
@@ -14,8 +14,14 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Identification Code Qualifiers used in EDI transactions.
- * Contains codes and descriptions for various types of identification numbers.
+ * Code values for the X12 Identification Code Qualifier (data element 66), which designates
+ * the system or authority behind an accompanying identification code. In the X12 834
+ * (005010X220A1) it appears as NM108 and N103/N104 to qualify identifiers such as tax IDs,
+ * SSNs, and payer/plan identifiers.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum IdentificationCodeQualifier implements EdiCodeEnum {
@@ -317,6 +323,10 @@ public enum IdentificationCodeQualifier implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeControlVersionNumber.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeControlVersionNumber.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Interchange Control Version Numbers used in EDI transactions,
- * specifically in the ISA12 segment of the interchange control header.
+ * Code values for the Interchange Control Version Number (ISA12, X12 data element I11) in
+ * the Interchange Control Header (ISA) of an X12 834 interchange (005010X220A1). States the
+ * ASC X12 version under which the interchange envelope is structured.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, publication year, enum name, or description, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum InterchangeControlVersionNumber implements EdiCodeEnum {
@@ -125,6 +130,10 @@ public enum InterchangeControlVersionNumber implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeIdQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeIdQualifier.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Interchange ID Qualifiers used in the ISA05 and ISA07 fields
- * of the EDI 834 Interchange Control Header (ISA) segment.
+ * Code values for the Interchange ID Qualifier (ISA05 and ISA07, X12 data element I05) in
+ * the Interchange Control Header (ISA) of an X12 834 interchange (005010X220A1). Qualifies
+ * the kind of sender ID (ISA06) and receiver ID (ISA08) that follows.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum InterchangeIdQualifier implements EdiCodeEnum {
@@ -210,6 +215,10 @@ public enum InterchangeIdQualifier implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeUsageIndicator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeUsageIndicator.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Interchange Usage Indicators used in EDI transactions,
- * specifically in the ISA15 segment of the interchange control header.
+ * Code values for the Interchange Usage Indicator (ISA15, X12 data element I14) in the
+ * Interchange Control Header (ISA) of an X12 834 interchange (005010X220A1). Marks whether
+ * the interchange carries production, test, or informational data.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum InterchangeUsageIndicator implements EdiCodeEnum {
@@ -73,6 +78,10 @@ public enum InterchangeUsageIndicator implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/ReferenceIdentificationQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/ReferenceIdentificationQualifier.java
@@ -14,8 +14,14 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Reference Identification Qualifier codes used in the EDI
- * transactions, specifically in REF segments to indicate the type of reference.
+ * Code values for the X12 Reference Identification Qualifier (data element 128), which
+ * states the meaning of an accompanying reference identifier. In the X12 834
+ * (005010X220A1) it appears as REF01 to type reference numbers such as subscriber,
+ * group/policy, and member identifiers.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum ReferenceIdentificationQualifier implements EdiCodeEnum {
@@ -148,6 +154,10 @@ public enum ReferenceIdentificationQualifier implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/ResponsibleAgencyCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/ResponsibleAgencyCode.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Responsible Agency Codes used in EDI transactions,
- * specifically in the GS07 segment element of the Functional Group Header.
+ * Code values for the Responsible Agency Code (GS07, X12 data element 455) in the
+ * Functional Group Header (GS). Names the body responsible for the standard used in the
+ * functional group; X12 834 groups (005010X220A1) use {@link #ASC_X12} ("X").
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum ResponsibleAgencyCode implements EdiCodeEnum {
@@ -61,6 +66,10 @@ public enum ResponsibleAgencyCode implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/SecurityInformationQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/SecurityInformationQualifier.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Security Information Qualifiers used in the ISA03 field
- * of the EDI 834 Interchange Control Header (ISA) segment.
+ * Code values for the Security Information Qualifier (ISA03, X12 data element I03) in the
+ * Interchange Control Header (ISA) of an X12 834 interchange (005010X220A1). Qualifies the
+ * type of security information carried in ISA04.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum SecurityInformationQualifier implements EdiCodeEnum {
@@ -67,6 +72,10 @@ public enum SecurityInformationQualifier implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/SecurityLevelCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/SecurityLevelCode.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Security Level Codes used in EDI transactions.
- * These codes define the sensitivity and confidentiality level of information.
+ * Code values for the X12 Security Level Code (data element 1204), a shared ASC X12 code
+ * set describing the sensitivity or confidentiality classification of information. Exposed
+ * by the X12 834 (005010X220A1) library as a reusable code list.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum SecurityLevelCode implements EdiCodeEnum {
@@ -130,6 +135,10 @@ public enum SecurityLevelCode implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/TimeCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/TimeCode.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Time Codes used in EDI transactions.
- * These codes specify time zones and time offsets.
+ * Code values for the X12 Time Code (data element 623), which identifies the time zone or
+ * ISO offset that applies to an accompanying time. In the X12 834 (005010X220A1) it
+ * qualifies times reported alongside date/time segments.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum TimeCode implements EdiCodeEnum {
@@ -137,6 +142,10 @@ public enum TimeCode implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionSetIdentifierCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionSetIdentifierCode.java
@@ -14,8 +14,14 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Transaction Set Identifier Codes used in EDI formats.
- * These codes identify the transaction set type in the ST segment (ST01 element).
+ * Code values for the Transaction Set Identifier Code (ST01, X12 data element 143) in the
+ * Transaction Set Header (ST). Names the transaction set that follows; the X12 834
+ * transaction uses {@link #BENEFIT_ENROLLMENT_AND_MAINTENANCE} ("834") under implementation
+ * guide 005010X220A1.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum TransactionSetIdentifierCode implements EdiCodeEnum {
@@ -125,6 +131,10 @@ public enum TransactionSetIdentifierCode implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionSetPurposeCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionSetPurposeCode.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Transaction Set Purpose Codes used in the EDI transactions,
- * specifically in BGN01 segment.
+ * Code values for the Transaction Set Purpose Code (BGN01, X12 data element 353) in the
+ * Beginning Segment (BGN). In the X12 834 (005010X220A1) it states the intent of the
+ * transmission, for example an original ("00") or a change ("04") file.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum TransactionSetPurposeCode implements EdiCodeEnum {
@@ -171,6 +176,10 @@ public enum TransactionSetPurposeCode implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionTypeCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionTypeCode.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Transaction Type Codes used in EDI transactions.
- * These codes identify the purpose and content of a transaction set.
+ * Code values for the X12 Transaction Type Code (data element 640), which characterizes the
+ * purpose or content of a transaction set. In the X12 834 (005010X220A1) it appears as
+ * BGN08 to distinguish, for example, a new initial group enrollment.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a
+ * value from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum TransactionTypeCode implements EdiCodeEnum {
@@ -174,6 +179,10 @@ public enum TransactionTypeCode implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/VersionCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/VersionCode.java
@@ -14,8 +14,14 @@ import lombok.Getter;
 import java.util.Map;
 
 /**
- * Enumeration representing Version Codes used in EDI transactions,
- * specifically in the GS08 segment element of the Functional Group Header.
+ * Code values for the Version / Release / Industry Identifier Code (GS08, X12 data element
+ * 480) in the Functional Group Header (GS). States the standard version and, for HIPAA
+ * transactions, the implementation guide; the X12 834 Benefit Enrollment and Maintenance
+ * guide is {@link #VERSION_005010X220A1} ("005010X220A1").
+ *
+ * <p>No default value is defined for this element. Its lookup registers no synonyms, so
+ * {@link #fromString(String)} matches only a code, enum name, or description and throws
+ * {@link IllegalArgumentException} when the input matches none.
  */
 @Getter
 public enum VersionCode implements EdiCodeEnum {
@@ -103,6 +109,10 @@ public enum VersionCode implements EdiCodeEnum {
         return LOOKUP.fromString(input);
     }
 
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
     @Override
     public String toString() {
         return code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -21,7 +21,10 @@ import com.fastChickensHR.edi.x834.loop2000.Member;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.dates.DateFormat;
+import com.fastChickensHR.edi.x834.loop2000.data.HealthCoverageDateQualifier;
 import com.fastChickensHR.edi.x834.loop2000.loop3000.HealthCoverage;
+import com.fastChickensHR.edi.x834.loop2000.loop3000.HealthCoverageDates;
 import com.fastChickensHR.edi.x834.segments.RefSegment;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import com.fastChickensHR.edi.x834.trailer.Trailer;
@@ -69,7 +72,9 @@ public final class X834FileGenerator implements FileGenerator {
                 for (Segment ref : refExtensions(record.fields())) {
                     member.addSegment(ref);
                 }
-                healthCoverage(record.fields()).ifPresent(member::addSegment);
+                for (Segment coverage : healthCoverage(record.fields())) {
+                    member.addSegment(coverage);
+                }
                 document.addMember(member);
             }
 
@@ -174,11 +179,11 @@ public final class X834FileGenerator implements FileGenerator {
     }
 
     /** Build the HD coverage segment when the Record carries any {@code "hd."} field. */
-    private Optional<Segment> healthCoverage(List<Field> fields) throws ValidationException {
+    private List<Segment> healthCoverage(List<Field> fields) throws ValidationException {
         Map<String, String> loc = byLocation(fields);
         boolean anyHd = loc.keySet().stream().anyMatch(k -> k.startsWith(X834Location.HD_PREFIX));
         if (!anyHd) {
-            return Optional.empty();
+            return List.of();
         }
         HealthCoverage.Builder hd = HealthCoverage.builder();
         apply(loc, X834Location.HD_MAINTENANCE_TYPE_CODE, hd::setMaintenanceTypeCode);
@@ -187,7 +192,29 @@ public final class X834FileGenerator implements FileGenerator {
         apply(loc, X834Location.HD_PLAN_COVERAGE_DESCRIPTION, hd::setPlanCoverageDescription);
         apply(loc, X834Location.HD_COVERAGE_LEVEL_CODE, hd::setCoverageLevelCode);
         apply(loc, X834Location.HD_EMPLOYMENT_STATUS_CODE, hd::setEmploymentStatusCode);
-        return Optional.of(hd.build());
+
+        // Loop 2300: the HD segment, followed by its coverage-date DTP segments (begin/end).
+        List<Segment> coverage = new java.util.ArrayList<>();
+        coverage.add(hd.build());
+        coverageDate(loc, X834Location.HD_BENEFIT_BEGIN_DATE, HealthCoverageDateQualifier.EFFECTIVE_DATE)
+                .ifPresent(coverage::add);
+        coverageDate(loc, X834Location.HD_BENEFIT_END_DATE, HealthCoverageDateQualifier.EXPIRATION_DATE)
+                .ifPresent(coverage::add);
+        return coverage;
+    }
+
+    /** Build a Loop 2300 coverage-date DTP (D8) for {@code key} when present, using {@code qualifier}. */
+    private static Optional<Segment> coverageDate(Map<String, String> loc, String key,
+                                                  HealthCoverageDateQualifier qualifier) throws ValidationException {
+        String value = loc.get(key);
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(HealthCoverageDates.builder()
+                .setDateTimeQualifier(qualifier.getCode())
+                .setDateTimeFormat(DateFormat.D8)
+                .setDateTimePeriod(parseDateTime(value))
+                .build());
     }
 
     /** Index a Record's non-omitted fields by their location (a built-in position is unique). */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
@@ -75,6 +75,10 @@ public final class X834Location {
     public static final String HD_PLAN_COVERAGE_DESCRIPTION = "hd.planCoverageDescription"; // HD04
     public static final String HD_COVERAGE_LEVEL_CODE = "hd.coverageLevelCode";            // HD05
     public static final String HD_EMPLOYMENT_STATUS_CODE = "hd.employmentStatusCode";      // HD09
+    /** Loop 2300 coverage begin date — DTP*348 (D8). */
+    public static final String HD_BENEFIT_BEGIN_DATE = "hd.benefitBeginDate";
+    /** Loop 2300 coverage end date — DTP*349 (D8). */
+    public static final String HD_BENEFIT_END_DATE = "hd.benefitEndDate";
 
     /** Custom REF extension: location is {@code "ref." + qualifier}, e.g. {@code "ref.ZZ"}. */
     public static final String REF_EXTENSION_PREFIX = "ref.";

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/BeginningSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/BeginningSegment.java
@@ -13,11 +13,13 @@ import com.fastChickensHR.edi.x834.X834Context;
 import lombok.Getter;
 
 /**
- * Represents the Beginning Segment (BGN) for a transaction set in an EDI 834 document.
- * This segment identifies the transaction set and provides control information.
+ * Represents the Beginning Segment (BGN) for a transaction set in an EDI 834 document
+ * (005010X220A1). The BGN follows the transaction set header (ST) in the header portion
+ * of the 834 and provides transaction set purpose and control information.
  */
 @Getter
 public class BeginningSegment extends BGNSegment {
+    /** Default BGN01 transaction set purpose code {@code "00"} (Original). */
     public static final String DEFAULT_TRANSACTION_SET_PURPOSE_CODE = "00";
 
     protected BeginningSegment(Builder builder) throws ValidationException {
@@ -29,6 +31,12 @@ public class BeginningSegment extends BGNSegment {
      */
     public static class Builder extends BGNSegment.AbstractBuilder<BeginningSegment.Builder> {
 
+        /**
+         * Creates a builder seeded with the default purpose code (BGN01=00) and the
+         * context's formatted document date as the transaction set reference date (BGN03).
+         *
+         * @param context The X834 context supplying the document date
+         */
         public Builder(X834Context context) {
             super();
             this.setTransactionSetPurposeCode(DEFAULT_TRANSACTION_SET_PURPOSE_CODE);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/FileEffectiveDate.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/FileEffectiveDate.java
@@ -12,17 +12,34 @@ import com.fastChickensHR.edi.x834.segments.DTPSegment;
 import com.fastChickensHR.edi.x834.X834Context;
 import lombok.experimental.Accessors;
 
+/**
+ * File effective date (DTP*007) in the header portion of the X12 834 (005010X220A1).
+ * <p>
+ * Produces the DTP segment carrying the master effective date for the file. Extends the
+ * generic {@link DTPSegment}.
+ */
 public class FileEffectiveDate extends DTPSegment {
+    /** Default DTP01 date/time qualifier {@code "007"} (Effective). */
     public static final String DEFAULT_DATE_TIME_QUALIFIER = "007";
 
     private FileEffectiveDate(FileEffectiveDate.Builder builder) throws ValidationException {
         super(builder);
     }
 
+    /**
+     * Creates a new Builder for FileEffectiveDate using the given context.
+     *
+     * @param context The X834 context supplying the date format and document date
+     * @return a new Builder instance
+     */
     public static FileEffectiveDate.Builder builder(X834Context context) {
         return new FileEffectiveDate.Builder(context);
     }
 
+    /**
+     * Builder for FileEffectiveDate. Seeds the effective-date qualifier (DTP01=007),
+     * the context's date format (DTP02), and the context's formatted document date (DTP03).
+     */
     @Accessors(chain = true)
     public static class Builder extends DTPSegment.AbstractBuilder<Builder> {
 
@@ -38,6 +55,12 @@ public class FileEffectiveDate extends DTPSegment {
             return this;
         }
 
+        /**
+         * Builds a new FileEffectiveDate instance.
+         *
+         * @return A new FileEffectiveDate instance
+         * @throws ValidationException if the date/time period (DTP03) is missing
+         */
         @Override
         public FileEffectiveDate build() throws ValidationException {
             if (dtp03 == null || dtp03.isEmpty()) {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/FunctionalGroupHeader.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/FunctionalGroupHeader.java
@@ -16,13 +16,18 @@ import com.fastChickensHR.edi.x834.X834Context;
 import lombok.Getter;
 
 /**
- * Represents the Functional Group Header segment specific to the X834 format.
- * This extends the generic GS segment with X834-specific functionality.
+ * Represents the Functional Group Header (GS) segment specific to the X834 format
+ * (005010X220A1). The GS opens the functional group inside the ISA/IEA interchange
+ * envelope and precedes the transaction set header (ST). Extends the generic GS segment
+ * with X834-specific defaults.
  */
 @Getter
 public class FunctionalGroupHeader extends GSSegment {
+    /** Default GS01 functional identifier code {@code "BE"} (Benefit Enrollment and Maintenance, 834). */
     private static final FunctionalIdentifierCode DEFAULT_FUNCTIONAL_ID_CODE = FunctionalIdentifierCode.fromString("BE");
+    /** Default GS07 responsible agency code (ASC X12). */
     private static final ResponsibleAgencyCode DEFAULT_RESPONSIBLE_AGENCY_CODE = ResponsibleAgencyCode.ASC_X12;
+    /** Default GS08 version/release/industry identifier code {@code "005010X220A1"} (the 834 guide). */
     private static final VersionCode DEFAULT_VERSION_CODE = VersionCode.fromString("005010X220A1");
 
     private final X834Context context;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/Header.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/Header.java
@@ -171,72 +171,156 @@ public class Header {
         }
 
         // Simple setters
+        /**
+         * Sets the transaction set identifier code (ST01); defaults to "834".
+         *
+         * @param transactionSetIdentifierCode the transaction set identifier code
+         * @return this builder instance
+         */
         public Builder setTransactionSetIdentifierCode(String transactionSetIdentifierCode) {
             this.transactionSetIdentifierCode = transactionSetIdentifierCode;
             return this;
         }
 
+        /**
+         * Sets the reference identification used by the Beginning Segment (BGN02).
+         *
+         * @param referenceIdentification the reference identification
+         * @return this builder instance
+         */
         public Builder setReferenceIdentification(String referenceIdentification) {
             this.referenceIdentification = referenceIdentification;
             return this;
         }
 
+        /**
+         * Sets the master policy number (REF*38).
+         *
+         * @param masterPolicyNumber the master policy number
+         * @return this builder instance
+         */
         public Builder setMasterPolicyNumber(String masterPolicyNumber) {
             this.masterPolicyNumber = masterPolicyNumber;
             return this;
         }
 
+        /**
+         * Sets the plan sponsor name (Loop 1000A, N1*P5).
+         *
+         * @param planSponsorName the plan sponsor name
+         * @return this builder instance
+         */
         public Builder setPlanSponsorName(String planSponsorName) {
             this.planSponsorName = planSponsorName;
             return this;
         }
 
+        /**
+         * Sets the payer name (Loop 1000B, N1*IN).
+         *
+         * @param payerName the payer name
+         * @return this builder instance
+         */
         public Builder setPayerName(String payerName) {
             this.payerName = payerName;
             return this;
         }
 
+        /**
+         * Sets the payer identification (Loop 1000B, N104).
+         *
+         * @param payerIdentification the payer identification
+         * @return this builder instance
+         */
         public Builder setPayerIdentification(String payerIdentification) {
             this.payerIdentification = payerIdentification;
             return this;
         }
 
         // Custom builder setters
+        /**
+         * Supplies a custom Interchange Control Header (ISA) builder, overriding the default.
+         *
+         * @param builder the custom ISA builder
+         * @return this builder instance
+         */
         public Builder setInterchangeControlHeaderBuilder(InterchangeControlHeader.Builder builder) {
             this.customInterchangeBuilder = builder;
             return this;
         }
 
+        /**
+         * Supplies a custom Functional Group Header (GS) builder, overriding the default.
+         *
+         * @param builder the custom GS builder
+         * @return this builder instance
+         */
         public Builder setFunctionalGroupHeaderBuilder(FunctionalGroupHeader.Builder builder) {
             this.customFunctionalBuilder = builder;
             return this;
         }
 
+        /**
+         * Supplies a custom Transaction Set Header (ST) builder, overriding the default.
+         *
+         * @param builder the custom ST builder
+         * @return this builder instance
+         */
         public Builder setTransactionSetHeaderBuilder(TransactionSetHeader.Builder builder) {
             this.customTransactionSetBuilder = builder;
             return this;
         }
 
+        /**
+         * Supplies a custom Beginning Segment (BGN) builder, overriding the default.
+         *
+         * @param builder the custom BGN builder
+         * @return this builder instance
+         */
         public Builder setBeginningSegmentBuilder(BeginningSegment.Builder builder) {
             this.customBeginningSegmentBuilder = builder;
             return this;
         }
 
+        /**
+         * Supplies a custom File Effective Date (DTP*007) builder, overriding the default.
+         *
+         * @param builder the custom DTP builder
+         * @return this builder instance
+         */
         public Builder setFileEffectiveDateBuilder(FileEffectiveDate.Builder builder) {
             this.customFileEffectiveDateBuilder = builder;
             return this;
         }
 
+        /**
+         * Supplies a custom Transaction Set Policy Number (REF*38) builder, overriding the default.
+         *
+         * @param builder the custom REF builder
+         * @return this builder instance
+         */
         public Builder setTransactionSetPolicyNumberBuilder(TransactionSetPolicyNumber.Builder builder) {
             this.customPolicyNumberBuilder = builder;
             return this;
         }
 
+        /**
+         * Supplies a custom Sponsor Name (Loop 1000A, N1*P5) builder, overriding the default.
+         *
+         * @param builder the custom sponsor builder
+         * @return this builder instance
+         */
         public Builder setSponsorNameBuilder(SponsorName.Builder builder) {
             this.customSponsorBuilder = builder;
             return this;
         }
 
+        /**
+         * Supplies a custom Payer (Loop 1000B, N1*IN) builder, overriding the default.
+         *
+         * @param builder the custom payer builder
+         * @return this builder instance
+         */
         public Builder setPayerBuilder(Payer.Builder builder) {
             this.customPayerBuilder = builder;
             return this;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/InterchangeControlHeader.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/InterchangeControlHeader.java
@@ -15,22 +15,34 @@ import com.fastChickensHR.edi.x834.X834Context;
 import lombok.Getter;
 
 /**
- * Represents the Interchange Control Header segment specific to the X834 format.
- * This extends the generic ISA segment with X834-specific functionality.
+ * Represents the Interchange Control Header (ISA) segment specific to the X834 format
+ * (005010X220A1). The ISA is the outermost segment of the interchange envelope and is
+ * paired with the closing IEA. Extends the generic ISA segment with X834-specific defaults.
  */
 @Getter
 public class InterchangeControlHeader extends ISASegment {
     private final X834Context context;
+    /** Default ISA01 authorization information qualifier {@code "00"} (No authorization information present). */
     public static final AuthorizationInformationQualifier DEFAULT_AUTHORIZATION_INFO_QUALIFIER = AuthorizationInformationQualifier.fromString("00");
+    /** Default ISA02 authorization information: 10 spaces (fixed-width, no data). */
     public static final String DEFAULT_AUTHORIZATION_INFO = TextUtils.spaces(10);
+    /** Default ISA03 security information qualifier {@code "00"} (No security information present). */
     public static final SecurityInformationQualifier DEFAULT_SECURITY_INFO_QUALIFIER = SecurityInformationQualifier.fromString("00");
+    /** Default ISA04 security information: 10 spaces (fixed-width, no data). */
     public static final String DEFAULT_SECURITY_INFO = TextUtils.spaces(10);
+    /** Default ISA05 interchange sender ID qualifier {@code "30"} (U.S. Federal Tax Identification Number). */
     public static final InterchangeIdQualifier DEFAULT_INTERCHANGE_SENDER_QUALIFIER = InterchangeIdQualifier.fromString("30");
+    /** Default ISA07 interchange receiver ID qualifier {@code "ZZ"} (Mutually Defined). */
     public static final InterchangeIdQualifier DEFAULT_INTERCHANGE_RECEIVER_QUALIFIER = InterchangeIdQualifier.fromString("ZZ");
+    /** Default ISA11 repetition separator {@code "^"}. */
     public static final String DEFAULT_REPETITION_SEPARATOR = "^";
+    /** Default ISA12 interchange control version number {@code "00501"} (5010). */
     public static final InterchangeControlVersionNumber DEFAULT_INTERCHANGE_CONTROL_VERSION = InterchangeControlVersionNumber.fromString("00501");
+    /** Default ISA14 acknowledgment requested flag {@code "0"} (No interchange acknowledgment requested). */
     public static final AcknowledgmentRequested DEFAULT_ACKNOWLEDGMENT_REQUESTED = AcknowledgmentRequested.fromString("0");
+    /** Default ISA15 usage indicator {@code "T"} (Test). */
     public static final InterchangeUsageIndicator DEFAULT_USAGE_INDICATOR = InterchangeUsageIndicator.fromString("T");
+    /** Default ISA16 component element separator {@code ":"}. */
     public static final String DEFAULT_COMPONENT_ELEMENT_SEPARATOR = ":";
 
     protected InterchangeControlHeader(Builder builder) throws ValidationException {
@@ -75,6 +87,12 @@ public class InterchangeControlHeader extends ISASegment {
             return this;
         }
 
+        /**
+         * Builds a new InterchangeControlHeader instance.
+         *
+         * @return A new InterchangeControlHeader instance
+         * @throws ValidationException if validation fails
+         */
         @Override
         public InterchangeControlHeader build() throws ValidationException {
             return new InterchangeControlHeader(this);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/TransactionSetHeader.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/TransactionSetHeader.java
@@ -13,15 +13,18 @@ import com.fastChickensHR.edi.x834.X834Context;
 import lombok.Getter;
 
 /**
- * Abstract class representing the beginning segment of the header loop in an EDI document.
- * This segment is commonly referred to as the "ST" segment and includes key fields such as
+ * Represents the Transaction Set Header (ST) segment that opens the 834 transaction set
+ * (005010X220A1), sitting just inside the GS/GE functional group. Includes key fields such as
  * the transaction set identifier code (ST01), transaction set control number (ST02),
- * and implementation convention reference (ST03).
+ * and implementation convention reference (ST03). Extends the generic ST segment.
  */
 @Getter
 public class TransactionSetHeader extends STSegment {
+    /** Default ST01 transaction set identifier code {@code "834"} (Benefit Enrollment and Maintenance). */
     private final static String DEFAULT_TRANSACTION_SET_ID = "834";
+    /** Default ST02 transaction set control number {@code "0001"}. */
     private final static String DEFAULT_CONTROL_NUMBER = "0001";
+    /** Default ST03 implementation convention reference {@code "005010X220A1"} (the 834 guide). */
     private final static String DEFAULT_CONVENTION_REFERENCE = "005010X220A1";
 
     protected TransactionSetHeader(Builder builder) throws ValidationException {
@@ -29,11 +32,14 @@ public class TransactionSetHeader extends STSegment {
     }
 
     /**
-     * Builder for the FunctionalGroupHeader.
+     * Builder for the TransactionSetHeader.
      */
     public static class Builder extends STSegment.AbstractBuilder<TransactionSetHeader.Builder> {
         protected X834Context context;
 
+        /**
+         * Creates a builder seeded with the default ST01/ST02/ST03 values (834, 0001, 005010X220A1).
+         */
         public Builder() {
             super();
             this.setSt01(DEFAULT_TRANSACTION_SET_ID);
@@ -41,6 +47,12 @@ public class TransactionSetHeader extends STSegment {
             this.setSt03(DEFAULT_CONVENTION_REFERENCE);
         }
 
+        /**
+         * Creates a builder using the context's transaction set control number for ST02,
+         * with the default ST01 (834) and ST03 (005010X220A1) values.
+         *
+         * @param context The X834 context supplying the transaction set control number
+         */
         public Builder(X834Context context) {
             super();
             this.context = context;
@@ -55,9 +67,9 @@ public class TransactionSetHeader extends STSegment {
         }
 
         /**
-         * Builds a new FunctionalGroupHeader instance
+         * Builds a new TransactionSetHeader instance
          *
-         * @return A new FunctionalGroupHeader instance
+         * @return A new TransactionSetHeader instance
          * @throws ValidationException if validation fails
          */
         public TransactionSetHeader build() throws ValidationException {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/TransactionSetPolicyNumber.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/TransactionSetPolicyNumber.java
@@ -12,11 +12,12 @@ import com.fastChickensHR.edi.x834.segments.RefSegment;
 import lombok.Getter;
 
 /**
- * Represents a policy number reference segment in an X834 transaction set.
- * This segment uses the REF segment format with a specific qualifier for policy numbers.
+ * Master policy number reference (REF*38) in the header portion of the X12 834 (005010X220A1).
+ * This segment uses the REF segment format with the {@code "38"} qualifier for the master policy number.
  */
 @Getter
 public class TransactionSetPolicyNumber extends RefSegment {
+    /** Default REF01 reference identification qualifier {@code "38"} (Master Policy Number). */
     private final static String DEFAULT_REFERENCE_IDENTIFICATION_QUALIFIER = "38";
 
     protected TransactionSetPolicyNumber(Builder builder) throws ValidationException {
@@ -24,14 +25,16 @@ public class TransactionSetPolicyNumber extends RefSegment {
     }
 
     /**
-     * Domain-specific accessor method
+     * Domain-specific accessor for the master policy number (REF02).
+     *
+     * @return the master policy number
      */
     public String getMasterPolicyNumber() {
         return getRef02();
     }
 
     /**
-     * Builder for the TransactionSetPolicyNumber.
+     * Builder for the TransactionSetPolicyNumber. Seeds the master-policy-number qualifier (REF01=38).
      */
     public static class Builder extends RefSegment.AbstractBuilder<TransactionSetPolicyNumber.Builder> {
 
@@ -46,7 +49,10 @@ public class TransactionSetPolicyNumber extends RefSegment {
         }
 
         /**
-         * Domain-specific setter
+         * Domain-specific setter for the master policy number (REF02).
+         *
+         * @param value the master policy number
+         * @return this builder instance
          */
         public Builder setMasterPolicyNumber(String value) {
             return setRef02(value);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop1000A/SponsorName.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop1000A/SponsorName.java
@@ -11,18 +11,36 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.segments.N1Segment;
 import lombok.experimental.Accessors;
 
+/**
+ * Loop 1000A plan sponsor name (N1*P5) in the X12 834 (005010X220A1).
+ * <p>
+ * Produces the N1 segment that identifies the plan sponsor (typically the employer)
+ * in the header portion of the 834, after the transaction set header/BGN and before
+ * the payer (Loop 1000B). Extends the generic {@link N1Segment}.
+ */
 public class SponsorName extends N1Segment {
+    /** Default N101 entity identifier code {@code "P5"} (Plan Sponsor). */
     public static final String DEFAULT_ENTITY_IDENTIFIER_CODE = "P5";
+    /** Default N103 identification code qualifier {@code "FI"} (Federal Taxpayer's Identification Number). */
     public static final String DEFAULT_IDENTIFICATION_CODE_QUALIFIER = "FI";
 
     private SponsorName(Builder builder) throws ValidationException {
         super(builder);
     }
 
+    /**
+     * Creates a new Builder instance for SponsorName.
+     *
+     * @return a new Builder instance
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Builder for SponsorName. Pre-seeds the plan-sponsor entity code (N101=P5) and
+     * identification qualifier (N103=FI) defaults.
+     */
     @Accessors(chain = true)
     public static class Builder extends AbstractBuilder<Builder> {
         public Builder() {
@@ -35,6 +53,12 @@ public class SponsorName extends N1Segment {
             return this;
         }
 
+        /**
+         * Builds a new SponsorName instance.
+         *
+         * @return A new SponsorName instance
+         * @throws ValidationException if validation fails
+         */
         @Override
         public SponsorName build() throws ValidationException {
             return new SponsorName(this);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop1000B/Payer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop1000B/Payer.java
@@ -11,18 +11,35 @@ import com.fastChickensHR.edi.x834.segments.N1Segment;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.experimental.Accessors;
 
+/**
+ * Loop 1000B payer name (N1*IN) in the X12 834 (005010X220A1).
+ * <p>
+ * Produces the N1 segment that identifies the payer (insurer) in the header portion
+ * of the 834, following the plan sponsor (Loop 1000A). Extends the generic {@link N1Segment}.
+ */
 public class Payer extends N1Segment {
+    /** Default N101 entity identifier code {@code "IN"} (Insurer). */
     public static final String DEFAULT_ENTITY_IDENTIFIER_CODE = "IN";
+    /** Default N103 identification code qualifier {@code "FI"} (Federal Taxpayer's Identification Number). */
     public static final String DEFAULT_IDENTIFICATION_CODE_QUALIFIER = "FI";
 
     private Payer(Builder builder) throws ValidationException {
         super(builder);
     }
 
+    /**
+     * Creates a new Builder instance for Payer.
+     *
+     * @return a new Builder instance
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Builder for Payer. Pre-seeds the insurer entity code (N101=IN) and
+     * identification qualifier (N103=FI) defaults.
+     */
     @Accessors(chain = true)
     public static class Builder extends AbstractBuilder<Builder> {
         public Builder() {
@@ -35,6 +52,12 @@ public class Payer extends N1Segment {
             return this;
         }
 
+        /**
+         * Builds a new Payer instance.
+         *
+         * @return A new Payer instance
+         * @throws ValidationException if validation fails
+         */
         @Override
         public Payer build() throws ValidationException {
             return new Payer(this);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop1000C/TPA.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop1000C/TPA.java
@@ -13,26 +13,51 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 
+/**
+ * Loop 1000C third-party administrator name (N1*TP) in the X12 834 (005010X220A1).
+ * <p>
+ * Produces the N1 segment that identifies the TPA/broker in the header portion of the
+ * 834, following the payer (Loop 1000B). Extends the generic {@link N1Segment}.
+ */
 @Getter
 public class TPA extends N1Segment {
+    /** Default N101 entity identifier code {@code "TP"} (Third Party Administrator). */
     public static final String DEFAULT_ENTITY_IDENTIFIER_CODE = "TP";
 
     private TPA(Builder builder) throws ValidationException {
         super(builder);
     }
 
+    /**
+     * Creates a new Builder instance for TPA.
+     *
+     * @return a new Builder instance
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Domain-specific accessor for the TPA name (N102).
+     *
+     * @return the TPA name
+     */
     public String getTPAName() {
         return getN102();
     }
 
+    /**
+     * Domain-specific accessor for the TPA identifier (N104).
+     *
+     * @return the TPA identification code
+     */
     public String getTPAIdentifier() {
         return getN104();
     }
 
+    /**
+     * Builder for TPA. Pre-seeds the third-party-administrator entity code (N101=TP) default.
+     */
     @Setter
     @Accessors(chain = true)
     public static class Builder extends AbstractBuilder<Builder> {
@@ -40,10 +65,22 @@ public class TPA extends N1Segment {
             this.setN101(DEFAULT_ENTITY_IDENTIFIER_CODE);
         }
 
+        /**
+         * Domain-specific setter for the TPA name (N102).
+         *
+         * @param value the TPA name
+         * @return this builder instance
+         */
         public Builder setTPAName(String value) {
             return setN102(value);
         }
 
+        /**
+         * Domain-specific setter for the TPA identifier (N104).
+         *
+         * @param value the TPA identification code
+         * @return this builder instance
+         */
         public Builder setTPAIdentifier(String value) {
             return setN104(value);
         }
@@ -53,6 +90,12 @@ public class TPA extends N1Segment {
             return this;
         }
 
+        /**
+         * Builds a new TPA instance.
+         *
+         * @return A new TPA instance
+         * @throws ValidationException if validation fails
+         */
         @Override
         public TPA build() throws ValidationException {
             return new TPA(this);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/INSSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/INSSegment.java
@@ -22,6 +22,7 @@ import lombok.experimental.Accessors;
  */
 @Getter
 public abstract class INSSegment extends Segment {
+    /** X12 segment identifier for the Loop 2000 member-level detail segment: {@code INS}. */
     public static final String SEGMENT_ID = "INS";
 
     private final MemberIndicator ins01;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/MemberIdentificationNumber.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/MemberIdentificationNumber.java
@@ -11,7 +11,14 @@ import com.fastChickensHR.edi.x834.segments.RefSegment;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.experimental.Accessors;
 
+/**
+ * Member identification number carried as a REF segment in Loop 2000 of the X12 834.
+ * <p>
+ * Renders {@code REF*DX*<identification number>}: REF01 is fixed to the qualifier
+ * {@code DX} and REF02 carries the member's identification number.
+ */
 public class MemberIdentificationNumber extends RefSegment {
+    /** REF01 qualifier {@code DX} — the fixed default reference qualifier for this member-identification REF segment. */
     public static final String DEFAULT_ENTITY_IDENTIFIER_CODE = "DX";
 
     private MemberIdentificationNumber(MemberIdentificationNumber.Builder builder) throws ValidationException {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/SubscriberNumber.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/SubscriberNumber.java
@@ -11,7 +11,14 @@ import com.fastChickensHR.edi.x834.segments.RefSegment;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.experimental.Accessors;
 
+/**
+ * Subscriber number carried as a REF segment in Loop 2000 of the X12 834.
+ * <p>
+ * Renders {@code REF*OF*<subscriber number>}: REF01 is fixed to the qualifier
+ * {@code OF} (Subscriber Number) and REF02 carries the subscriber's number.
+ */
 public class SubscriberNumber extends RefSegment {
+    /** REF01 qualifier {@code OF} — Subscriber Number; the fixed default for this REF segment. */
     public static final String DEFAULT_ENTITY_IDENTIFIER_CODE = "OF";
 
     private SubscriberNumber(SubscriberNumber.Builder builder) throws ValidationException {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberDemographics.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberDemographics.java
@@ -12,7 +12,10 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.Getter;
 
 /**
- * Represents Member Demographics information in X834 EDI format
+ * Member demographics as a DMG segment in Loop 2100A of the X12 834.
+ * <p>
+ * Carries the member's demographic detail — the date format qualifier (DMG01)
+ * and birth date (DMG02) are required; gender and related elements follow.
  */
 @Getter
 public class MemberDemographics extends DMGSegment {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberName.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberName.java
@@ -17,7 +17,9 @@ import lombok.experimental.Accessors;
  * name and identification details.
  */
 public class MemberName extends NM1Segment {
+    /** NM101 entity identifier {@code IL} — Insured or Subscriber; the fixed default for the member NM1. */
     public static final String ENTITY_IDENTIFIER_CODE = "IL";
+    /** NM102 entity type qualifier {@code 1} — Person; the fixed default for the member NM1. */
     public static final String PERSON_ENTITY_TYPE = "1";
 
     protected MemberName(Builder builder) throws ValidationException {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberResidenceStreetAddress.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberResidenceStreetAddress.java
@@ -12,8 +12,8 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.Getter;
 
 /**
- * Represents a Member Residence Street Address segment in X834 EDI format
- * Implements address line 1 (N301) and address line 2 (N302)
+ * Member residence street address as an N3 segment in Loop 2100A of the X12 834.
+ * Implements address line 1 (N301) and address line 2 (N302).
  */
 @Getter
 public class MemberResidenceStreetAddress extends N3Segment {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100C/MemberMailingAddress.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100C/MemberMailingAddress.java
@@ -12,17 +12,20 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.Getter;
 
 /**
- * Represents a Member Residence Street Address segment in X834 EDI format
- * Currently implementing only the 01 and 02 elements
+ * Member mailing address as an NM1 segment in Loop 2100C of the X12 834.
+ * <p>
+ * NM101 defaults to the entity identifier {@code 31} (Postal Mailing Address).
+ * Currently implements only the NM101 and NM102 elements.
  */
 @Getter
 public class MemberMailingAddress extends NM1Segment {
 
     /**
-     * Entity Identifier Code (NM101) values for Member Residence Street Address
+     * Entity Identifier Code (NM101) values for the member mailing address.
      */
     @Getter
     public enum EntityIdentifierCode {
+        /** NM101 {@code 31} — Postal Mailing Address; the default for this segment. */
         POSTAL_MAILING_ADDRESS("31", "Postal Mailing Address");
 
         private final String code;
@@ -40,7 +43,7 @@ public class MemberMailingAddress extends NM1Segment {
     }
 
     /**
-     * Builder for MemberResidenceStreetAddress
+     * Builder for MemberMailingAddress.
      */
     public static class Builder extends AbstractBuilder<Builder> {
         public Builder() {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100C/MemberMailingCityStateZipCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100C/MemberMailingCityStateZipCode.java
@@ -31,7 +31,7 @@ public class MemberMailingCityStateZipCode extends N4Segment {
     }
 
     /**
-     * Builder for MemberResidenceCityStateZipCode
+     * Builder for MemberMailingCityStateZipCode.
      */
     public static class Builder extends AbstractBuilder<Builder> {
         @Override

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/AMTSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/AMTSegment.java
@@ -26,8 +26,11 @@ import lombok.Getter;
 public abstract class AMTSegment extends Segment {
     public static final String SEGMENT_ID = "AMT";
 
+    /** AMT01 — amount qualifier code (required). */
     protected final String amt01;
+    /** AMT02 — monetary amount (required). */
     protected final String amt02;
+    /** AMT03 — credit/debit flag code; when present must be "C" or "D" (optional). */
     protected final String amt03;
 
     protected AMTSegment(AbstractBuilder<?> builder) throws ValidationException {
@@ -91,33 +94,46 @@ public abstract class AMTSegment extends Segment {
         protected String amt02;
         protected String amt03;
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the AMT segment.
+         *
+         * @return a new {@link AMTSegment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract AMTSegment build() throws ValidationException;
 
+        /** Sets AMT01 (amount qualifier code). */
         public T setAmountQualifierCode(String value) {
             this.amt01 = value;
             return self();
         }
 
+        /** Sets AMT02 (monetary amount). */
         public T setMonetaryAmount(String value) {
             this.amt02 = value;
             return self();
         }
 
+        /** Sets AMT03 (credit/debit flag code); when present must be "C" or "D". */
         public T setCreditDebitFlagCode(String value) {
             this.amt03 = value;
             return self();
         }
 
+        /** Element alias for {@link #setAmountQualifierCode(String)}. */
         public T setAmt01(String value) {
             return setAmountQualifierCode(value);
         }
 
+        /** Element alias for {@link #setMonetaryAmount(String)}. */
         public T setAmt02(String value) {
             return setMonetaryAmount(value);
         }
 
+        /** Element alias for {@link #setCreditDebitFlagCode(String)}. */
         public T setAmt03(String value) {
             return setCreditDebitFlagCode(value);
         }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/DMGSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/DMGSegment.java
@@ -13,8 +13,26 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 /**
- * Represents the DMG segment in X12 834 format.
- * This segment is used for demographic information such as birth date, gender, etc.
+ * Represents the DMG (Demographic Information) segment in the X12 834
+ * (005010X220A1) Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * This segment carries demographic information about a member — birth date,
+ * gender, marital status, and related codes.
+ * <p>
+ * Element/position map (meanings derived from the accessor names on this class):
+ * <ul>
+ *     <li>DMG01 = date/time period format qualifier</li>
+ *     <li>DMG02 = birth date (formatted per DMG01)</li>
+ *     <li>DMG03 = gender code (commonly M = Male, F = Female)</li>
+ *     <li>DMG04 = marital status code</li>
+ *     <li>DMG05 = race or ethnicity code</li>
+ *     <li>DMG06 = citizenship status code</li>
+ *     <li>DMG07 = country code</li>
+ *     <li>DMG08 = basis of verification code</li>
+ *     <li>DMG09 = quantity</li>
+ *     <li>DMG10 = code list qualifier code</li>
+ *     <li>DMG11 = industry code</li>
+ * </ul>
  */
 @Getter
 public abstract class DMGSegment extends Segment {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/DTPSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/DTPSegment.java
@@ -15,12 +15,29 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+/**
+ * Represents the DTP (Date or Time or Period) segment in the X12 834
+ * (005010X220A1) Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * This segment expresses a date, time, or period together with a qualifier that
+ * states what the date means and a format code that states how it is encoded.
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>DTP01 = date/time qualifier — what the date represents (required)</li>
+ *     <li>DTP02 = date/time format qualifier — how DTP03 is formatted (required)</li>
+ *     <li>DTP03 = date/time period value, max 35 characters (required)</li>
+ * </ul>
+ */
 @Getter
 public abstract class DTPSegment extends Segment {
     public static final String SEGMENT_ID = "DTP";
 
+    /** DTP01 — date/time qualifier stating what the date represents (required). */
     protected final DateTimeQualifier dtp01;
+    /** DTP02 — date/time format qualifier stating how DTP03 is encoded (required). */
     protected final DateFormat dtp02;
+    /** DTP03 — the date/time period value, max 35 characters (required). */
     protected final String dtp03;
 
     protected DTPSegment(AbstractBuilder<?> builder) throws ValidationException {
@@ -56,18 +73,26 @@ public abstract class DTPSegment extends Segment {
         return new String[]{dtp01.getCode(), dtp02.getFormat(), dtp03};
     }
 
+    /** @return DTP01 — the date/time qualifier. */
     public DateTimeQualifier getDateTimeQualifier() {
         return getDtp01();
     }
 
+    /** @return DTP02 — the date/time format qualifier. */
     public DateFormat getDateTimeFormat() {
         return getDtp02();
     }
 
+    /** @return DTP03 — the date/time period value. */
     public String getDateTimePeriod() {
         return getDtp03();
     }
 
+    /**
+     * Abstract builder for DTP segments.
+     *
+     * @param <T> the concrete builder type for method chaining
+     */
     public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
         protected DateTimeQualifier dtp01;
         protected DateFormat dtp02;
@@ -77,51 +102,68 @@ public abstract class DTPSegment extends Segment {
             // No default initialization
         }
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the DTP segment.
+         *
+         * @return a new {@link DTPSegment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract DTPSegment build() throws ValidationException;
 
+        /** Sets DTP01 (date/time qualifier) from its string code. */
         public T setDateTimeQualifier(String value) {
             this.dtp01 = DateTimeQualifier.fromString(value);
             return self();
         }
 
+        /** Sets DTP01 (date/time qualifier). */
         public T setDateTimeQualifier(DateTimeQualifier value) {
             this.dtp01 = value;
             return self();
         }
 
+        /** Sets DTP02 (date/time format qualifier). */
         public T setDateTimeFormat(DateFormat value) {
             this.dtp02 = value;
             return self();
         }
 
+        /** Sets DTP03 (date/time period), formatting the value with the previously set DTP02 format. */
         public T setDateTimePeriod(LocalDateTime value) {
             this.dtp03 = DateFormatter.formatDate(this.dtp02, value);
             return self();
         }
 
+        /** Sets DTP03 (date/time period), formatting the value with the supplied format. */
         public T setDateTimePeriod(LocalDateTime value, DateFormat format) {
             this.dtp03 = DateFormatter.formatDate(format, value);
             return self();
         }
 
+        /** Element alias for {@link #setDateTimeQualifier(String)}. */
         public T setDtp01(String value) {
             return setDateTimeQualifier(value);
         }
 
+        /** Element alias for {@link #setDateTimeQualifier(DateTimeQualifier)}. */
         public T setDtp01(DateTimeQualifier value) {
             return setDateTimeQualifier(value);
         }
 
+        /** Element alias for {@link #setDateTimeFormat(DateFormat)}. */
         public T setDtp02(DateFormat value) {
             return setDateTimeFormat(value);
         }
 
+        /** Element alias for {@link #setDateTimePeriod(LocalDateTime)}. */
         public T setDtp03(LocalDateTime value) {
             return setDateTimePeriod(value);
         }
 
+        /** Element alias for {@link #setDateTimePeriod(LocalDateTime, DateFormat)}. */
         public T setDtp03(LocalDateTime value, DateFormat format) {
             return setDateTimePeriod(value, format);
         }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/GESegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/GESegment.java
@@ -13,14 +13,24 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 /**
- * Represents the GE (Functional Group Trailer) segment in the EDI 834 format.
- * This segment defines the end of a functional group and provides the included transaction set count
- * and the group control number.
+ * Represents the GE (Functional Group Trailer) segment in the X12 834
+ * (005010X220A1) format.
+ * <p>
+ * This segment marks the end of a functional group opened by a {@link GSSegment}
+ * and reconciles it via the transaction-set count and matching group control number.
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>GE01 = number of transaction sets included in the group</li>
+ *     <li>GE02 = group control number (must match the GS06 of the paired GS segment)</li>
+ * </ul>
  */
 @Getter
 abstract public class GESegment extends Segment {
     public static final String SEGMENT_ID = "GE";
+    /** GE01 — number of transaction sets included in the functional group. */
     protected final String ge01;
+    /** GE02 — group control number, matching the paired GS06. */
     protected final String ge02;
 
     protected GESegment(GESegment.AbstractBuilder<?> builder) throws ValidationException {
@@ -38,38 +48,56 @@ abstract public class GESegment extends Segment {
         return new String[]{this.ge01, this.ge02};
     }
 
+    /** @return GE01 — number of transaction sets included in the group. */
     public String getNumberOfTransactionSets() {
         return getGe01();
     }
 
+    /** @return GE02 — group control number. */
     public String getGroupControlNumber() {
         return getGe02();
     }
 
+    /**
+     * Abstract builder for GE segments.
+     *
+     * @param <T> the concrete builder type for method chaining
+     */
     @Setter
     @Accessors(chain = true)
     public abstract static class AbstractBuilder<T extends GESegment.AbstractBuilder<T>> {
         private String ge01;
         private String ge02;
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the GE segment.
+         *
+         * @return a new {@link GESegment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract GESegment build() throws ValidationException;
 
+        /** Sets GE01 (number of transaction sets). */
         public T setGe01(String value) {
             this.ge01 = value;
             return self();
         }
 
+        /** Element alias for {@link #setGe01(String)}. */
         public T setNumberOfTransactionSets(String value) {
             return setGe01(value);
         }
 
+        /** Sets GE02 (group control number). */
         public T setGe02(String value) {
             this.ge02 = value;
             return self();
         }
 
+        /** Element alias for {@link #setGe02(String)}. */
         public T setGroupControlNumber(String value) {
             return setGe02(value);
         }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/GSSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/GSSegment.java
@@ -20,20 +20,39 @@ import lombok.experimental.Accessors;
 import java.time.LocalDateTime;
 
 /**
- * Represents the GS (Functional Group Header) segment in EDI formats.
- * This segment initiates and identifies a functional group within an interchange.
+ * Represents the GS (Functional Group Header) segment in the X12 834
+ * (005010X220A1) format.
+ * <p>
+ * This segment opens a functional group inside an interchange and identifies the
+ * business function, trading partners, timestamp, control number, and standards
+ * version. It is closed by a matching {@link GESegment}.
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>GS01 = functional identifier code (the group's business function)</li>
+ *     <li>GS02 = application sender's code (2–15 characters)</li>
+ *     <li>GS03 = application receiver's code (2–15 characters)</li>
+ *     <li>GS04 = creation date (YYYYMMDD)</li>
+ *     <li>GS05 = creation time (HHMM)</li>
+ *     <li>GS06 = group control number (max 9 characters; matched by GE02)</li>
+ *     <li>GS07 = responsible agency code</li>
+ *     <li>GS08 = version / release / industry identifier code</li>
+ * </ul>
  */
 @Getter
 abstract public class GSSegment extends Segment {
     public static final String SEGMENT_ID = "GS";
 
+    /** GS01 — functional identifier code (the group's business function). */
     protected final FunctionalIdentifierCode gs01;
-    protected final String gs02; // Application Sender's Code 
+    protected final String gs02; // Application Sender's Code
     protected final String gs03; // Application Receiver's Code
     protected final String gs04; // Date (YYYYMMDD)
     protected final String gs05; // Time (HHMM)
     protected final String gs06; // Group Control Number
+    /** GS07 — responsible agency code. */
     protected final ResponsibleAgencyCode gs07;
+    /** GS08 — version / release / industry identifier code. */
     protected final VersionCode gs08;
 
     protected GSSegment(AbstractBuilder<?> builder) throws ValidationException {
@@ -97,34 +116,42 @@ abstract public class GSSegment extends Segment {
         };
     }
 
+    /** @return GS01 — functional identifier code. */
     public FunctionalIdentifierCode getFunctionalIdentifierCode() {
         return gs01;
     }
 
+    /** @return GS02 — application sender's code. */
     public String getApplicationSenderCode() {
         return gs02;
     }
 
+    /** @return GS03 — application receiver's code. */
     public String getApplicationReceiverCode() {
         return gs03;
     }
 
+    /** @return GS04 — group creation date (YYYYMMDD). */
     public String getTransactionSetCreationDate() {
         return gs04;
     }
 
+    /** @return GS05 — group creation time (HHMM). */
     public String getTransactionSetCreationTime() {
         return gs05;
     }
 
+    /** @return GS06 — group control number. */
     public String getGroupControlNumber() {
         return gs06;
     }
 
+    /** @return GS07 — responsible agency code. */
     public ResponsibleAgencyCode getResponsibleAgencyCode() {
         return gs07;
     }
 
+    /** @return GS08 — version / release / industry identifier code. */
     public VersionCode getVersionReleaseIndustryCode() {
         return gs08;
     }
@@ -148,80 +175,103 @@ abstract public class GSSegment extends Segment {
         protected AbstractBuilder() {
         }
 
+        /** Sets GS01 (functional identifier code) from its string code. */
         public T setGs01(String value) {
             this.gs01 = FunctionalIdentifierCode.fromString(value);
             return self();
         }
 
+        /** Sets GS02 (application sender's code). */
         public T setGs02(String gs02) {
             this.gs02 = gs02;
             return self();
         }
 
+        /** Sets GS03 (application receiver's code). */
         public T setGs03(String gs03) {
             this.gs03 = gs03;
             return self();
         }
 
+        /** Sets GS04 (creation date), formatting the value with the supplied date format. */
         public T setGs04(LocalDateTime value, DateFormat dateFormat) {
             this.gs04 = DateFormatter.formatDate(dateFormat, value);
             return self();
         }
 
+        /** Sets GS05 (creation time), formatting the value with the supplied time format. */
         public T setGs05(LocalDateTime value, TimeFormat timeFormat) {
             this.gs05 = DateFormatter.formatTime(timeFormat, value);
             return self();
         }
 
+        /** Sets GS06 (group control number). */
         public T setGs06(String gs06) {
             this.gs06 = gs06;
             return self();
         }
 
+        /** Sets GS07 (responsible agency code) from its string code. */
         public T setGs07(String value) {
             this.gs07 = ResponsibleAgencyCode.fromString(value);
             return self();
         }
 
+        /** Sets GS08 (version / release / industry identifier code) from its string code. */
         public T setGs08(String value) {
             this.gs08 = VersionCode.fromString(value);
             return self();
         }
 
+        /** Domain alias for {@link #setGs01(String)}. */
         public T setFunctionalIdentifierCode(String code) {
             return setGs01(code);
         }
 
+        /** Domain alias for {@link #setGs02(String)}. */
         public T setApplicationSenderCode(String code) {
             return setGs02(code);
         }
 
+        /** Domain alias for {@link #setGs03(String)}. */
         public T setApplicationReceiverCode(String code) {
             return setGs03(code);
         }
 
+        /** Domain alias for {@link #setGs04(LocalDateTime, DateFormat)}. */
         public T setTransactionSetCreationDate(LocalDateTime date, DateFormat dateFormat) {
             return setGs04(date, dateFormat);
         }
 
+        /** Domain alias for {@link #setGs05(LocalDateTime, TimeFormat)}. */
         public T setTransactionSetCreationTime(LocalDateTime value, TimeFormat timeFormat) {
             return setGs05(value, timeFormat);
         }
 
+        /** Domain alias for {@link #setGs06(String)}. */
         public T setGroupControlNumber(String number) {
             return setGs06(number);
         }
 
+        /** Domain alias for {@link #setGs07(String)}. */
         public T setResponsibleAgencyCode(String code) {
             return setGs07(code);
         }
 
+        /** Domain alias for {@link #setGs08(String)}. */
         public T setVersionReleaseIndustryCode(String code) {
             return setGs08(code);
         }
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the GS segment.
+         *
+         * @return a new {@link GSSegment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract GSSegment build() throws ValidationException;
     }
 }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/HDSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/HDSegment.java
@@ -13,8 +13,28 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 /**
- * Represents the HD segment in X12 834 format.
- * This segment is used for health coverage information.
+ * Represents the HD (Health Coverage) segment in the X12 834
+ * (005010X220A1) Benefit Enrollment and Maintenance transaction (Loop 2300).
+ * <p>
+ * This segment describes a member's health coverage — the maintenance action being
+ * applied, the insurance line, and related coverage attributes.
+ * <p>
+ * Element/position map (meanings derived from the accessor names on this class):
+ * <ul>
+ *     <li>HD01 = maintenance type code (required)</li>
+ *     <li>HD02 = maintenance reason code</li>
+ *     <li>HD03 = insurance line code (required)</li>
+ *     <li>HD04 = plan coverage description</li>
+ *     <li>HD05 = coverage level code</li>
+ *     <li>HD06 = medicare plan code</li>
+ *     <li>HD07 = medicare eligibility reason code</li>
+ *     <li>HD08 = COBRA qualifying event code</li>
+ *     <li>HD09 = employment status code</li>
+ *     <li>HD10 = student status code</li>
+ *     <li>HD11 = handicap indicator (Y/N)</li>
+ *     <li>HD12 = date qualifier</li>
+ *     <li>HD13 = birth date</li>
+ * </ul>
  */
 @Getter
 public abstract class HDSegment extends Segment {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/IDCSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/IDCSegment.java
@@ -27,9 +27,13 @@ import lombok.Getter;
 public abstract class IDCSegment extends Segment {
     public static final String SEGMENT_ID = "IDC";
 
+    /** IDC01 — plan coverage description (required, max 50 characters). */
     protected final String idc01;
+    /** IDC02 — identification card type code (required). */
     protected final String idc02;
+    /** IDC03 — identification card action code (required). */
     protected final String idc03;
+    /** IDC04 — identification card count; when present must be a non-negative number (optional). */
     protected final String idc04;
 
     protected IDCSegment(AbstractBuilder<?> builder) throws ValidationException {
@@ -115,42 +119,57 @@ public abstract class IDCSegment extends Segment {
         protected String idc03;
         protected String idc04;
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the IDC segment.
+         *
+         * @return a new {@link IDCSegment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract IDCSegment build() throws ValidationException;
 
+        /** Sets IDC01 (plan coverage description). */
         public T setPlanCoverageDescription(String value) {
             this.idc01 = value;
             return self();
         }
 
+        /** Sets IDC02 (identification card type code). */
         public T setIdentificationCardTypeCode(String value) {
             this.idc02 = value;
             return self();
         }
 
+        /** Sets IDC03 (identification card action code). */
         public T setIdentificationCardActionCode(String value) {
             this.idc03 = value;
             return self();
         }
 
+        /** Sets IDC04 (identification card count). */
         public T setIdentificationCardCount(String value) {
             this.idc04 = value;
             return self();
         }
 
+        /** Element alias for {@link #setPlanCoverageDescription(String)}. */
         public T setIdc01(String value) {
             return setPlanCoverageDescription(value);
         }
 
+        /** Element alias for {@link #setIdentificationCardTypeCode(String)}. */
         public T setIdc02(String value) {
             return setIdentificationCardTypeCode(value);
         }
 
+        /** Element alias for {@link #setIdentificationCardActionCode(String)}. */
         public T setIdc03(String value) {
             return setIdentificationCardActionCode(value);
         }
 
+        /** Element alias for {@link #setIdentificationCardCount(String)}. */
         public T setIdc04(String value) {
             return setIdentificationCardCount(value);
         }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/IEASegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/IEASegment.java
@@ -13,14 +13,25 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 /**
- * Represents the IEA (Interchange Control Trailer) segment in the EDI 834 format.
- * This segment defines the end of an interchange envelope and provides the number of included
- * functional groups and the interchange control number.
+ * Represents the IEA (Interchange Control Trailer) segment in the X12 834
+ * (005010X220A1) format.
+ * <p>
+ * This segment closes the interchange envelope opened by an {@link ISASegment} and
+ * reconciles it via the count of functional groups and the matching interchange
+ * control number.
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>IEA01 = number of included functional groups (required)</li>
+ *     <li>IEA02 = interchange control number (required; matches the ISA13 of the paired ISA)</li>
+ * </ul>
  */
 @Getter
 abstract public class IEASegment extends Segment {
     public static final String SEGMENT_ID = "IEA";
+    /** IEA01 — number of functional groups included in the interchange. */
     protected final String iea01; // Number of Included Functional Groups
+    /** IEA02 — interchange control number, matching the paired ISA13. */
     protected final String iea02; // Interchange Control Number
 
     protected IEASegment(IEASegment.AbstractBuilder<?> builder) throws ValidationException {
@@ -48,38 +59,56 @@ abstract public class IEASegment extends Segment {
         return new String[]{this.iea01, this.iea02};
     }
 
+    /** @return IEA01 — number of included functional groups. */
     public String getNumberOfIncludedGroups() {
         return getIea01();
     }
 
+    /** @return IEA02 — interchange control number. */
     public String getInterchangeControlNumber() {
         return getIea02();
     }
 
+    /**
+     * Abstract builder for IEA segments.
+     *
+     * @param <T> the concrete builder type for method chaining
+     */
     @Setter
     @Accessors(chain = true)
     public abstract static class AbstractBuilder<T extends IEASegment.AbstractBuilder<T>> {
         private String iea01;
         private String iea02;
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the IEA segment.
+         *
+         * @return a new {@link IEASegment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract IEASegment build() throws ValidationException;
 
+        /** Sets IEA01 (number of included functional groups). */
         public T setIea01(String value) {
             this.iea01 = value;
             return self();
         }
 
+        /** Element alias for {@link #setIea01(String)}. */
         public T setNumberOfIncludedGroups(String value) {
             return setIea01(value);
         }
 
+        /** Sets IEA02 (interchange control number). */
         public T setIea02(String value) {
             this.iea02 = value;
             return self();
         }
 
+        /** Element alias for {@link #setIea02(String)}. */
         public T setInterchangeControlNumber(String value) {
             return setIea02(value);
         }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/ISASegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/ISASegment.java
@@ -14,27 +14,61 @@ import lombok.Getter;
 import lombok.experimental.Accessors;
 
 /**
- * Represents the ISA (Interchange Control Header) segment in EDI formats.
- * This segment initiates and identifies an interchange of electronic data.
+ * Represents the ISA (Interchange Control Header) segment in the X12 834
+ * (005010X220A1) format.
+ * <p>
+ * This segment opens the interchange envelope and identifies the interchange of
+ * electronic data. It is a fixed-width segment: several elements have exact required
+ * lengths (ISA02 and ISA04 are 10 characters, ISA06 and ISA08 are 15 characters,
+ * ISA16 is 1 character). It is closed by a matching {@link IEASegment}.
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>ISA01 = authorization information qualifier</li>
+ *     <li>ISA02 = authorization information (exactly 10 characters)</li>
+ *     <li>ISA03 = security information qualifier</li>
+ *     <li>ISA04 = security information (exactly 10 characters)</li>
+ *     <li>ISA05 = interchange sender ID qualifier</li>
+ *     <li>ISA06 = interchange sender ID (exactly 15 characters; right-padded by the builder)</li>
+ *     <li>ISA07 = interchange receiver ID qualifier</li>
+ *     <li>ISA08 = interchange receiver ID (right-padded to 15 characters by the builder)</li>
+ *     <li>ISA09 = interchange date (YYMMDD)</li>
+ *     <li>ISA10 = interchange time (HHMM)</li>
+ *     <li>ISA11 = repetition / interchange control standards separator</li>
+ *     <li>ISA12 = interchange control version number</li>
+ *     <li>ISA13 = interchange control number (matched by IEA02)</li>
+ *     <li>ISA14 = acknowledgment requested flag</li>
+ *     <li>ISA15 = interchange usage indicator (e.g. test vs production)</li>
+ *     <li>ISA16 = component element separator (exactly 1 character)</li>
+ * </ul>
  */
 @Getter
 abstract public class ISASegment extends Segment {
     public static final String SEGMENT_ID = "ISA";
 
+    /** ISA01 — authorization information qualifier. */
     protected final AuthorizationInformationQualifier isa01;
+    /** ISA02 — authorization information (exactly 10 characters). */
     protected final String isa02;
+    /** ISA03 — security information qualifier. */
     protected final SecurityInformationQualifier isa03;
+    /** ISA04 — security information (exactly 10 characters). */
     protected final String isa04;
+    /** ISA05 — interchange sender ID qualifier. */
     protected final InterchangeIdQualifier isa05;
     protected final String isa06; // Interchange Sender ID
+    /** ISA07 — interchange receiver ID qualifier. */
     protected final InterchangeIdQualifier isa07;
     protected final String isa08; // Interchange Receiver ID
     protected final String isa09; // Interchange Date (YYMMDD)
     protected final String isa10; // Interchange Time (HHMM)
     protected final String isa11; // Repetition Separator
+    /** ISA12 — interchange control version number. */
     protected final InterchangeControlVersionNumber isa12;
     protected final String isa13; // Interchange Control Number
+    /** ISA14 — acknowledgment requested flag. */
     protected final AcknowledgmentRequested isa14;
+    /** ISA15 — interchange usage indicator (e.g. test vs production). */
     protected final InterchangeUsageIndicator isa15;
     protected final String isa16; // Component Element Separator
 
@@ -135,66 +169,82 @@ abstract public class ISASegment extends Segment {
         };
     }
 
+    /** @return ISA01 — authorization information qualifier. */
     public AuthorizationInformationQualifier getAuthorizationInformationQualifier() {
         return isa01;
     }
 
+    /** @return ISA02 — authorization information. */
     public String getAuthorizationInformation() {
         return isa02;
     }
 
+    /** @return ISA03 — security information qualifier. */
     public SecurityInformationQualifier getSecurityInformationQualifier() {
         return isa03;
     }
 
+    /** @return ISA04 — security information. */
     public String getSecurityInformation() {
         return isa04;
     }
 
+    /** @return ISA05 — interchange sender ID qualifier. */
     public InterchangeIdQualifier getInterchangeSenderQualifier() {
         return isa05;
     }
 
+    /** @return ISA06 — interchange sender ID. */
     public String getInterchangeSenderID() {
         return isa06;
     }
 
+    /** @return ISA07 — interchange receiver ID qualifier. */
     public InterchangeIdQualifier getInterchangeReceiverQualifier() {
         return isa07;
     }
 
+    /** @return ISA08 — interchange receiver ID. */
     public String getInterchangeReceiverID() {
         return isa08;
     }
 
+    /** @return ISA09 — interchange date (YYMMDD). */
     public String getInterchangeDate() {
         return isa09;
     }
 
+    /** @return ISA10 — interchange time (HHMM). */
     public String getInterchangeTime() {
         return isa10;
     }
 
+    /** @return ISA11 — repetition / interchange control standards separator. */
     public String getInterchangeControlStandardsIdentifier() {
         return isa11;
     }
 
+    /** @return ISA12 — interchange control version number. */
     public InterchangeControlVersionNumber getInterchangeControlVersionNumber() {
         return isa12;
     }
 
+    /** @return ISA13 — interchange control number. */
     public String getInterchangeControlNumber() {
         return isa13;
     }
 
+    /** @return ISA14 — acknowledgment requested flag. */
     public AcknowledgmentRequested getAcknowledgmentRequested() {
         return isa14;
     }
 
+    /** @return ISA15 — interchange usage indicator. */
     public InterchangeUsageIndicator getUsageIndicator() {
         return isa15;
     }
 
+    /** @return ISA16 — component element separator. */
     public String getComponentElementSeparator() {
         return isa16;
     }
@@ -226,146 +276,178 @@ abstract public class ISASegment extends Segment {
         public AbstractBuilder() {
         }
 
+        /** Sets ISA01 (authorization information qualifier) from its string code. */
         public T setIsa01(String value) {
             this.isa01 = AuthorizationInformationQualifier.fromString(value);
             return self();
         }
 
+        /** Sets ISA02 (authorization information; must be exactly 10 characters). */
         public T setIsa02(String isa02) {
             this.isa02 = isa02;
             return self();
         }
 
+        /** Sets ISA03 (security information qualifier) from its string code. */
         public T setIsa03(String value) {
             this.isa03 = SecurityInformationQualifier.fromString(value);
             return self();
         }
 
+        /** Sets ISA04 (security information; must be exactly 10 characters). */
         public T setIsa04(String isa04) {
             this.isa04 = isa04;
             return self();
         }
 
+        /** Sets ISA05 (interchange sender ID qualifier) from its string code. */
         public T setIsa05(String value) {
             this.isa05 = InterchangeIdQualifier.fromString(value);
             return self();
         }
 
+        /** Sets ISA06 (interchange sender ID), right-padding it to the fixed 15-character width. */
         public T setIsa06(String isa06) {
             this.isa06 = TextUtils.padRight(isa06, 15);
             return self();
         }
 
+        /** Sets ISA07 (interchange receiver ID qualifier) from its string code. */
         public T setIsa07(String value) {
             this.isa07 = InterchangeIdQualifier.fromString(value);
             return self();
         }
 
+        /** Sets ISA08 (interchange receiver ID), right-padding it to the fixed 15-character width. */
         public T setIsa08(String isa08) {
             this.isa08 = TextUtils.padRight(isa08, 15);
             return self();
         }
 
+        /** Sets ISA09 (interchange date, YYMMDD). */
         public T setIsa09(String isa09) {
             this.isa09 = isa09;
             return self();
         }
 
+        /** Sets ISA10 (interchange time, HHMM). */
         public T setIsa10(String isa10) {
             this.isa10 = isa10;
             return self();
         }
 
+        /** Sets ISA11 (repetition / interchange control standards separator). */
         public T setIsa11(String isa11) {
             this.isa11 = isa11;
             return self();
         }
 
+        /** Sets ISA12 (interchange control version number) from its string code. */
         public T setIsa12(String value) {
             this.isa12 = InterchangeControlVersionNumber.fromString(value);
             return self();
         }
 
+        /** Sets ISA13 (interchange control number). */
         public T setIsa13(String isa13) {
             this.isa13 = isa13;
             return self();
         }
 
+        /** Sets ISA14 (acknowledgment requested flag) from its string code. */
         public T setIsa14(String value) {
             this.isa14 = AcknowledgmentRequested.fromString(value);
             return self();
         }
 
+        /** Sets ISA15 (interchange usage indicator) from its string code. */
         public T setIsa15(String value) {
             this.isa15 = InterchangeUsageIndicator.fromString(value);
             return self();
         }
 
+        /** Sets ISA16 (component element separator; must be exactly 1 character). */
         public T setIsa16(String isa16) {
             this.isa16 = isa16;
             return self();
         }
 
+        /** Domain alias for {@link #setIsa01(String)}. */
         public T setAuthorizationInformationQualifier(String value) {
             return setIsa01(value);
         }
 
+        /** Domain alias for {@link #setIsa02(String)}. */
         public T setAuthorizationInformation(String info) {
             return setIsa02(info);
         }
 
+        /** Domain alias for {@link #setIsa03(String)}. */
         public T setSecurityInformationQualifier(String qualifier) {
             return setIsa03(qualifier);
         }
 
+        /** Domain alias for {@link #setIsa04(String)}. */
         public T setSecurityInformation(String info) {
             return setIsa04(info);
         }
 
+        /** Domain alias for {@link #setIsa05(String)}. */
         public T setInterchangeSenderQualifier(String qualifier) {
             return setIsa05(qualifier);
         }
 
+        /** Domain alias for {@link #setIsa06(String)} (value is right-padded to 15 characters). */
         public T setInterchangeSenderID(String id) {
             return setIsa06(id);
         }
 
+        /** Domain alias for {@link #setIsa07(String)}. */
         public T setInterchangeReceiverQualifier(String qualifier) {
             return setIsa07(qualifier);
         }
 
+        /** Domain alias for {@link #setIsa08(String)} (value is right-padded to 15 characters). */
         public T setInterchangeReceiverID(String id) {
             return setIsa08(id);
         }
 
+        /** Domain alias for {@link #setIsa09(String)}. */
         public T setInterchangeDate(String date) {
             return setIsa09(date);
         }
 
+        /** Domain alias for {@link #setIsa10(String)}. */
         public T setInterchangeTime(String time) {
             return setIsa10(time);
         }
 
+        /** Domain alias for {@link #setIsa11(String)}. */
         public T setInterchangeControlStandardsIdentifier(String identifier) {
             return setIsa11(identifier);
         }
 
+        /** Domain alias for {@link #setIsa12(String)}. */
         public T setInterchangeControlVersionNumber(String version) {
             return setIsa12(version);
         }
 
+        /** Domain alias for {@link #setIsa13(String)}. */
         public T setInterchangeControlNumber(String number) {
             return setIsa13(number);
         }
 
+        /** Domain alias for {@link #setIsa14(String)}. */
         public T setAcknowledgmentRequested(String ack) {
             return setIsa14(ack);
         }
 
+        /** Domain alias for {@link #setIsa15(String)}. */
         public T setUsageIndicator(String indicator) {
             return setIsa15(indicator);
         }
 
+        /** Domain alias for {@link #setIsa16(String)}. */
         public T setComponentElementSeparator(String separator) {
             return setIsa16(separator);
         }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/N1Segment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/N1Segment.java
@@ -12,13 +12,34 @@ import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.Getter;
 
+/**
+ * Represents the N1 (Party Identification) segment in the X12 834
+ * (005010X220A1) Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * This segment names a party in a loop — in the 834 it is used for the plan
+ * sponsor / payer — via an entity identifier, a free-form name, and an optional
+ * coded identifier.
+ * <p>
+ * Element/position map (meanings derived from the accessor names on this class):
+ * <ul>
+ *     <li>N101 = entity identifier code (the party's role)</li>
+ *     <li>N102 = plan sponsor name (free-form, max 60 characters)</li>
+ *     <li>N103 = identification code qualifier (what N104 is)</li>
+ *     <li>N104 = sponsor identifier (the coded identification value)</li>
+ * </ul>
+ * At least one of N102 or N103 must be supplied.
+ */
 @Getter
 public abstract class N1Segment extends Segment {
     public static final String SEGMENT_ID = "N1";
 
+    /** N101 — entity identifier code (the party's role). */
     protected final EntityIdentifierCode n101;
+    /** N102 — plan sponsor name (free-form, max 60 characters). */
     protected final String n102;
+    /** N103 — identification code qualifier describing N104. */
     protected final IdentificationCodeQualifier n103;
+    /** N104 — sponsor identifier (the coded identification value). */
     protected final String n104;
 
     protected N1Segment(AbstractBuilder<?> builder) throws ValidationException {
@@ -52,64 +73,88 @@ public abstract class N1Segment extends Segment {
         return new String[]{n101.getCode(), n102, n103.getCode(), n104};
     }
 
+    /** @return N101 — entity identifier code. */
     public EntityIdentifierCode getEntityIdentifierCode() {
         return getN101();
     }
 
+    /** @return N102 — plan sponsor name. */
     public String getPlanSponsorName() {
         return getN102();
     }
 
+    /** @return N103 — identification code qualifier. */
     public IdentificationCodeQualifier getIdentificationCodeQualifier() {
         return getN103();
     }
 
+    /** @return N104 — sponsor identifier. */
     public String getSponsorIdentifier() {
         return getN104();
     }
 
+    /**
+     * Abstract builder for N1 segments.
+     *
+     * @param <T> the concrete builder type for method chaining
+     */
     public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
         protected EntityIdentifierCode n101;
         protected String n102;
         protected IdentificationCodeQualifier n103;
         protected String n104;
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the N1 segment.
+         *
+         * @return a new {@link N1Segment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract N1Segment build() throws ValidationException;
 
+        /** Sets N101 (entity identifier code) from its string code. */
         public T setEntityIdentifierCode(String value) {
             this.n101 = EntityIdentifierCode.fromString(value);
             return self();
         }
 
+        /** Sets N102 (plan sponsor name). */
         public T setPlanSponsorName(String value) {
             this.n102 = value;
             return self();
         }
 
+        /** Sets N103 (identification code qualifier) from its string code. */
         public T setIdentificationCodeQualifier(String value) {
             this.n103 = IdentificationCodeQualifier.fromString(value);
             return self();
         }
 
+        /** Sets N104 (sponsor identifier). */
         public T setSponsorIdentifier(String value) {
             this.n104 = value;
             return self();
         }
 
+        /** Element alias for {@link #setEntityIdentifierCode(String)}. */
         public T setN101(String value) {
             return setEntityIdentifierCode(value);
         }
 
+        /** Element alias for {@link #setPlanSponsorName(String)}. */
         public T setN102(String value) {
             return setPlanSponsorName(value);
         }
 
+        /** Element alias for {@link #setIdentificationCodeQualifier(String)}. */
         public T setN103(String value) {
             return setIdentificationCodeQualifier(value);
         }
 
+        /** Element alias for {@link #setSponsorIdentifier(String)}. */
         public T setN104(String value) {
             return setSponsorIdentifier(value);
         }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/N3Segment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/N3Segment.java
@@ -11,8 +11,17 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.Getter;
 
 /**
- * Represents the N3 segment in X12 834 format.
- * This segment is used for address information.
+ * Represents the N3 (Party Location / Address) segment in the X12 834
+ * (005010X220A1) Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * This segment carries the street address lines for the party named in the
+ * enclosing loop.
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>N301 = address line 1</li>
+ *     <li>N302 = address line 2</li>
+ * </ul>
  */
 @Getter
 public abstract class N3Segment extends Segment {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/N4Segment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/N4Segment.java
@@ -11,8 +11,22 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.Getter;
 
 /**
- * Represents the N4 segment in X12 834 format.
- * This segment is used for geographic location information.
+ * Represents the N4 (Geographic Location) segment in the X12 834
+ * (005010X220A1) Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * This segment carries the city/state/postal geographic information for the party
+ * named in the enclosing loop.
+ * <p>
+ * Element/position map (meanings derived from the accessor names on this class):
+ * <ul>
+ *     <li>N401 = city name</li>
+ *     <li>N402 = state or province code</li>
+ *     <li>N403 = postal code</li>
+ *     <li>N404 = country code</li>
+ *     <li>N405 = location qualifier</li>
+ *     <li>N406 = location identifier</li>
+ *     <li>N407 = country subdivision code</li>
+ * </ul>
  */
 @Getter
 public abstract class N4Segment extends Segment {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/NM1Segment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/NM1Segment.java
@@ -23,14 +23,23 @@ import lombok.Getter;
 public abstract class NM1Segment extends Segment {
     public static final String SEGMENT_ID = "NM1";
 
+    /** NM101 — entity identifier code (the party's role). */
     protected final String nm101;
+    /** NM102 — entity type qualifier (1 = person, 2 = non-person / organization). */
     protected final String nm102;
+    /** NM103 — last name or organization name. */
     protected final String nm103;
+    /** NM104 — first name. */
     protected final String nm104;
+    /** NM105 — middle name. */
     protected final String nm105;
+    /** NM106 — name prefix. */
     protected final String nm106;
+    /** NM107 — name suffix. */
     protected final String nm107;
+    /** NM108 — identification code qualifier (what NM109 is). */
     protected final String nm108;
+    /** NM109 — identification code value. */
     protected final String nm109;
 
     protected NM1Segment(AbstractBuilder<?> builder) throws ValidationException {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/RefSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/RefSegment.java
@@ -11,12 +11,31 @@ import com.fastChickensHR.edi.x834.data.ReferenceIdentificationQualifier;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.Getter;
 
+/**
+ * Represents the REF (Reference Information) segment in the X12 834
+ * (005010X220A1) Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * This segment attaches a secondary reference identifier to the enclosing loop:
+ * a qualifier states what kind of reference it is, followed by the reference value
+ * and/or a free-form description.
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>REF01 = reference identification qualifier (what kind of reference)</li>
+ *     <li>REF02 = reference identification value (max 80 characters)</li>
+ *     <li>REF03 = reference description (max 80 characters)</li>
+ * </ul>
+ * At least one of REF02 or REF03 must be supplied.
+ */
 @Getter
 public abstract class RefSegment extends Segment {
     public static final String SEGMENT_ID = "REF";
 
+    /** REF01 — reference identification qualifier (what kind of reference this is). */
     protected final ReferenceIdentificationQualifier ref01;
+    /** REF02 — reference identification value (max 80 characters). */
     protected final String ref02;
+    /** REF03 — reference description (max 80 characters). */
     protected final String ref03;
 
     protected RefSegment(RefSegment.AbstractBuilder<?> builder) throws ValidationException {
@@ -51,57 +70,78 @@ public abstract class RefSegment extends Segment {
         return new String[]{ref01.getCode(), ref02, ref03};
     }
 
+    /** @return REF01 — reference identification qualifier. */
     public ReferenceIdentificationQualifier getReferenceIdentificationQualifier() {
         return getRef01();
     }
 
+    /** @return REF02 — reference identification value. */
     public String getReferenceIdentification() {
         return getRef02();
     }
 
+    /** @return REF03 — reference description. */
     public String getReferenceDescription() {
         return getRef03();
     }
 
+    /**
+     * Abstract builder for REF segments.
+     *
+     * @param <T> the concrete builder type for method chaining
+     */
     public abstract static class AbstractBuilder<T extends RefSegment.AbstractBuilder<T>> {
         protected ReferenceIdentificationQualifier ref01;
         protected String ref02;
         protected String ref03;
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the REF segment.
+         *
+         * @return a new {@link RefSegment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract RefSegment build() throws ValidationException;
 
+        /** Sets REF01 (reference identification qualifier) from its string code. */
         public T setReferenceIdentificationQualifier(String value) {
             this.ref01 = ReferenceIdentificationQualifier.fromString(value);
             return self();
         }
 
+        /** Sets REF02 (reference identification value). */
         public T setReferenceIdentification(String value) {
             this.ref02 = value;
             return self();
         }
 
+        /** Sets REF03 (reference description). */
         public T setReferenceDescription(String value) {
             this.ref03 = value;
             return self();
         }
 
+        /** Element alias for {@link #setReferenceIdentificationQualifier(String)}. */
         public T setRef01(String value) {
             return setReferenceIdentificationQualifier(value);
         }
 
+        /** Element alias for {@link #setReferenceIdentification(String)}. */
         public T setRef02(String value) {
             return setReferenceIdentification(value);
         }
 
+        /** Element alias for {@link #setReferenceDescription(String)}. */
         public T setRef03(String value) {
             return setReferenceDescription(value);
         }
     }
 
     /**
-     * Concrete builder implementation for RefSegment
+     * Concrete builder implementation for {@link RefSegment}.
      */
     public static class Builder extends AbstractBuilder<Builder> {
         @Override
@@ -116,7 +156,7 @@ public abstract class RefSegment extends Segment {
     }
 
     /**
-     * Concrete implementation of STSegment
+     * Concrete implementation of {@link RefSegment} used by the default Builder.
      */
     private static class RefSegmentImpl extends RefSegment {
         private RefSegmentImpl(AbstractBuilder<?> builder) throws ValidationException {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/SESegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/SESegment.java
@@ -11,13 +11,24 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import lombok.Getter;
 
 /**
- * Represents the SE (Transaction Set Trailer) segment in the EDI 834 format.
- * This segment defines the end of a transaction set and provides the segment count and control number.
+ * Represents the SE (Transaction Set Trailer) segment in the X12 834
+ * (005010X220A1) format.
+ * <p>
+ * This segment closes a transaction set opened by an {@link STSegment} and
+ * reconciles it via the count of included segments and the matching control number.
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>SE01 = number of segments included in the transaction set (inclusive of ST and SE)</li>
+ *     <li>SE02 = transaction set control number (matches the ST02 of the paired ST segment)</li>
+ * </ul>
  */
 @Getter
 abstract public class SESegment extends Segment {
     public static final String SEGMENT_ID = "SE";
+    /** SE01 — number of segments included in the transaction set. */
     protected final String se01;
+    /** SE02 — transaction set control number, matching the paired ST02. */
     protected final String se02;
 
     protected SESegment(SESegment.AbstractBuilder<?> builder) throws ValidationException {
@@ -35,37 +46,55 @@ abstract public class SESegment extends Segment {
         return new String[]{this.se01, this.se02};
     }
 
+    /** @return SE01 — number of segments in the transaction set. */
     public String getTransactionSegmentCount() {
         return getSe01();
     }
 
+    /** @return SE02 — transaction set control number. */
     public String getSetControlNumber() {
         return getSe02();
     }
 
 
+    /**
+     * Abstract builder for SE segments.
+     *
+     * @param <T> the concrete builder type for method chaining
+     */
     public abstract static class AbstractBuilder<T extends SESegment.AbstractBuilder<T>> {
         private String se01;
         private String se02;
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the SE segment.
+         *
+         * @return a new {@link SESegment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract SESegment build() throws ValidationException;
 
+        /** Sets SE01 (number of segments in the transaction set). */
         public T setSe01(String value) {
             this.se01 = value;
             return self();
         }
 
+        /** Element alias for {@link #setSe01(String)}. */
         public T setTransactionSegmentCount(String value) {
             return setSe01(value);
         }
 
+        /** Sets SE02 (transaction set control number). */
         public T setSe02(String value) {
             this.se02 = value;
             return self();
         }
 
+        /** Element alias for {@link #setSe02(String)}. */
         public T setSetControlNumber(String value) {
             return setSe02(value);
         }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/STSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/STSegment.java
@@ -13,9 +13,19 @@ import com.fastChickensHR.edi.x834.header.TransactionSetHeader;
 import lombok.Getter;
 
 /**
- * Represents the ST (Transaction Set Header) segment in the EDI format.
- * This segment defines the beginning of a transaction set and provides
- * the transaction set identifier, control number, and implementation convention reference.
+ * Represents the ST (Transaction Set Header) segment in the X12 834
+ * (005010X220A1) format.
+ * <p>
+ * This segment opens a transaction set, naming the transaction type, a control
+ * number, and the implementation convention it conforms to. It is closed by a
+ * matching {@link SESegment}.
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>ST01 = transaction set identifier code (e.g. "834")</li>
+ *     <li>ST02 = transaction set control number (4–9 characters; matched by SE02)</li>
+ *     <li>ST03 = implementation convention reference (optional, max 35 characters)</li>
+ * </ul>
  */
 @Getter
 abstract public class STSegment extends Segment {
@@ -67,50 +77,71 @@ abstract public class STSegment extends Segment {
         return new String[]{this.st01.getCode(), this.st02, this.st03};
     }
 
+    /** @return ST01 — transaction set identifier code. */
     public TransactionSetIdentifierCode getTransactionSetIdentifierCode() {
         return getSt01();
     }
 
+    /** @return ST02 — transaction set control number. */
     public String getTransactionSetControlNumber() {
         return getSt02();
     }
 
+    /** @return ST03 — implementation convention reference. */
     public String getImplementationConventionReference() {
         return getSt03();
     }
 
+    /**
+     * Abstract builder for ST segments.
+     *
+     * @param <T> the concrete builder type for method chaining
+     */
     public abstract static class AbstractBuilder<T extends STSegment.AbstractBuilder<T>> {
         private TransactionSetIdentifierCode st01;
         private String st02;
         private String st03;
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the ST segment.
+         *
+         * @return a new {@link STSegment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract STSegment build() throws ValidationException;
 
+        /** Sets ST01 (transaction set identifier code) from its string code. */
         public T setSt01(String value) {
             this.st01 = TransactionSetIdentifierCode.fromString(value);
             return self();
         }
 
+        /** Domain alias for {@link #setSt01(String)}. */
         public T setTransactionSetIdentifierCode(String value) {
             return setSt01(value);
         }
 
+        /** Sets ST02 (transaction set control number). */
         public T setSt02(String value) {
             this.st02 = value;
             return self();
         }
 
+        /** Domain alias for {@link #setSt02(String)}. */
         public T setTransactionSetControlNumber(String value) {
             return setSt02(value);
         }
 
+        /** Sets ST03 (implementation convention reference). */
         public T setSt03(String value) {
             this.st03 = value;
             return self();
         }
 
+        /** Domain alias for {@link #setSt03(String)}. */
         public T setImplementationConventionReference(String value) {
             return setSt03(value);
         }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/Segment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/Segment.java
@@ -11,8 +11,19 @@ import com.fastChickensHR.edi.x834.X834Context;
 import lombok.Setter;
 
 /**
- * Base class for all EDI segments.
- * Now context-aware to reduce direct dependency on X834Document.
+ * Base class for all X12 EDI segments (e.g. ISA, GS, ST, NM1) in the 834
+ * Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * A segment is an ordered list of data elements sharing a two- or three-character
+ * segment identifier. Concrete subclasses supply that identifier via
+ * {@link #getSegmentIdentifier()} and the ordered element values via
+ * {@link #getElementValues()}; this base class handles rendering those values into
+ * a delimited EDI segment string using the separators and terminators carried on the
+ * {@link X834Context}.
+ * <p>
+ * Segments are context-aware to reduce direct dependency on {@code X834Document}: the
+ * {@link X834Context} must be set (see the generated setter) before {@link #render()}
+ * is called.
  */
 @Setter
 public abstract class Segment {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/FunctionalGroupTrailer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/FunctionalGroupTrailer.java
@@ -45,6 +45,12 @@ public class FunctionalGroupTrailer extends GESegment {
             return this;
         }
 
+        /**
+         * Builds a new FunctionalGroupTrailer instance.
+         *
+         * @return A new FunctionalGroupTrailer instance
+         * @throws ValidationException if validation fails
+         */
         @Override
         public FunctionalGroupTrailer build() throws ValidationException {
             return new FunctionalGroupTrailer(this);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/InterchangeControlTrailer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/InterchangeControlTrailer.java
@@ -21,6 +21,7 @@ import lombok.experimental.Accessors;
  */
 @Getter
 public class InterchangeControlTrailer extends IEASegment {
+    /** Default IEA01 — number of functional groups in the interchange; always {@code "1"} for an 834. */
     public static final String DEFAULT_NUMBER_OF_INCLUDED_GROUPS = "1";
 
     private InterchangeControlTrailer(Builder builder) throws ValidationException {
@@ -48,6 +49,12 @@ public class InterchangeControlTrailer extends IEASegment {
             return this;
         }
 
+        /**
+         * Builds a new InterchangeControlTrailer instance.
+         *
+         * @return A new InterchangeControlTrailer instance
+         * @throws ValidationException if validation fails
+         */
         @Override
         public InterchangeControlTrailer build() throws ValidationException {
             return new InterchangeControlTrailer(this);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/TransactionSetTrailer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/TransactionSetTrailer.java
@@ -45,6 +45,12 @@ public class TransactionSetTrailer extends SESegment {
             return this;
         }
 
+        /**
+         * Builds a new TransactionSetTrailer instance.
+         *
+         * @return A new TransactionSetTrailer instance
+         * @throws ValidationException if validation fails
+         */
         @Override
         public TransactionSetTrailer build() throws ValidationException {
             return new TransactionSetTrailer(this);

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
@@ -226,6 +226,40 @@ class X834FileGeneratorTest {
                 "mailing 2100C must render after residence 2100A");
     }
 
+    @Test
+    void emitsCoverageDateDtpsInsideTheHdLoop2300() {
+        List<Field> envelope = List.of(
+                file(X834Location.SENDER_ID, "SENDER123"),
+                file(X834Location.RECEIVER_ID, "RECV456"),
+                file(X834Location.INTERCHANGE_CONTROL_NUMBER, "000000001"),
+                file(X834Location.GROUP_CONTROL_NUMBER, "1"),
+                file(X834Location.TRANSACTION_SET_CONTROL_NUMBER, "0001"),
+                file(X834Location.DOCUMENT_DATE, "2026-01-15"),
+                file(X834Location.REFERENCE_IDENTIFICATION, "REFID001"),
+                file(X834Location.MASTER_POLICY_NUMBER, "MP-100"),
+                file(X834Location.PLAN_SPONSOR_NAME, "ACME CORP"),
+                file(X834Location.PAYER_NAME, "BLUE CROSS"));
+
+        Record subscriber = Record.of(List.of(
+                emp(X834Location.MEMBER_INDICATOR, "Y"),
+                emp(X834Location.RELATIONSHIP_CODE, "18"),
+                emp(X834Location.MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.SUBSCRIBER_NUMBER, "E12345"),
+                emp(X834Location.HD_MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.HD_INSURANCE_LINE_CODE, "HLT"),
+                emp(X834Location.HD_BENEFIT_BEGIN_DATE, "2026-01-01"),
+                emp(X834Location.HD_BENEFIT_END_DATE, "2026-12-31")));
+
+        String out = generator.generate(new FileContent(Direction.OUTBOUND, envelope, List.of(subscriber)));
+
+        contains(out, "HD*001");
+        contains(out, "DTP*348*D8*20260101~");   // Loop 2300 coverage begin
+        contains(out, "DTP*349*D8*20261231~");   // Loop 2300 coverage end
+        // The coverage-date DTPs render after the HD segment, inside the same 2300 loop.
+        assertTrue(out.indexOf("DTP*348") > out.indexOf("HD*001"), "begin DTP must follow HD");
+        assertTrue(out.indexOf("DTP*349") > out.indexOf("DTP*348"), "end DTP must follow begin DTP");
+    }
+
     private static void contains(String haystack, String needle) {
         assertTrue(haystack.contains(needle), () -> "expected 834 to contain: " + needle + "\n---\n" + haystack);
     }


### PR DESCRIPTION
## Summary

Finishes the two remaining open items from the 834-module completion work.

### #71 — Loop 2300 coverage-date DTPs
`HealthCoverageDates` (the 2300 coverage DTP) existed but was never emitted. `X834FileGenerator` now builds `DTP*348` (coverage begin) and `DTP*349` (coverage end) in D8 format from new `hd.benefitBeginDate` / `hd.benefitEndDate` location keys, emitting them right after the `HD` segment inside the same member's Loop 2300. `healthCoverage()` now returns the ordered `HD` + DTP list.

### #80/#81/#82 — Documentation sweep
Comprehensive JavaDoc across the module (done as four disjoint passes, verified compile + full-suite green):
- **Segments** — class docs naming the X12 segment + an element/position map; documented element accessors and `DEFAULT_*` qualifiers.
- **Data enums** — each documents the X12 element / data-element number it represents, its 834 usage, and its no-default / `fromString`-throws behavior.
- **Member-loop + envelope** — loop identity (2100A/2100C/2300, 1000A/B/C), segment mappings, documented defaults.
- Also fixed several pre-existing copy-paste JavaDoc errors (mailing wrappers, `TransactionSetHeader`).

Documentation changes are comment-only — no code, signatures, defaults, or behavior changed.

## Issues
Closes #71, #80, #81, #82.

## Testing
Full multi-module suite green (x834: 1986 tests). New generator test asserts the coverage-date DTPs render in-order inside the HD loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)