### PR TITLE
feat(edi): ISA14 acknowledgment-requested (x834) + TA1 parsing (x999) — ADR-0383 fast-follows

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
@@ -41,6 +41,8 @@ public class X834Context {
     private String groupControlNumber;
     private String senderID;
     private String receiverID;
+    /** ISA14 — Interchange Acknowledgment Requested ("1" to request a TA1/999). Null defaults to "0". */
+    private String acknowledgmentRequested;
     private LocalDateTime documentDate;
     private DateFormat dateFormat;
     private TimeFormat timeFormat;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -93,6 +93,7 @@ public final class X834FileGenerator implements FileGenerator {
         apply(file, X834Location.GROUP_CONTROL_NUMBER, context::setGroupControlNumber);
         apply(file, X834Location.TRANSACTION_SET_CONTROL_NUMBER, context::setTransactionSetControlNumber);
         apply(file, X834Location.DOCUMENT_DATE, v -> context.setDocumentDate(parseDateTime(v)));
+        apply(file, X834Location.ACKNOWLEDGMENT_REQUESTED, context::setAcknowledgmentRequested);
         return context;
     }
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
@@ -28,6 +28,7 @@ public final class X834Location {
     public static final String GROUP_CONTROL_NUMBER = "groupControlNumber";
     public static final String TRANSACTION_SET_CONTROL_NUMBER = "transactionSetControlNumber";
     public static final String DOCUMENT_DATE = "documentDate";
+    public static final String ACKNOWLEDGMENT_REQUESTED = "acknowledgmentRequested"; // ISA14 ("1" requests a TA1/999)
 
     // ---- File level: header data (Header.Builder) ----
     public static final String TRANSACTION_SET_ID = "transactionSetId";

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/InterchangeControlHeader.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/InterchangeControlHeader.java
@@ -77,7 +77,9 @@ public class InterchangeControlHeader extends ISASegment {
             this.isa11 = DEFAULT_REPETITION_SEPARATOR;
             this.isa12 = DEFAULT_INTERCHANGE_CONTROL_VERSION;
             this.isa13 = context.getInterchangeControlNumber();
-            this.isa14 = DEFAULT_ACKNOWLEDGMENT_REQUESTED;
+            this.isa14 = (context.getAcknowledgmentRequested() != null && !context.getAcknowledgmentRequested().isBlank())
+                    ? AcknowledgmentRequested.fromString(context.getAcknowledgmentRequested())
+                    : DEFAULT_ACKNOWLEDGMENT_REQUESTED;
             this.isa15 = DEFAULT_USAGE_INDICATOR;
             this.isa16 = DEFAULT_COMPONENT_ELEMENT_SEPARATOR;
         }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
@@ -288,6 +288,32 @@ class X834FileGeneratorTest {
         contains(out, "NM1*IL*1*DOE*JANE****34*123456789~");
     }
 
+    @Test
+    void isa14RequestsAnAcknowledgmentWhenTheKeyIsSet() {
+        List<Field> envelope = List.of(
+                file(X834Location.SENDER_ID, "SENDER123"),
+                file(X834Location.RECEIVER_ID, "RECV456"),
+                file(X834Location.INTERCHANGE_CONTROL_NUMBER, "000000001"),
+                file(X834Location.GROUP_CONTROL_NUMBER, "1"),
+                file(X834Location.TRANSACTION_SET_CONTROL_NUMBER, "0001"),
+                file(X834Location.DOCUMENT_DATE, "2026-01-15"),
+                file(X834Location.REFERENCE_IDENTIFICATION, "REFID001"),
+                file(X834Location.MASTER_POLICY_NUMBER, "MP-100"),
+                file(X834Location.PLAN_SPONSOR_NAME, "ACME CORP"),
+                file(X834Location.PAYER_NAME, "BLUE CROSS"),
+                file(X834Location.ACKNOWLEDGMENT_REQUESTED, "1"));
+
+        Record subscriber = Record.of(List.of(
+                emp(X834Location.MEMBER_INDICATOR, "Y"),
+                emp(X834Location.RELATIONSHIP_CODE, "18"),
+                emp(X834Location.MAINTENANCE_TYPE_CODE, "001")));
+
+        String out = generator.generate(new FileContent(Direction.OUTBOUND, envelope, List.of(subscriber)));
+
+        // ISA13 (control number) then ISA14 = 1 (Acknowledgment Requested).
+        contains(out, "000000001*1*");
+    }
+
     private static void contains(String haystack, String needle) {
         assertTrue(haystack.contains(needle), () -> "expected 834 to contain: " + needle + "\n---\n" + haystack);
     }

--- a/x999/src/main/java/com/fastChickensHR/edi/x999/X999.java
+++ b/x999/src/main/java/com/fastChickensHR/edi/x999/X999.java
@@ -30,6 +30,12 @@ public final class X999 {
     /** AK901 — functional group acknowledgment code (see {@link #ACCEPTED} et al). */
     public static final String GROUP_STATUS = "groupAckStatus";
 
+    // ---- File level: TA1 interchange acknowledgment (may stand alone or accompany a 999) ----
+    /** TA101 — interchange control number (the original ISA13) the TA1 acknowledges. */
+    public static final String ACKNOWLEDGED_INTERCHANGE_CONTROL_NUMBER = "acknowledgedInterchangeControlNumber";
+    /** TA104 — interchange acknowledgment code (A accepted, E accepted-with-errors, R rejected). */
+    public static final String INTERCHANGE_ACK_STATUS = "interchangeAckStatus";
+
     // ---- Record level: one per acknowledged transaction set ----
     /** AK202 — transaction set control number (the original ST02) being acknowledged. */
     public static final String TRANSACTION_SET_CONTROL_NUMBER = "transactionSetControlNumber";

--- a/x999/src/main/java/com/fastChickensHR/edi/x999/X999FileParser.java
+++ b/x999/src/main/java/com/fastChickensHR/edi/x999/X999FileParser.java
@@ -63,6 +63,10 @@ public final class X999FileParser implements FileParser {
             String[] e = segment.split(java.util.regex.Pattern.quote(String.valueOf(elementSeparator)), -1);
             switch (e[0]) {
                 case "ISA" -> addField(fileFields, RecordLevel.FILE, X999.INTERCHANGE_CONTROL_NUMBER, at(e, 13));
+                case "TA1" -> {
+                    addField(fileFields, RecordLevel.FILE, X999.ACKNOWLEDGED_INTERCHANGE_CONTROL_NUMBER, at(e, 1));
+                    addField(fileFields, RecordLevel.FILE, X999.INTERCHANGE_ACK_STATUS, at(e, 4));
+                }
                 case "AK1" -> {
                     addField(fileFields, RecordLevel.FILE, X999.FUNCTIONAL_ID_CODE, at(e, 1));
                     addField(fileFields, RecordLevel.FILE, X999.GROUP_CONTROL_NUMBER, at(e, 2));

--- a/x999/src/test/java/com/fastChickensHR/edi/x999/X999FileParserTest.java
+++ b/x999/src/test/java/com/fastChickensHR/edi/x999/X999FileParserTest.java
@@ -101,6 +101,26 @@ class X999FileParserTest {
     }
 
     @Test
+    void parsesAStandaloneTa1InterchangeAcknowledgment() {
+        String ack = ISA + "TA1*000000123*260119*1200*A*000~";
+
+        FileContent out = parser.parse(ack);
+
+        assertEquals("000000123", file(out, X999.ACKNOWLEDGED_INTERCHANGE_CONTROL_NUMBER)); // TA101
+        assertEquals("A", file(out, X999.INTERCHANGE_ACK_STATUS));                           // TA104
+    }
+
+    @Test
+    void parsesARejectingTa1() {
+        String ack = ISA + "TA1*000000777*260119*1200*R*022~";
+
+        FileContent out = parser.parse(ack);
+
+        assertEquals("000000777", file(out, X999.ACKNOWLEDGED_INTERCHANGE_CONTROL_NUMBER));
+        assertEquals("R", file(out, X999.INTERCHANGE_ACK_STATUS));
+    }
+
+    @Test
     void blankInputProducesAnEmptyFileContent() {
         FileContent out = parser.parse("   ");
         assertTrue(out.fileFields().isEmpty());


### PR DESCRIPTION
## Summary
The edi-side fast-follows for the ADR-0383 ack loop, so the app can request acks and read interchange-level ones.

**x834 — ISA14 (Interchange Acknowledgment Requested)**
- `X834Context.acknowledgmentRequested`; `InterchangeControlHeader` reads it (defaults to `"0"` — unchanged when unset).
- `X834Location.ACKNOWLEDGMENT_REQUESTED` + `X834FileGenerator` mapping, so the kernel path can emit `ISA14=1`.

**x999 — TA1 parsing**
- Reads the `TA1` interchange acknowledgment: `TA101` (acknowledged ISA13) → `ACKNOWLEDGED_INTERCHANGE_CONTROL_NUMBER`, `TA104` → `INTERCHANGE_ACK_STATUS`, at file level, alongside the existing AK1/AK9.

## Testing
`ISA14=1` renders in the ISA (control number then `*1*`); standalone TA1 accept + reject parse. Full 5-module reactor green.

## Consumed by
mono: sets `ACKNOWLEDGMENT_REQUESTED=1` on outbound, and (optionally) correlates a TA1 by acknowledged ICN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)