### PR TITLE
fix: audit findings — corrupted 332 description, stale ISA10/GS05 time, empty Member.validate() (#120, #121, #122)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
@@ -46,8 +46,6 @@ public class X834Context {
     private LocalDateTime documentDate;
     private DateFormat dateFormat;
     private TimeFormat timeFormat;
-    private String formattedDocumentDate;
-    private String formattedDocumentTime;
 
     // Constants
     /** Interchange control version (ISA12) for the 5010 release: {@code "00501"}. */
@@ -67,8 +65,6 @@ public class X834Context {
         this.documentDate = LocalDateTime.now();
         this.dateFormat = DateFormat.DATE;
         this.timeFormat = TimeFormat.TIME;
-        this.formattedDocumentDate = formatDate(documentDate);
-        this.formattedDocumentTime = formatTime(documentDate);
         this.elementSeparator = ElementSeparator.ASTERISK;
         this.segmentTerminator = SegmentTerminator.TILDE;
         this.subElementSeparator = SubElementSeparator.GREATER_THAN;
@@ -143,15 +139,22 @@ public class X834Context {
     }
 
     /**
-     * Sets the document date and refreshes the cached formatted document date.
-     *
-     * @param date the document date/time
-     * @return this context instance for chaining
+     * @return the document date formatted with the current {@link #getDateFormat() date format}.
+     * Rendered into ISA09 (interchange date), GS04 (group date), BGN03 and the file effective DTP.
+     * Always derived from {@link #getDocumentDate()} on read, so it can never go stale.
      */
-    public X834Context setDocumentDate(LocalDateTime date) {
-        this.documentDate = date;
-        this.formattedDocumentDate = formatDate(date);
-        return this;
+    public String getFormattedDocumentDate() {
+        return formatDate(documentDate);
+    }
+
+    /**
+     * @return the document time formatted with the current {@link #getTimeFormat() time format}.
+     * Rendered into ISA10 (interchange time) and GS05 (group time). Always derived from
+     * {@link #getDocumentDate()} on read, so it follows {@link #setDocumentDate} consistently
+     * with the formatted date.
+     */
+    public String getFormattedDocumentTime() {
+        return formatTime(documentDate);
     }
 
     /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/DateTimeQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/DateTimeQualifier.java
@@ -354,7 +354,7 @@ public enum DateTimeQualifier implements EdiCodeEnum {
     TERMINATED("329", "Terminated"),
     REFERRAL_DATE("330", "Referral Date"),
     EVALUATION_DATE("331", "Evaluation Date"),
-    PLACEMENT_DATE("332", "Field Date"),
+    PLACEMENT_DATE("332", "Placement Date"),
     INDIVIDUAL_EDUCATION_PLAN("333", "Individual Education Plan (IEP)"),
     RE_EVALUATION_DATE("334", "Re-evaluation Date"),
     DISMISSAL_DATE("335", "Dismissal Date"),

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/Member.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/Member.java
@@ -41,12 +41,26 @@ public class Member extends BaseMember {
     }
 
     /**
-     * Validates this member has the minimum required fields.
+     * Validates this member has the minimum required fields: the INS-segment trio
+     * (member indicator, relationship code, maintenance type code) that
+     * {@link X834MemberWriter} dereferences unconditionally, plus each dependent's
+     * own validation.
      *
      * @throws ValidationException If validation fails
      */
     @Override
     public void validate() throws ValidationException {
-        // Implementation omitted for shortness
+        if (memberIndicator == null) {
+            throw new ValidationException("Member must have a member indicator (INS01)");
+        }
+        if (relationshipCode == null) {
+            throw new ValidationException("Member must have a relationship code (INS02)");
+        }
+        if (maintenanceTypeCode == null) {
+            throw new ValidationException("Member must have a maintenance type code (INS03)");
+        }
+        for (DependentMember dependent : dependents) {
+            dependent.validate();
+        }
     }
 }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/X834ContextTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/X834ContextTest.java
@@ -7,8 +7,11 @@
  */
 package com.fastChickensHR.edi.x834;
 
+import com.fastChickensHR.edi.x834.dates.DateFormat;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -68,5 +71,47 @@ class X834ContextTest {
     void testEmptyGroupControlNumberThrows() {
         X834Context ctx = validContext().setGroupControlNumber("");
         assertThrows(ValidationException.class, ctx::validate);
+    }
+
+    @Test
+    void testFormattedDateAndTimeBothFollowSetDocumentDate() {
+        X834Context ctx = new X834Context()
+                .setDocumentDate(LocalDateTime.of(2024, 1, 1, 0, 0));
+
+        assertEquals("20240101", ctx.getFormattedDocumentDate(),
+                "ISA09/GS04 date should come from the configured document date");
+        assertEquals("0000", ctx.getFormattedDocumentTime(),
+                "ISA10/GS05 time should come from the configured document date, not construction wall-clock");
+    }
+
+    @Test
+    void testFormattedTimeIsNotFrozenAtConstruction() {
+        X834Context ctx = new X834Context()
+                .setDocumentDate(LocalDateTime.of(2023, 11, 15, 12, 30, 45));
+
+        assertEquals("20231115", ctx.getFormattedDocumentDate());
+        assertEquals("1230", ctx.getFormattedDocumentTime());
+
+        ctx.setDocumentDate(LocalDateTime.of(2025, 6, 30, 23, 59, 0));
+        assertEquals("20250630", ctx.getFormattedDocumentDate());
+        assertEquals("2359", ctx.getFormattedDocumentTime());
+    }
+
+    @Test
+    void testFormatChangesAfterConstructionAreReflectedOnRead() {
+        X834Context ctx = new X834Context()
+                .setDocumentDate(LocalDateTime.of(2023, 11, 15, 12, 30, 0));
+
+        ctx.setDateFormat(DateFormat.D6);
+        assertEquals("231115", ctx.getFormattedDocumentDate(),
+                "changing the date format after construction should be reflected in the formatted date");
+    }
+
+    @Test
+    void testDefaultDocumentDateStillDrivesFormattedValues() {
+        X834Context ctx = new X834Context();
+
+        assertEquals(ctx.formatDate(ctx.getDocumentDate()), ctx.getFormattedDocumentDate());
+        assertEquals(ctx.formatTime(ctx.getDocumentDate()), ctx.getFormattedDocumentTime());
     }
 }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/data/DateTimeQualifierTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/data/DateTimeQualifierTest.java
@@ -67,6 +67,19 @@ class DateTimeQualifierTest {
         assertThrows(IllegalArgumentException.class, () -> DateTimeQualifier.fromString(null));
     }
 
+    /**
+     * Qualifier 332's official X12 description is "Placement Date". A mechanical rename
+     * once corrupted this domain literal to "Field Date", which broke description-based
+     * lookup; this pins the correct wording.
+     */
+    @Test
+    void testPlacementDateDescriptionLookup() {
+        assertEquals("Placement Date", DateTimeQualifier.PLACEMENT_DATE.getDescription());
+        assertEquals(DateTimeQualifier.PLACEMENT_DATE, DateTimeQualifier.fromString("Placement Date"));
+        assertEquals(DateTimeQualifier.PLACEMENT_DATE, DateTimeQualifier.fromString("332"));
+        assertThrows(IllegalArgumentException.class, () -> DateTimeQualifier.fromString("Field Date"));
+    }
+
     @ParameterizedTest
     @MethodSource("provideLookupValues")
     void testAllLookupValues(String input, DateTimeQualifier expected) throws Exception {

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/header/FunctionalGroupHeaderTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/header/FunctionalGroupHeaderTest.java
@@ -40,8 +40,6 @@ class FunctionalGroupHeaderTest {
         context.setDocumentDate(testDateTime)
                 .setSenderID(senderID)
                 .setReceiverID(receiverID)
-                .setFormattedDocumentDate(formattedDate)
-                .setFormattedDocumentTime(formattedTime)
                 .setGroupControlNumber(groupControlNumber);
     }
 

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/MemberTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/MemberTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
+import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
+import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemberTest {
+
+    private Member validMember() {
+        Member member = new Member();
+        member.setMemberIndicator(MemberIndicator.INSURED);
+        member.setRelationshipCode(IndividualRelationshipCode.SELF);
+        member.setMaintenanceTypeCode(MaintenanceTypeCode.ADDITION);
+        return member;
+    }
+
+    @Test
+    void validMemberPassesValidation() {
+        assertDoesNotThrow(() -> validMember().validate());
+    }
+
+    @Test
+    void missingMemberIndicatorThrows() {
+        Member member = validMember();
+        member.setMemberIndicator(null);
+        ValidationException ex = assertThrows(ValidationException.class, member::validate);
+        assertTrue(ex.getMessage().contains("member indicator"));
+    }
+
+    @Test
+    void missingRelationshipCodeThrows() {
+        Member member = validMember();
+        member.setRelationshipCode(null);
+        ValidationException ex = assertThrows(ValidationException.class, member::validate);
+        assertTrue(ex.getMessage().contains("relationship code"));
+    }
+
+    @Test
+    void missingMaintenanceTypeCodeThrows() {
+        Member member = validMember();
+        member.setMaintenanceTypeCode(null);
+        ValidationException ex = assertThrows(ValidationException.class, member::validate);
+        assertTrue(ex.getMessage().contains("maintenance type code"));
+    }
+
+    @Test
+    void invalidDependentFailsMemberValidation() {
+        Member member = validMember();
+        DependentMember dependent = new DependentMember();
+        // No relationship code — DependentMember.validate() rejects this.
+        member.addDependent(dependent);
+
+        ValidationException ex = assertThrows(ValidationException.class, member::validate);
+        assertTrue(ex.getMessage().contains("relationship code"));
+    }
+
+    @Test
+    void validDependentPassesMemberValidation() {
+        Member member = validMember();
+        DependentMember dependent = new DependentMember();
+        dependent.setRelationshipCode(IndividualRelationshipCode.SPOUSE);
+        member.addDependent(dependent);
+
+        assertDoesNotThrow(member::validate);
+    }
+}


### PR DESCRIPTION
Three confirmed bugs from the #118 fresh-eyes audit, fixed together.

## #120 — DateTimeQualifier 332 corrupted description

Restores qualifier 332's official X12 description to **"Placement Date"** — the mechanical vocabulary-rename sweep (`e77f91b`) had corrupted this domain string literal to "Field Date" (verified against `e77f91b^` at the old path). Since `EdiEnumLookup` indexes descriptions, `fromString("Placement Date")` threw and `fromString("Field Date")` wrongly resolved to 332. Added a pinning test for description, both lookups, and rejection of "Field Date".

A diff of the whole rename commit for changed string literals plus a sweep of current enum code/description pairs confirms 332 was the **only** corrupted X12 term (046 "Field Failure" and the various Location/Record descriptions are genuine X12 wording).

## #121 — ISA10/GS05 time frozen at context construction

`X834Context` no longer caches `formattedDocumentDate`/`formattedDocumentTime`. `getFormattedDocumentDate()`/`getFormattedDocumentTime()` now derive on read from `documentDate` + the current date/time formats, so ISA10/GS05 follow `setDocumentDate` exactly like ISA09/GS04 do, format changes after construction take effect, and the accidental cache-clobbering public setters disappear with the fields. Default behavior (document date = now at construction) unchanged. Tests cover README's `setDocumentDate(2024-01-01T00:00)` scenario, re-setting the date, post-construction format changes, and the no-document-date default.

## #122 — Member.validate() was an empty placeholder

Implements the minimum-field validation the JavaDoc promises and `X834Document.Builder.build()` relies on: the INS trio the member writer dereferences unconditionally — `memberIndicator` (INS01), `relationshipCode` (INS02), `maintenanceTypeCode` (INS03) — plus cascading to each dependent's own `validate()`. Conservative by design: any member missing these would already NPE in `X834MemberWriter.toSegments`, so no legitimately-working document starts failing. New `MemberTest` covers the happy path, each missing field, and dependent cascade.

Full suite green locally (`mvn test`: 2000+ tests, 0 failures).

Closes #120
Closes #121
Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)