### PR TITLE
feat(x999): X12 999/997 acknowledgment parser on the FileParser seam (ADR-0383 slice 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Java toolkit for benefit-enrollment EDI: generate X12 834 files and CSV, and p
 | `core` | Format-neutral file kernel: the `FileContent` model and the `parse` / `generate` seam. |
 | `x834` | X12 834 benefit-enrollment file generator. |
 | `csv`  | CSV parser and generator. |
+| `x999` | X12 999 / 997 acknowledgment parser. |
 
 ## Install
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>core</module>
         <module>x834</module>
         <module>csv</module>
+        <module>x999</module>
     </modules>
 
     <properties>

--- a/x999/pom.xml
+++ b/x999/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+
+    This file is part of the FastChickensHR project.
+
+    For license information see the LICENSE file in the root of this project.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.fastchickenshr</groupId>
+        <artifactId>edi</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>x999</artifactId>
+    <name>FastChickensHR EDI 999</name>
+    <description>X12 999 / 997 acknowledgment support — parses into the core file kernel</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fastchickenshr</groupId>
+            <artifactId>core</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/x999/src/main/java/com/fastChickensHR/edi/x999/X999.java
+++ b/x999/src/main/java/com/fastChickensHR/edi/x999/X999.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x999;
+
+/**
+ * The 999 (and 997) acknowledgment dialect's {@code Location.name} vocabulary — the tokens
+ * {@link X999FileParser} emits so a consumer (the ack poller) can read the acknowledgment by location,
+ * the mirror of how the 834 generator reads its own {@link com.fastChickensHR.edi.core.Location}s.
+ *
+ * <p>File-level fields describe the acknowledged <em>functional group</em> (the reply is one group per
+ * 999); each record describes one acknowledged <em>transaction set</em>. Values are the raw X12 codes —
+ * the parser stays dialect-dumb and leaves accept/reject interpretation to the caller.
+ */
+public final class X999 {
+    private X999() {
+    }
+
+    // ---- File level: the 999's own envelope + the acknowledged group ----
+    /** ISA13 of the 999 interchange. */
+    public static final String INTERCHANGE_CONTROL_NUMBER = "interchangeControlNumber";
+    /** AK101 — functional identifier code of the acknowledged group (e.g. {@code BE} for an 834). */
+    public static final String FUNCTIONAL_ID_CODE = "functionalIdCode";
+    /** AK102 — group control number (the original GS06) being acknowledged; the correlation key. */
+    public static final String GROUP_CONTROL_NUMBER = "groupControlNumber";
+    /** AK901 — functional group acknowledgment code (see {@link #ACCEPTED} et al). */
+    public static final String GROUP_STATUS = "groupAckStatus";
+
+    // ---- Record level: one per acknowledged transaction set ----
+    /** AK202 — transaction set control number (the original ST02) being acknowledged. */
+    public static final String TRANSACTION_SET_CONTROL_NUMBER = "transactionSetControlNumber";
+    /** AK501 / IK501 — transaction set acknowledgment code (see {@link #ACCEPTED} et al). */
+    public static final String TRANSACTION_SET_STATUS = "transactionSetAckStatus";
+
+    // ---- Acknowledgment codes (AK901 / AK501 / IK501), for the consumer's convenience ----
+    /** {@code A} — Accepted. */
+    public static final String ACCEPTED = "A";
+    /** {@code E} — Accepted, but errors were noted. */
+    public static final String ACCEPTED_WITH_ERRORS = "E";
+    /** {@code P} — Partially accepted (some transaction sets rejected). */
+    public static final String PARTIALLY_ACCEPTED = "P";
+    /** {@code R} — Rejected. */
+    public static final String REJECTED = "R";
+    /** {@code M} — Rejected: message authentication code failed. */
+    public static final String REJECTED_AUTH = "M";
+    /** {@code W} — Rejected: assurance failed validity tests. */
+    public static final String REJECTED_VALIDITY = "W";
+    /** {@code X} — Rejected: content decryption failed. */
+    public static final String REJECTED_DECRYPTION = "X";
+}

--- a/x999/src/main/java/com/fastChickensHR/edi/x999/X999FileParser.java
+++ b/x999/src/main/java/com/fastChickensHR/edi/x999/X999FileParser.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x999;
+
+import com.fastChickensHR.edi.core.Direction;
+import com.fastChickensHR.edi.core.Field;
+import com.fastChickensHR.edi.core.FileContent;
+import com.fastChickensHR.edi.core.FileParser;
+import com.fastChickensHR.edi.core.Location;
+import com.fastChickensHR.edi.core.Record;
+import com.fastChickensHR.edi.core.RecordLevel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The X12 999 / 997 implementation of the {@link FileParser} seam: reads a functional acknowledgment
+ * into a format-neutral {@link FileContent}. An acknowledgment replies to one functional group, so the
+ * file-level fields carry the acknowledged group (functional id, group control number, group status),
+ * and each {@link Record} carries one acknowledged transaction set (its control number and status) —
+ * see {@link X999}.
+ *
+ * <p>The parser is dialect-dumb: it walks segments and emits the raw X12 codes as {@link Field}s at
+ * their {@link X999} locations, leaving accept/reject interpretation and correlation to the caller. It
+ * reads {@code AK1} (group), {@code AK2} (transaction set), {@code AK5}/{@code IK5} (transaction set
+ * response) and {@code AK9} (group response); interior error-detail segments ({@code AK3/AK4/IK3/IK4})
+ * are skipped in this pass. Delimiters are taken from the interchange's {@code ISA} envelope, defaulting
+ * to {@code *} (element) and {@code ~} (segment).
+ */
+public final class X999FileParser implements FileParser {
+
+    private static final char DEFAULT_ELEMENT_SEPARATOR = '*';
+    private static final char DEFAULT_SEGMENT_TERMINATOR = '~';
+    private static final int ISA_LENGTH = 106;
+
+    @Override
+    public FileContent parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return new FileContent(Direction.INBOUND, List.of(), List.of());
+        }
+
+        char elementSeparator = DEFAULT_ELEMENT_SEPARATOR;
+        char segmentTerminator = DEFAULT_SEGMENT_TERMINATOR;
+        if (raw.startsWith("ISA") && raw.length() >= ISA_LENGTH) {
+            elementSeparator = raw.charAt(3);
+            segmentTerminator = raw.charAt(ISA_LENGTH - 1);
+        }
+
+        List<Field> fileFields = new ArrayList<>();
+        List<Record> records = new ArrayList<>();
+        String pendingTransactionSetControlNumber = null;
+
+        for (String rawSegment : raw.split(java.util.regex.Pattern.quote(String.valueOf(segmentTerminator)))) {
+            String segment = rawSegment.strip();
+            if (segment.isEmpty()) {
+                continue;
+            }
+            String[] e = segment.split(java.util.regex.Pattern.quote(String.valueOf(elementSeparator)), -1);
+            switch (e[0]) {
+                case "ISA" -> addField(fileFields, RecordLevel.FILE, X999.INTERCHANGE_CONTROL_NUMBER, at(e, 13));
+                case "AK1" -> {
+                    addField(fileFields, RecordLevel.FILE, X999.FUNCTIONAL_ID_CODE, at(e, 1));
+                    addField(fileFields, RecordLevel.FILE, X999.GROUP_CONTROL_NUMBER, at(e, 2));
+                }
+                case "AK2" -> pendingTransactionSetControlNumber = at(e, 2);
+                case "AK5", "IK5" -> {
+                    List<Field> fields = new ArrayList<>();
+                    addField(fields, RecordLevel.RECORD, X999.TRANSACTION_SET_CONTROL_NUMBER,
+                            pendingTransactionSetControlNumber);
+                    addField(fields, RecordLevel.RECORD, X999.TRANSACTION_SET_STATUS, at(e, 1));
+                    if (!fields.isEmpty()) {
+                        records.add(Record.of(fields));
+                    }
+                    pendingTransactionSetControlNumber = null;
+                }
+                case "AK9" -> addField(fileFields, RecordLevel.FILE, X999.GROUP_STATUS, at(e, 1));
+                default -> { /* other segments (GS/ST/AK3/AK4/IK3/IK4/SE/GE/IEA) carry no field we surface */ }
+            }
+        }
+
+        return new FileContent(Direction.INBOUND, fileFields, records);
+    }
+
+    /** The element at index {@code i}, trimmed; null when absent or blank (absence, not a blank value). */
+    private static String at(String[] elements, int i) {
+        if (i >= elements.length) {
+            return null;
+        }
+        String value = elements[i].strip();
+        return value.isEmpty() ? null : value;
+    }
+
+    private static void addField(List<Field> into, RecordLevel level, String location, String value) {
+        if (value != null) {
+            into.add(new Field(new Location(level, location), value));
+        }
+    }
+}

--- a/x999/src/test/java/com/fastChickensHR/edi/x999/X999FileParserTest.java
+++ b/x999/src/test/java/com/fastChickensHR/edi/x999/X999FileParserTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x999;
+
+import com.fastChickensHR.edi.core.Direction;
+import com.fastChickensHR.edi.core.Field;
+import com.fastChickensHR.edi.core.FileContent;
+import com.fastChickensHR.edi.core.Record;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class X999FileParserTest {
+
+    private final X999FileParser parser = new X999FileParser();
+
+    // A well-formed 106-char ISA (element sep '*', segment terminator '~', ISA13 = 000000123).
+    private static final String ISA =
+            "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *260119*1200*U*00501*000000123*0*P*:~";
+
+    @Test
+    void parsesAnAcceptedAcknowledgment() {
+        String ack = ISA
+                + "GS*FA*SENDER*RECEIVER*20260119*1200*42*X*005010X231A1~"
+                + "ST*999*0001~"
+                + "AK1*BE*000000042~"
+                + "AK2*834*0001~"
+                + "IK5*A~"
+                + "AK9*A*1*1*1~"
+                + "SE*5*0001~GE*1*42~IEA*1*000000123~";
+
+        FileContent out = parser.parse(ack);
+
+        assertEquals(Direction.INBOUND, out.direction());
+        assertEquals("000000123", file(out, X999.INTERCHANGE_CONTROL_NUMBER)); // ISA13
+        assertEquals("BE", file(out, X999.FUNCTIONAL_ID_CODE));                // AK101
+        assertEquals("000000042", file(out, X999.GROUP_CONTROL_NUMBER));       // AK102 (acked GS06)
+        assertEquals("A", file(out, X999.GROUP_STATUS));                       // AK901
+
+        assertEquals(1, out.records().size());
+        Record ts = out.records().get(0);
+        assertEquals("0001", rec(ts, X999.TRANSACTION_SET_CONTROL_NUMBER));    // AK202 (acked ST02)
+        assertEquals("A", rec(ts, X999.TRANSACTION_SET_STATUS));               // IK501
+    }
+
+    @Test
+    void parsesARejectionWithMultipleTransactionSets() {
+        String ack = ISA
+                + "AK1*BE*000000042~"
+                + "AK2*834*0001~IK5*A~"
+                + "AK2*834*0002~IK5*R~"
+                + "AK9*P*2*2*1~";
+
+        FileContent out = parser.parse(ack);
+
+        assertEquals("P", file(out, X999.GROUP_STATUS)); // partially accepted
+        assertEquals(2, out.records().size());
+        assertEquals("0001", rec(out.records().get(0), X999.TRANSACTION_SET_CONTROL_NUMBER));
+        assertEquals("A", rec(out.records().get(0), X999.TRANSACTION_SET_STATUS));
+        assertEquals("0002", rec(out.records().get(1), X999.TRANSACTION_SET_CONTROL_NUMBER));
+        assertEquals("R", rec(out.records().get(1), X999.TRANSACTION_SET_STATUS));
+    }
+
+    @Test
+    void reads997StyleAk5AndSkipsErrorDetailSegments() {
+        String ack = ISA
+                + "AK1*BE*000000042~"
+                + "AK2*834*0007~"
+                + "AK3*NM1*8**8~AK4*3*1068*7~" // error-detail segments — skipped this pass
+                + "AK5*E~"
+                + "AK9*E*1*1*1~";
+
+        FileContent out = parser.parse(ack);
+
+        assertEquals("E", file(out, X999.GROUP_STATUS));
+        assertEquals(1, out.records().size());
+        assertEquals("0007", rec(out.records().get(0), X999.TRANSACTION_SET_CONTROL_NUMBER));
+        assertEquals("E", rec(out.records().get(0), X999.TRANSACTION_SET_STATUS));
+    }
+
+    @Test
+    void fallsBackToDefaultDelimitersWhenNoIsaEnvelope() {
+        // No ISA — the parser defaults to '*' / '~'.
+        String ack = "AK1*BE*000000042~AK2*834*0001~IK5*A~AK9*A*1*1*1~";
+
+        FileContent out = parser.parse(ack);
+
+        assertEquals("000000042", file(out, X999.GROUP_CONTROL_NUMBER));
+        assertNull(file(out, X999.INTERCHANGE_CONTROL_NUMBER)); // no ISA present
+        assertEquals(1, out.records().size());
+        assertEquals("0001", rec(out.records().get(0), X999.TRANSACTION_SET_CONTROL_NUMBER));
+    }
+
+    @Test
+    void blankInputProducesAnEmptyFileContent() {
+        FileContent out = parser.parse("   ");
+        assertTrue(out.fileFields().isEmpty());
+        assertTrue(out.records().isEmpty());
+        assertEquals(Direction.INBOUND, out.direction());
+    }
+
+    private static String file(FileContent fc, String location) {
+        return valueAt(fc.fileFields(), location);
+    }
+
+    private static String rec(Record record, String location) {
+        return valueAt(record.fields(), location);
+    }
+
+    private static String valueAt(List<Field> fields, String location) {
+        return fields.stream()
+                .filter(f -> f.location().name().equals(location))
+                .map(Field::value)
+                .findFirst()
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
## Summary
Slice 2 of **ADR-0383** (999/TA1 ack loop): a new **`x999`** module that parses an X12 999/997 functional acknowledgment into the format-neutral `FileContent`, on the `core/FileParser` seam — symmetric with `X834FileGenerator` and `CsvFileParser`.

- **File-level fields** carry the acknowledged group: `functionalIdCode` (AK101), `groupControlNumber` (AK102 = the original GS06 — the correlation key), `groupAckStatus` (AK901), and the 999's own `interchangeControlNumber` (ISA13).
- **Each `Record`** carries one acknowledged transaction set: `transactionSetControlNumber` (AK202 = original ST02) + `transactionSetAckStatus` (AK5/IK5).
- `X999` names the location vocabulary + the accept/reject code constants.

The parser stays dialect-dumb (raw X12 codes as `Field`s by location, interpretation left to the caller). `AK3/AK4/IK3/IK4` error-detail segments are skipped this pass; TA1 is a later slice. Delimiters are read from the ISA envelope, defaulting to `*` / `~`.

## Testing
`X999FileParserTest`: accepted ack, partial rejection with multiple transaction sets, 997-style `AK5` + skipped error detail, default-delimiter fallback (no ISA), blank input. Full 5-module reactor green.

## Consumed by
mono slice 3 (the ack poller) — correlate by group/transaction control number, transition `TRANSMITTED → ACKNOWLEDGED/REJECTED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)