### PR TITLE
docs(x834): NM1Segment method-level JavaDoc (#81 follow-up)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/NM1Segment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/NM1Segment.java
@@ -64,42 +64,56 @@ public abstract class NM1Segment extends Segment {
         return new String[]{nm101, nm102, nm103, nm104, nm105, nm106, nm107, nm108, nm109};
     }
 
+    /** @return NM101 — entity identifier code. */
     public String getEntityIdentifierCode() {
         return getNm101();
     }
 
+    /** @return NM102 — entity type qualifier (1 = person, 2 = non-person). */
     public String getEntityTypeQualifier() {
         return getNm102();
     }
 
+    /** @return NM103 — last name or organization name. */
     public String getLastName() {
         return getNm103();
     }
 
+    /** @return NM104 — first name. */
     public String getFirstName() {
         return getNm104();
     }
 
+    /** @return NM105 — middle name. */
     public String getMiddleName() {
         return getNm105();
     }
 
+    /** @return NM106 — name prefix. */
     public String getNamePrefix() {
         return getNm106();
     }
 
+    /** @return NM107 — name suffix. */
     public String getNameSuffix() {
         return getNm107();
     }
 
+    /** @return NM108 — identification code qualifier. */
     public String getIdentificationCodeQualifier() {
         return getNm108();
     }
 
+    /** @return NM109 — identification code value. */
     public String getIdentificationCode() {
         return getNm109();
     }
 
+    /**
+     * Abstract builder for NM1 segments.
+     *
+     * @param <T> the concrete builder type for method chaining
+     */
     public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
         protected String nm101;
         protected String nm102;
@@ -111,87 +125,112 @@ public abstract class NM1Segment extends Segment {
         protected String nm108;
         protected String nm109;
 
+        /** @return this builder cast to the concrete type. */
         protected abstract T self();
 
+        /**
+         * Builds and validates the NM1 segment.
+         *
+         * @return a new {@link NM1Segment} instance
+         * @throws ValidationException if validation fails
+         */
         public abstract NM1Segment build() throws ValidationException;
 
+        /** Sets NM101 (entity identifier code). */
         public T setEntityIdentifierCode(String value) {
             this.nm101 = value;
             return self();
         }
 
+        /** Sets NM102 (entity type qualifier; 1 = person, 2 = non-person). */
         public T setEntityTypeQualifier(String value) {
             this.nm102 = value;
             return self();
         }
 
+        /** Sets NM103 (last name or organization name). */
         public T setLastName(String value) {
             this.nm103 = value;
             return self();
         }
 
+        /** Sets NM104 (first name). */
         public T setFirstName(String value) {
             this.nm104 = value;
             return self();
         }
 
+        /** Sets NM105 (middle name). */
         public T setMiddleName(String value) {
             this.nm105 = value;
             return self();
         }
 
+        /** Sets NM106 (name prefix). */
         public T setNamePrefix(String value) {
             this.nm106 = value;
             return self();
         }
 
+        /** Sets NM107 (name suffix). */
         public T setNameSuffix(String value) {
             this.nm107 = value;
             return self();
         }
 
+        /** Sets NM108 (identification code qualifier). */
         public T setIdentificationCodeQualifier(String value) {
             this.nm108 = value;
             return self();
         }
 
+        /** Sets NM109 (identification code value). */
         public T setIdentificationCode(String value) {
             this.nm109 = value;
             return self();
         }
 
+        /** Element alias for {@link #setEntityIdentifierCode(String)}. */
         public T setNm101(String value) {
             return setEntityIdentifierCode(value);
         }
 
+        /** Element alias for {@link #setEntityTypeQualifier(String)}. */
         public T setNm102(String value) {
             return setEntityTypeQualifier(value);
         }
 
+        /** Element alias for {@link #setLastName(String)}. */
         public T setNm103(String value) {
             return setLastName(value);
         }
 
+        /** Element alias for {@link #setFirstName(String)}. */
         public T setNm104(String value) {
             return setFirstName(value);
         }
 
+        /** Element alias for {@link #setMiddleName(String)}. */
         public T setNm105(String value) {
             return setMiddleName(value);
         }
 
+        /** Element alias for {@link #setNamePrefix(String)}. */
         public T setNm106(String value) {
             return setNamePrefix(value);
         }
 
+        /** Element alias for {@link #setNameSuffix(String)}. */
         public T setNm107(String value) {
             return setNameSuffix(value);
         }
 
+        /** Element alias for {@link #setIdentificationCodeQualifier(String)}. */
         public T setNm108(String value) {
             return setIdentificationCodeQualifier(value);
         }
 
+        /** Element alias for {@link #setIdentificationCode(String)}. */
         public T setNm109(String value) {
             return setIdentificationCode(value);
         }


### PR DESCRIPTION
Small follow-up to #113: adds the NM1Segment getter/setter/builder-alias JavaDoc that landed just after that PR was cut. Comment-only; compiles clean. Part of #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)