### PR TITLE
feat(x834): member reporting categories loop (2700/2710/2750)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/EntityIdentifierCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/EntityIdentifierCode.java
@@ -181,7 +181,8 @@ public enum EntityIdentifierCode implements EdiCodeEnum {
     INSURER("IN", "Insurer"),
     TERMINAL_LOCATION("T3", "Terminal Location"),
     PLAN_SPONSOR("P5", "Plan Sponsor"),
-    PRIMARY_TAX_PAYER("TP", "Primary Taxpayer");
+    PRIMARY_TAX_PAYER("TP", "Primary Taxpayer"),
+    PARTICIPANT("75", "Participant");
 
     private final String code;
     private final String description;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -11,6 +11,7 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import lombok.Getter;
 import lombok.Setter;
@@ -128,6 +129,26 @@ public abstract class BaseMember {
      */
     public void addSegment(Segment segment) {
         additionalSegments.add(segment);
+    }
+
+    /**
+     * This member's reporting categories (Loop 2700/2710/2750). Emitted by
+     * {@link X834MemberWriter} as an {@code LS*2700} … {@code LE*2700} block after the
+     * member's 2300 segments, one {@code LX}/{@code N1*75}/{@code REF} occurrence per entry.
+     * Empty for a member that carries none, in which case no block is emitted.
+     */
+    private final List<ReportingCategory> reportingCategories = new ArrayList<>();
+
+    /**
+     * Adds a reporting category (one Loop 2710/2750 occurrence) to this member. Order is
+     * preserved; the {@code LX} assigned number is set at render time over the emitted occurrences.
+     *
+     * @param category the reporting category to emit (ignored if null)
+     */
+    public void addReportingCategory(ReportingCategory category) {
+        if (category != null) {
+            reportingCategories.add(category);
+        }
     }
 
     /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -10,6 +10,11 @@ package com.fastChickensHR.edi.x834.loop2000;
 import com.fastChickensHR.edi.x834.dates.DateFormat;
 import com.fastChickensHR.edi.x834.dates.DateFormatter;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.DTPSegment;
+import com.fastChickensHR.edi.x834.segments.LESegment;
+import com.fastChickensHR.edi.x834.segments.LSSegment;
+import com.fastChickensHR.edi.x834.segments.LXSegment;
+import com.fastChickensHR.edi.x834.segments.RefSegment;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import com.fastChickensHR.edi.x834.X834Context;
 import com.fastChickensHR.edi.x834.loop2000.data.BenefitStatusCode;
@@ -21,6 +26,8 @@ import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceStreetAddre
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingAddress;
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingCityStateZipCode;
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingStreetAddress;
+import com.fastChickensHR.edi.x834.loop2000.loop2700.MemberReportingCategoryName;
+import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -115,7 +122,47 @@ public class X834MemberWriter {
         // Emitting them here keeps a member's coverage nested inside its own loop, before any
         // dependent's loop begins.
         segments.addAll(member.getAdditionalSegments());
+
+        // Loop 2700/2710/2750 (member reporting categories), emitted after the 2300 block.
+        appendReportingCategories(segments, member);
     }
+
+    /**
+     * Loop 2700/2710/2750 (member reporting categories): an {@code LS*2700} … {@code LE*2700}
+     * block wrapping one {@code LX}/{@code N1*75}/{@code REF}(/{@code DTP}) occurrence per
+     * {@link ReportingCategory}. The whole block is suppressed when the member carries none, and
+     * the {@code LX} assigned number is counted over the emitted occurrences (1-based).
+     */
+    private void appendReportingCategories(List<Segment> segments, BaseMember member)
+            throws ValidationException {
+        List<ReportingCategory> categories = member.getReportingCategories();
+        if (categories.isEmpty()) {
+            return;
+        }
+        segments.add(LSSegment.builder().setLoopIdentifierCode(REPORTING_CATEGORY_LOOP_ID).build());
+        int assignedNumber = 1;
+        for (ReportingCategory category : categories) {
+            segments.add(LXSegment.builder().setAssignedNumber(assignedNumber++).build());
+            segments.add(MemberReportingCategoryName.builder()
+                    .setReportingCategoryName(category.getName())
+                    .build());
+            segments.add(new RefSegment.Builder()
+                    .setReferenceIdentificationQualifier(category.getReferenceQualifier())
+                    .setReferenceIdentification(category.getValue())
+                    .build());
+            if (category.getDate() != null && category.getDateQualifier() != null) {
+                segments.add(new DTPSegment.Builder()
+                        .setDateTimeQualifier(category.getDateQualifier())
+                        .setDateTimeFormat(DateFormat.D8)
+                        .setDateTimePeriod(category.getDate(), DateFormat.D8)
+                        .build());
+            }
+        }
+        segments.add(LESegment.builder().setLoopIdentifierCode(REPORTING_CATEGORY_LOOP_ID).build());
+    }
+
+    /** LS01/LE01 loop identifier for the Member Reporting Categories loop (2700). */
+    private static final String REPORTING_CATEGORY_LOOP_ID = "2700";
 
     /** Loop 2100A NM1 (member name). Emitted when a last name is present. */
     private void appendMemberName(List<Segment> segments, BaseMember member) throws ValidationException {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2700/MemberReportingCategoryName.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2700/MemberReportingCategoryName.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2700;
+
+import com.fastChickensHR.edi.x834.data.EntityIdentifierCode;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.N1Segment;
+import lombok.Getter;
+
+/**
+ * The N1 (Party Identification) segment that names a member reporting category in
+ * Loop 2750 of the X12 834 (005010X220A1).
+ * <p>
+ * N101 is fixed to {@code 75} (Participant); N102 carries the reporting-category
+ * <em>name</em> — the label the carrier uses to identify what this occurrence
+ * reports (e.g. {@code INDIVIDUALREPNAME}, {@code RELATIONSHIP}). The category's
+ * value rides the REF segment that follows this one in the same 2750 occurrence.
+ * <p>
+ * The name is a carrier-specific label, so it is supplied per occurrence rather
+ * than drawn from a fixed enum.
+ */
+@Getter
+public class MemberReportingCategoryName extends N1Segment {
+
+    private MemberReportingCategoryName(Builder builder) throws ValidationException {
+        super(builder);
+    }
+
+    /** @return N102 — the reporting-category name. */
+    public String getReportingCategoryName() {
+        return getN102();
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link MemberReportingCategoryName}; N101 defaults to {@code 75} (Participant). */
+    public static class Builder extends N1Segment.AbstractBuilder<Builder> {
+        public Builder() {
+            this.n101 = EntityIdentifierCode.PARTICIPANT;
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        /** Sets N102 (the reporting-category name). */
+        public Builder setReportingCategoryName(String value) {
+            return setPlanSponsorName(value);
+        }
+
+        @Override
+        public MemberReportingCategoryName build() throws ValidationException {
+            return new MemberReportingCategoryName(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2700/ReportingCategory.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2700/ReportingCategory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2700;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * A single member reporting category — one occurrence of Loop 2710/2750 in the
+ * X12 834 (005010X220A1).
+ * <p>
+ * A reporting category is a name/value pair the carrier collects against a
+ * member: the {@link #name} labels what is being reported (carried in the 2750
+ * {@code N1*75} segment) and the {@link #value} is what is reported for it
+ * (carried in the following {@code REF} segment under {@link #referenceQualifier},
+ * which defaults to {@code ZZ}, Mutually Defined). An occurrence may also carry a
+ * {@link #date} (emitted as a {@code DTP} segment) when {@link #dateQualifier} is
+ * set to state what the date means.
+ * <p>
+ * This is a pure domain object; translation to 834 segments is the writer's job.
+ */
+@Getter
+@Setter
+public class ReportingCategory {
+    /** The category label (2750 {@code N1*75} N102) — required. */
+    private String name;
+    /** The REF qualifier for the value (2750 {@code REF} REF01); defaults to {@code ZZ}. */
+    private String referenceQualifier = "ZZ";
+    /** The reported value (2750 {@code REF} REF02) — required. */
+    private String value;
+    /** An optional category date (2750 {@code DTP} DTP03). */
+    private LocalDateTime date;
+    /** The qualifier stating what {@link #date} means (2750 {@code DTP} DTP01); required when a date is present. */
+    private String dateQualifier;
+
+    public ReportingCategory() {
+    }
+
+    /**
+     * @param name  the category label (2750 {@code N1*75})
+     * @param value the reported value (2750 {@code REF})
+     */
+    public ReportingCategory(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/LESegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/LESegment.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import lombok.Getter;
+
+/**
+ * Represents the LE (Loop Trailer) segment in the X12 834 (005010X220A1)
+ * Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * LE closes a bounded loop opened by a matching {@link LSSegment}; both carry
+ * the same loop identifier code. In the 834 this closes Loop 2700 (Member
+ * Reporting Categories).
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>LE01 = loop identifier code — the loop this trailer closes (e.g. "2700")</li>
+ * </ul>
+ */
+@Getter
+public class LESegment extends Segment {
+    public static final String SEGMENT_ID = "LE";
+
+    /** LE01 — loop identifier code naming the loop this trailer closes. */
+    protected final String le01;
+
+    private LESegment(Builder builder) throws ValidationException {
+        this.le01 = builder.le01;
+        validate();
+    }
+
+    private void validate() throws ValidationException {
+        if (le01 == null || le01.trim().isEmpty()) {
+            throw new ValidationException("LE01 (Loop Identifier Code) is required");
+        }
+    }
+
+    @Override
+    public String getSegmentIdentifier() {
+        return SEGMENT_ID;
+    }
+
+    @Override
+    public String[] getElementValues() {
+        return new String[]{le01};
+    }
+
+    /** @return LE01 — loop identifier code. */
+    public String getLoopIdentifierCode() {
+        return getLe01();
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link LESegment}. */
+    public static class Builder {
+        private String le01;
+
+        /** Sets LE01 (loop identifier code). */
+        public Builder setLoopIdentifierCode(String value) {
+            this.le01 = value;
+            return this;
+        }
+
+        /** Element alias for {@link #setLoopIdentifierCode(String)}. */
+        public Builder setLe01(String value) {
+            return setLoopIdentifierCode(value);
+        }
+
+        /**
+         * Builds and validates the LE segment.
+         *
+         * @return a new {@link LESegment}
+         * @throws ValidationException if validation fails
+         */
+        public LESegment build() throws ValidationException {
+            return new LESegment(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/LSSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/LSSegment.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import lombok.Getter;
+
+/**
+ * Represents the LS (Loop Header) segment in the X12 834 (005010X220A1)
+ * Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * LS opens a bounded loop and is closed by a matching {@link LESegment}; both
+ * carry the same loop identifier code so the pair brackets the enclosed
+ * occurrences. In the 834 this brackets Loop 2700 (Member Reporting Categories).
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>LS01 = loop identifier code — the loop this header opens (e.g. "2700")</li>
+ * </ul>
+ */
+@Getter
+public class LSSegment extends Segment {
+    public static final String SEGMENT_ID = "LS";
+
+    /** LS01 — loop identifier code naming the loop this header opens. */
+    protected final String ls01;
+
+    private LSSegment(Builder builder) throws ValidationException {
+        this.ls01 = builder.ls01;
+        validate();
+    }
+
+    private void validate() throws ValidationException {
+        if (ls01 == null || ls01.trim().isEmpty()) {
+            throw new ValidationException("LS01 (Loop Identifier Code) is required");
+        }
+    }
+
+    @Override
+    public String getSegmentIdentifier() {
+        return SEGMENT_ID;
+    }
+
+    @Override
+    public String[] getElementValues() {
+        return new String[]{ls01};
+    }
+
+    /** @return LS01 — loop identifier code. */
+    public String getLoopIdentifierCode() {
+        return getLs01();
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link LSSegment}. */
+    public static class Builder {
+        private String ls01;
+
+        /** Sets LS01 (loop identifier code). */
+        public Builder setLoopIdentifierCode(String value) {
+            this.ls01 = value;
+            return this;
+        }
+
+        /** Element alias for {@link #setLoopIdentifierCode(String)}. */
+        public Builder setLs01(String value) {
+            return setLoopIdentifierCode(value);
+        }
+
+        /**
+         * Builds and validates the LS segment.
+         *
+         * @return a new {@link LSSegment}
+         * @throws ValidationException if validation fails
+         */
+        public LSSegment build() throws ValidationException {
+            return new LSSegment(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/LXSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/LXSegment.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import lombok.Getter;
+
+/**
+ * Represents the LX (Assigned Number) segment in the X12 834 (005010X220A1)
+ * Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * LX carries a sequential number that distinguishes one occurrence of a
+ * repeating loop from the next. In the 834 it opens each occurrence of Loop
+ * 2710 within the Member Reporting Categories block (Loop 2700), so the number
+ * is assigned at render time over the occurrences actually emitted.
+ * <p>
+ * Element/position map:
+ * <ul>
+ *     <li>LX01 = assigned number — a positive sequential counter (max 6 digits)</li>
+ * </ul>
+ */
+@Getter
+public class LXSegment extends Segment {
+    public static final String SEGMENT_ID = "LX";
+
+    /** LX01 — assigned number distinguishing this loop occurrence. */
+    protected final int lx01;
+
+    private LXSegment(Builder builder) throws ValidationException {
+        this.lx01 = builder.lx01;
+        validate();
+    }
+
+    private void validate() throws ValidationException {
+        if (lx01 < 1) {
+            throw new ValidationException("LX01 (Assigned Number) must be a positive integer");
+        }
+        if (lx01 > 999999) {
+            throw new ValidationException("LX01 (Assigned Number) must be 6 digits or fewer");
+        }
+    }
+
+    @Override
+    public String getSegmentIdentifier() {
+        return SEGMENT_ID;
+    }
+
+    @Override
+    public String[] getElementValues() {
+        return new String[]{Integer.toString(lx01)};
+    }
+
+    /** @return LX01 — assigned number. */
+    public int getAssignedNumber() {
+        return getLx01();
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link LXSegment}. */
+    public static class Builder {
+        private int lx01;
+
+        /** Sets LX01 (assigned number). */
+        public Builder setAssignedNumber(int value) {
+            this.lx01 = value;
+            return this;
+        }
+
+        /** Element alias for {@link #setAssignedNumber(int)}. */
+        public Builder setLx01(int value) {
+            return setAssignedNumber(value);
+        }
+
+        /**
+         * Builds and validates the LX segment.
+         *
+         * @return a new {@link LXSegment}
+         * @throws ValidationException if validation fails
+         */
+        public LXSegment build() throws ValidationException {
+            return new LXSegment(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/N1Segment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/N1Segment.java
@@ -70,7 +70,10 @@ public abstract class N1Segment extends Segment {
 
     @Override
     public String[] getElementValues() {
-        return new String[]{n101.getCode(), n102, n103.getCode(), n104};
+        // N103 is optional (an N1 may name a party by free-form N102 alone, e.g. the 2750
+        // reporting-category party which carries only N101=75 + N102=<category name>). Guard the
+        // dereference so a null qualifier renders as an empty trailing element rather than an NPE.
+        return new String[]{n101.getCode(), n102, n103 == null ? null : n103.getCode(), n104};
     }
 
     /** @return N101 — entity identifier code. */

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
@@ -12,6 +12,7 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import org.junit.jupiter.api.Test;
 
@@ -250,5 +251,75 @@ class X834MemberWriterTest {
         assertTrue(out.contains("NM1*IL*1*DOE*JOHN~"), () -> "dependent name; got:\n" + out);
         assertEquals(out.indexOf("JANE") < out.indexOf("JOHN"), true,
                 "subscriber loop must precede dependent loop");
+    }
+
+    @Test
+    void emitsNoReportingCategoryBlockWhenMemberHasNone() throws ValidationException {
+        Member member = baseSubscriber();
+
+        String out = render(writer.toSegments(member));
+
+        assertFalse(out.contains("LS*2700"), () -> "no LS when there are no categories; got:\n" + out);
+        assertFalse(out.contains("LE*2700"), () -> "no LE when there are no categories; got:\n" + out);
+    }
+
+    @Test
+    void emitsReportingCategoryLoopMatchingTheBcbsmExample() throws ValidationException {
+        // BCBSM companion guide (pp. 11-12) example: two 2750 occurrences under one LS/LE block.
+        Member member = baseSubscriber();
+        member.addReportingCategory(new ReportingCategory("INDIVIDUALREPNAME", "JOHN DOE"));
+        member.addReportingCategory(new ReportingCategory("RELATIONSHIP", "4"));
+
+        String flat = render(writer.toSegments(member)).replace("\n", "");
+
+        assertTrue(flat.contains(
+                        "LS*2700~"
+                        + "LX*1~"
+                        + "N1*75*INDIVIDUALREPNAME~"
+                        + "REF*ZZ*JOHN DOE~"
+                        + "LX*2~"
+                        + "N1*75*RELATIONSHIP~"
+                        + "REF*ZZ*4~"
+                        + "LE*2700~"),
+                () -> "expected the BCBSM 2700/2750 block; got:\n" + flat);
+    }
+
+    @Test
+    void emitsReportingCategoryBlockAfterTheMemberCoverageSegments() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.addReportingCategory(new ReportingCategory("RELATIONSHIP", "4"));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.indexOf("NM1*IL") < out.indexOf("LS*2700"),
+                () -> "reporting-category block must follow the 2100 member segments; got:\n" + out);
+    }
+
+    @Test
+    void emitsReportingCategoryDateWhenPresent() throws ValidationException {
+        Member member = baseSubscriber();
+        ReportingCategory category = new ReportingCategory("APPLICATIONDATE", "X");
+        category.setDate(LocalDateTime.of(2026, 3, 1, 0, 0));
+        category.setDateQualifier("007"); // application/effective date qualifier
+        member.addReportingCategory(category);
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("DTP*007*D8*20260301~"),
+                () -> "expected a 2750 DTP when a category carries a date; got:\n" + out);
+    }
+
+    @Test
+    void honorsACustomReferenceQualifier() throws ValidationException {
+        Member member = baseSubscriber();
+        ReportingCategory category = new ReportingCategory("SUBGROUP", "0042");
+        category.setReferenceQualifier("DX"); // BCN carries sub-group under REF*DX rather than ZZ
+        member.addReportingCategory(category);
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("REF*DX*0042~"),
+                () -> "expected the REF to use the category's own qualifier; got:\n" + out);
     }
 }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/segments/LESegmentTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/segments/LESegmentTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LESegmentTest {
+    private final X834Context context = new X834Context();
+
+    @Test
+    void rendersLoopTrailerWithIdentifier() throws ValidationException {
+        LESegment segment = LESegment.builder().setLoopIdentifierCode("2700").build();
+        segment.setContext(context);
+
+        assertEquals("LE", segment.getSegmentIdentifier());
+        assertEquals("2700", segment.getLoopIdentifierCode());
+        assertEquals("LE*2700~", segment.render().trim());
+    }
+
+    @Test
+    void rejectsMissingLoopIdentifier() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> LESegment.builder().build());
+        assertTrue(ex.getMessage().contains("LE01"));
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/segments/LSSegmentTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/segments/LSSegmentTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LSSegmentTest {
+    private final X834Context context = new X834Context();
+
+    @Test
+    void rendersLoopHeaderWithIdentifier() throws ValidationException {
+        LSSegment segment = LSSegment.builder().setLoopIdentifierCode("2700").build();
+        segment.setContext(context);
+
+        assertEquals("LS", segment.getSegmentIdentifier());
+        assertEquals("2700", segment.getLoopIdentifierCode());
+        assertEquals("LS*2700~", segment.render().trim());
+    }
+
+    @Test
+    void rejectsMissingLoopIdentifier() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> LSSegment.builder().build());
+        assertTrue(ex.getMessage().contains("LS01"));
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/segments/LXSegmentTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/segments/LXSegmentTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LXSegmentTest {
+    private final X834Context context = new X834Context();
+
+    @Test
+    void rendersAssignedNumber() throws ValidationException {
+        LXSegment segment = LXSegment.builder().setAssignedNumber(1).build();
+        segment.setContext(context);
+
+        assertEquals("LX", segment.getSegmentIdentifier());
+        assertEquals(1, segment.getAssignedNumber());
+        assertEquals("LX*1~", segment.render().trim());
+    }
+
+    @Test
+    void rejectsNonPositiveAssignedNumber() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> LXSegment.builder().setAssignedNumber(0).build());
+        assertTrue(ex.getMessage().contains("LX01"));
+    }
+}


### PR DESCRIPTION
Part of #139

First slice of #139 — the member loop's missing, carrier-demanded structures.

## What

Adds the **2700/2710/2750 Member Reporting Categories** loop: an `LS*2700` … `LE*2700` block wrapping one `LX` / `N1*75` / `REF` (/ optional `DTP`) occurrence per category. The category *name* rides the `N1*75` segment (N102); its *value* rides the following `REF` under a qualifier that defaults to `ZZ` (Mutually Defined). Reproduces the BCBSM companion-guide example:

```
LS*2700~
LX*1~
N1*75*INDIVIDUALREPNAME~
REF*ZZ*JOHN DOE~
LX*2~
N1*75*RELATIONSHIP~
REF*ZZ*4~
LE*2700~
```

This is the library's first **config-driven repeating loop** — the set of occurrences comes from configuration (the reporting categories a member carries), not from a data row like a dependent or a coverage. The whole block is suppressed when a member has none, and the `LX` assigned number is counted at render time over the emitted occurrences.

## Changes

- **New segments** `LS` (loop header), `LE` (loop trailer), `LX` (assigned number).
- **`MemberReportingCategoryName`** — the concrete `N1*75` party segment (N101 fixed to `75` Participant, N102 = category name).
- **`ReportingCategory`** — a pure domain value on `BaseMember` (name, reference qualifier defaulting to `ZZ`, value, optional date + date qualifier).
- **`X834MemberWriter`** emits the block after the member's 2300 segments.

## Prerequisites cleared along the way

- `EntityIdentifierCode` gains `75` "Participant" — a missing TR3 qualifier of exactly the class audited in #138 / research doc 0617.
- `N1Segment.getElementValues()` guarded against a null `N103` — a 2750 `N1` carries only N101/N102, so the unguarded `n103.getCode()` (the "N1 NPE" listed in #138) would have thrown. This also makes any N102-only `N1` safe.

## Tests

2013 pass, full reactor green. New: `LS`/`LE`/`LX` segment tests, and writer tests covering the BCBSM two-occurrence example, block suppression when empty, ordering after the 2100 segments, the optional `DTP`, and a non-default REF qualifier.

## Not in this slice

The remaining #139 structures (`PER`, 2310, 2320/2330 COB, 2200 `DSB`, `LUI`, `HLH`) are follow-on slices, each pulled by its own carrier demand. The REF-qualifier enum is also incomplete (`17` is missing) — the same `fromString`-funnel class 0617 catalogued; that qualifier-completeness axis is left to #139 / #138 rather than widened here.

Related: #139 (parent), #138 (emission-correctness bugs incl. the N1 NPE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
