### PR TITLE
feat(csv): configurable DelimitedFormat + csv() preset (#132)

### DIFF
--- a/csv/src/main/java/com/fastChickensHR/edi/csv/CsvFileGenerator.java
+++ b/csv/src/main/java/com/fastChickensHR/edi/csv/CsvFileGenerator.java
@@ -12,7 +12,6 @@ import com.fastChickensHR.edi.core.FileContent;
 import com.fastChickensHR.edi.core.FileGenerator;
 import com.fastChickensHR.edi.core.Record;
 import com.fastChickensHR.edi.core.RecordLevel;
-import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 
 import java.io.IOException;
@@ -35,9 +34,17 @@ import java.util.Map;
  */
 public final class CsvFileGenerator implements FileGenerator {
 
-    private static final CSVFormat FORMAT = CSVFormat.DEFAULT.builder()
-            .setRecordSeparator("\n")
-            .build();
+    private final DelimitedFormat format;
+
+    /** Writes plain flat CSV ({@link DelimitedFormat#csv()}). */
+    public CsvFileGenerator() {
+        this(DelimitedFormat.csv());
+    }
+
+    /** Writes a delimited flat file in the given {@code format} (e.g. to match a foreign feed). */
+    public CsvFileGenerator(DelimitedFormat format) {
+        this.format = format;
+    }
 
     @Override
     public String generate(FileContent file) {
@@ -63,8 +70,10 @@ public final class CsvFileGenerator implements FileGenerator {
         header.addAll(columns);
 
         StringWriter out = new StringWriter();
-        try (CSVPrinter printer = new CSVPrinter(out, FORMAT)) {
-            printer.printRecord(header);
+        try (CSVPrinter printer = new CSVPrinter(out, format.generateFormat())) {
+            if (format.hasHeader()) {
+                printer.printRecord(header);
+            }
             for (Record record : file.records()) {
                 printRow(printer, header, record, RecordLevel.RECORD);
                 for (Record child : record.children()) {

--- a/csv/src/main/java/com/fastChickensHR/edi/csv/CsvFileParser.java
+++ b/csv/src/main/java/com/fastChickensHR/edi/csv/CsvFileParser.java
@@ -14,7 +14,6 @@ import com.fastChickensHR.edi.core.Field;
 import com.fastChickensHR.edi.core.FileContent;
 import com.fastChickensHR.edi.core.Record;
 import com.fastChickensHR.edi.core.Location;
-import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 
@@ -37,14 +36,21 @@ import java.util.List;
  */
 public final class CsvFileParser implements FileParser {
 
-    private static final CSVFormat FORMAT = CSVFormat.DEFAULT.builder()
-            .setHeader()
-            .setSkipHeaderRecord(true)
-            .build();
+    private final DelimitedFormat format;
+
+    /** Reads plain flat CSV ({@link DelimitedFormat#csv()}). */
+    public CsvFileParser() {
+        this(DelimitedFormat.csv());
+    }
+
+    /** Reads a delimited flat file in the given {@code format} (e.g. to match a foreign feed). */
+    public CsvFileParser(DelimitedFormat format) {
+        this.format = format;
+    }
 
     @Override
     public FileContent parse(String raw) {
-        try (CSVParser parser = CSVParser.parse(raw == null ? "" : raw, FORMAT)) {
+        try (CSVParser parser = CSVParser.parse(raw == null ? "" : raw, format.parseFormat())) {
             List<String> headers = parser.getHeaderNames();
             boolean nested = headers.contains(Csv.RECORD_LEVEL_COLUMN);
             List<Record> records = nested ? parseNested(parser, headers) : parseFlat(parser, headers);

--- a/csv/src/main/java/com/fastChickensHR/edi/csv/DelimitedFormat.java
+++ b/csv/src/main/java/com/fastChickensHR/edi/csv/DelimitedFormat.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.csv;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.QuoteMode;
+
+/**
+ * The shape of a delimited flat file: how a line is split into cells and how cells are quoted,
+ * escaped, and terminated. A {@code DelimitedFormat} is a small, edi-owned value that
+ * <em>wraps</em> Apache Commons CSV's {@link CSVFormat} — the wrap is deliberate: callers configure
+ * a curated set of knobs (delimiter, quote, escape, quoting policy, record separator, header
+ * handling) and never touch the underlying engine, so the dependency stays an implementation detail
+ * the module can swap or extend without breaking consumers.
+ *
+ * <p>Build one with a preset factory such as {@link #csv()} for a known convention, or with
+ * {@link #builder()} to match a foreign system's file exactly.
+ */
+public final class DelimitedFormat {
+
+    private final char delimiter;
+    private final Character quote;
+    private final Character escape;
+    private final QuoteMode quoteMode;
+    private final String recordSeparator;
+    private final boolean header;
+
+    private DelimitedFormat(Builder builder) {
+        this.delimiter = builder.delimiter;
+        this.quote = builder.quote;
+        this.escape = builder.escape;
+        this.quoteMode = builder.quoteMode;
+        this.recordSeparator = builder.recordSeparator;
+        this.header = builder.header;
+    }
+
+    /**
+     * The pinned CSV convention: comma-delimited, {@code "}-quoted with quote-doubling (no escape
+     * character), minimal quoting, LF ({@code \n}) record separator, and a leading header row.
+     * This is the format the module's round-trip tests verify; it is the one preset guaranteed to
+     * survive parse-then-generate unchanged.
+     */
+    public static DelimitedFormat csv() {
+        return builder()
+                .delimiter(',')
+                .quote('"')
+                .escape(null)
+                .quoteMode(QuoteMode.MINIMAL)
+                .recordSeparator("\n")
+                .header(true)
+                .build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Whether files in this format carry a leading header row. */
+    boolean hasHeader() {
+        return header;
+    }
+
+    /** The Commons CSV format for reading — header-aware when {@link #hasHeader()}. */
+    CSVFormat parseFormat() {
+        CSVFormat.Builder builder = base();
+        if (header) {
+            builder.setHeader().setSkipHeaderRecord(true);
+        }
+        return builder.build();
+    }
+
+    /** The Commons CSV format for writing; the header row (when any) is printed by the generator. */
+    CSVFormat generateFormat() {
+        return base().build();
+    }
+
+    private CSVFormat.Builder base() {
+        return CSVFormat.DEFAULT.builder()
+                .setDelimiter(delimiter)
+                .setQuote(quote)
+                .setEscape(escape)
+                .setQuoteMode(quoteMode)
+                .setRecordSeparator(recordSeparator);
+    }
+
+    /**
+     * Assembles a custom {@link DelimitedFormat}. Defaults mirror {@link #csv()}; override only the
+     * knobs a target file differs on.
+     */
+    public static final class Builder {
+        private char delimiter = ',';
+        private Character quote = '"';
+        private Character escape = null;
+        private QuoteMode quoteMode = QuoteMode.MINIMAL;
+        private String recordSeparator = "\n";
+        private boolean header = true;
+
+        private Builder() {
+        }
+
+        public Builder delimiter(char delimiter) {
+            this.delimiter = delimiter;
+            return this;
+        }
+
+        /** The quote character, or {@code null} for an unquoted format. */
+        public Builder quote(Character quote) {
+            this.quote = quote;
+            return this;
+        }
+
+        /**
+         * The escape character, or {@code null} to escape an embedded quote by doubling it (the CSV
+         * convention).
+         */
+        public Builder escape(Character escape) {
+            this.escape = escape;
+            return this;
+        }
+
+        public Builder quoteMode(QuoteMode quoteMode) {
+            this.quoteMode = quoteMode;
+            return this;
+        }
+
+        public Builder recordSeparator(String recordSeparator) {
+            this.recordSeparator = recordSeparator;
+            return this;
+        }
+
+        public Builder header(boolean header) {
+            this.header = header;
+            return this;
+        }
+
+        public DelimitedFormat build() {
+            return new DelimitedFormat(this);
+        }
+    }
+}

--- a/csv/src/test/java/com/fastChickensHR/edi/csv/DelimitedFormatTest.java
+++ b/csv/src/test/java/com/fastChickensHR/edi/csv/DelimitedFormatTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.csv;
+
+import com.fastChickensHR.edi.core.Direction;
+import com.fastChickensHR.edi.core.Field;
+import com.fastChickensHR.edi.core.FileContent;
+import com.fastChickensHR.edi.core.Location;
+import com.fastChickensHR.edi.core.Record;
+import com.fastChickensHR.edi.core.RecordLevel;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.fastChickensHR.edi.core.RecordLevel.RECORD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Proves the parser/generator are configurable through {@link DelimitedFormat}, not hard-wired to
+ * comma-separated values. Same records, a different format ⇒ a different file that still round-trips.
+ */
+class DelimitedFormatTest {
+
+    private static Field f(RecordLevel level, String name, String value) {
+        return new Field(new Location(level, name), value);
+    }
+
+    private final List<Record> records = List.of(
+            Record.of(List.of(f(RECORD, "id", "1"), f(RECORD, "name", "Jane"))),
+            Record.of(List.of(f(RECORD, "id", "2"), f(RECORD, "name", "John"))));
+
+    private FileContent content() {
+        return new FileContent(Direction.OUTBOUND, List.of(), records);
+    }
+
+    @Test
+    void pipeDelimitedFormatUsesThePipeSeparatorAndRoundTrips() {
+        DelimitedFormat pipe = DelimitedFormat.builder().delimiter('|').build();
+
+        String out = new CsvFileGenerator(pipe).generate(content());
+
+        assertEquals("id|name\n1|Jane\n2|John\n", out);
+        assertEquals(records, new CsvFileParser(pipe).parse(out).records());
+    }
+
+    @Test
+    void tabDelimitedFormatRoundTrips() {
+        DelimitedFormat tab = DelimitedFormat.builder().delimiter('\t').build();
+
+        String out = new CsvFileGenerator(tab).generate(content());
+
+        assertEquals("id\tname\n1\tJane\n2\tJohn\n", out);
+        assertEquals(records, new CsvFileParser(tab).parse(out).records());
+    }
+
+    @Test
+    void headerlessFormatOmitsTheHeaderRow() {
+        DelimitedFormat noHeader = DelimitedFormat.builder().header(false).build();
+
+        String out = new CsvFileGenerator(noHeader).generate(content());
+
+        assertEquals("1,Jane\n2,John\n", out);
+    }
+}


### PR DESCRIPTION
Closes #132. The **non-breaking** half of the #127 `csv → flatfile` rename.

## What
Introduces `DelimitedFormat` — a small, edi-owned value that **wraps (never exposes)** Apache Commons CSV's `CSVFormat` (#130). Curated knobs only (delimiter, quote, escape, quoting policy, record separator, header handling), a `csv()` static-factory preset pinning the existing convention (comma / `"`-doubling / no-escape / minimal / **LF** / header) per #131, and a `builder()` for matching foreign feeds. No `toCsvFormat()` escape hatch.

`CsvFileParser` / `CsvFileGenerator` now take a `DelimitedFormat`; their **no-arg constructors default to `csv()`**, so existing callers — including `mono`'s `new CsvFileParser()` — are untouched. This delivers the map's "configurable, able to match foreign files" destination **without** a breaking change.

## Why this is the safe half
The mechanical hard rename (`csv → flatfile.delimited`, class/package/module/artifactId) is deliberately split into the paired follow-up **#133** (blocked by this), so the breaking cross-repo window (#129 policy) is isolated to that PR. This PR breaks nothing.

## Tests
`mvn -pl csv test` → **14/14 green**:
- the 11 existing round-trip tests are **unchanged and byte-identical**, proving `csv()` reproduces the old hardcoded `CSVFormat` exactly;
- 3 new tests cover pipe / tab / headerless formats, proving configurability.

## Follow-ups
- #133 — hard rename to `flatfile.delimited` (breaking; paired with mono #541)
- mono #541 — import + pom follow
