### PR TITLE
feat(x834): member NM1 identification code (NM108/NM109) for SSN emission

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -137,6 +137,8 @@ public final class X834FileGenerator implements FileGenerator {
         apply(loc, X834Location.LAST_NAME, member::setLastName);
         apply(loc, X834Location.FIRST_NAME, member::setFirstName);
         apply(loc, X834Location.MIDDLE_NAME, member::setMiddleName);
+        apply(loc, X834Location.NAME_ID_QUALIFIER, member::setNameIdQualifier);
+        apply(loc, X834Location.NAME_ID, member::setNameId);
         apply(loc, X834Location.BIRTH_DATE, v -> member.setBirthDate(parseDateTime(v)));
         apply(loc, X834Location.GENDER, member::setGender);
         apply(loc, X834Location.ADDRESS_LINE_1, member::setAddressLine1);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
@@ -52,6 +52,8 @@ public final class X834Location {
     public static final String LAST_NAME = "lastName";        // NM103
     public static final String FIRST_NAME = "firstName";      // NM104
     public static final String MIDDLE_NAME = "middleName";    // NM105
+    public static final String NAME_ID_QUALIFIER = "nameIdQualifier"; // NM108 (e.g. 34 = SSN)
+    public static final String NAME_ID = "nameId";                    // NM109 (e.g. the SSN)
     public static final String BIRTH_DATE = "birthDate";      // DMG02 (D8)
     public static final String GENDER = "gender";             // DMG03
     public static final String ADDRESS_LINE_1 = "addressLine1"; // N301

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -37,6 +37,16 @@ public abstract class BaseMember {
     protected String firstName;
     protected String lastName;
     protected String middleName;
+    /**
+     * NM108 — identification code qualifier carried in the member name segment (Loop 2100A NM1),
+     * e.g. {@code 34} for a Social Security Number. Must be paired with {@link #nameId}.
+     */
+    protected String nameIdQualifier;
+    /**
+     * NM109 — identification code carried in the member name segment (Loop 2100A NM1), e.g. the
+     * member's SSN when {@link #nameIdQualifier} is {@code 34}. Must be paired with the qualifier.
+     */
+    protected String nameId;
     protected LocalDateTime birthDate;
     protected String gender;
     protected MemberIndicator memberIndicator;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -122,11 +122,17 @@ public class X834MemberWriter {
         if (isBlank(member.getLastName())) {
             return;
         }
-        segments.add(MemberName.builder()
+        MemberName.Builder name = MemberName.builder()
                 .setLastName(member.getLastName())
                 .setFirstName(emptyToNull(member.getFirstName()))
-                .setMiddleName(emptyToNull(member.getMiddleName()))
-                .build());
+                .setMiddleName(emptyToNull(member.getMiddleName()));
+        // NM108/NM109 (e.g. 34 + SSN) — set together or not at all (MemberName enforces the pairing).
+        String idQualifier = emptyToNull(member.getNameIdQualifier());
+        String id = emptyToNull(member.getNameId());
+        if (idQualifier != null && id != null) {
+            name.setIdentificationCodeQualifier(idQualifier).setIdentificationCode(id);
+        }
+        segments.add(name.build());
     }
 
     /**

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
@@ -260,6 +260,34 @@ class X834FileGeneratorTest {
         assertTrue(out.indexOf("DTP*349") > out.indexOf("DTP*348"), "end DTP must follow begin DTP");
     }
 
+    @Test
+    void emitsMemberNM1WithSsnFromNameIdKernelFields() {
+        List<Field> envelope = List.of(
+                file(X834Location.SENDER_ID, "SENDER123"),
+                file(X834Location.RECEIVER_ID, "RECV456"),
+                file(X834Location.INTERCHANGE_CONTROL_NUMBER, "000000001"),
+                file(X834Location.GROUP_CONTROL_NUMBER, "1"),
+                file(X834Location.TRANSACTION_SET_CONTROL_NUMBER, "0001"),
+                file(X834Location.DOCUMENT_DATE, "2026-01-15"),
+                file(X834Location.REFERENCE_IDENTIFICATION, "REFID001"),
+                file(X834Location.MASTER_POLICY_NUMBER, "MP-100"),
+                file(X834Location.PLAN_SPONSOR_NAME, "ACME CORP"),
+                file(X834Location.PAYER_NAME, "BLUE CROSS"));
+
+        Record subscriber = Record.of(List.of(
+                emp(X834Location.MEMBER_INDICATOR, "Y"),
+                emp(X834Location.RELATIONSHIP_CODE, "18"),
+                emp(X834Location.MAINTENANCE_TYPE_CODE, "001"),
+                emp(X834Location.LAST_NAME, "DOE"),
+                emp(X834Location.FIRST_NAME, "JANE"),
+                emp(X834Location.NAME_ID_QUALIFIER, "34"),
+                emp(X834Location.NAME_ID, "123456789")));
+
+        String out = generator.generate(new FileContent(Direction.OUTBOUND, envelope, List.of(subscriber)));
+
+        contains(out, "NM1*IL*1*DOE*JANE****34*123456789~");
+    }
+
     private static void contains(String haystack, String needle) {
         assertTrue(haystack.contains(needle), () -> "expected 834 to contain: " + needle + "\n---\n" + haystack);
     }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
@@ -60,6 +60,32 @@ class X834MemberWriterTest {
     }
 
     @Test
+    void emitsMemberNameWithIdentificationCodeWhenNM108AndNM109Present() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.setFirstName("JANE");
+        member.setNameIdQualifier("34"); // SSN
+        member.setNameId("123456789");
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("NM1*IL*1*DOE*JANE****34*123456789~"),
+                () -> "expected member NM1 with NM108/NM109 (SSN); got:\n" + out);
+    }
+
+    @Test
+    void omitsIdentificationCodeWhenNM108AndNM109NotBothPresent() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.setNameIdQualifier("34"); // qualifier only, no code
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("NM1*IL*1*DOE~"),
+                () -> "unpaired NM108 must be dropped (no NM1 id elements); got:\n" + out);
+    }
+
+    @Test
     void emitsDemographicsDMGWhenBirthDatePresent() throws ValidationException {
         Member member = baseSubscriber();
         member.setLastName("DOE");


### PR DESCRIPTION
## Summary
The member name segment (Loop 2100A NM1) emitted name only and couldn't carry an identification code (e.g. the member's SSN with qualifier `34`). This adds that.

- `BaseMember`: new `nameIdQualifier` (NM108) + `nameId` (NM109).
- `X834Location`: new kernel keys `NAME_ID_QUALIFIER` / `NAME_ID`.
- `X834MemberWriter.appendMemberName`: sets NM108/NM109 — only when **both** are present, since `MemberName` enforces the X12 both-or-neither pairing rule.
- `X834FileGenerator`: maps the new keys through the `FileContent` path.

Result: `NM1*IL*1*<last>*<first>***<qualifier>*<id>` (e.g. `*34*<ssn>`).

This is the library half of the ADR-0084 SSN-in-NM1 slice; the mono side will feed `Person.ssn` (Sensitive, read under `@SystemContext`) into these keys next.

## Testing
Writer + generator tests: paired NM108/NM109 emits `NM1*IL*1*DOE*JANE****34*123456789`; an unpaired qualifier is dropped. Full suite green (1989).

🤖 Generated with [Claude Code](https://claude.com/claude-code)