### PR TITLE
refactor(x834): single failure-reporting channel for 834 generation (#163)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/GenerationError.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/GenerationError.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834;
+
+import java.util.Objects;
+
+/**
+ * A single, structured reason an {@link X834Document} could not be generated.
+ *
+ * <p>Every failure carries a {@link Phase} (was the structure invalid before serialization, or did
+ * a value fail to serialize), a free-form {@code location} label naming where it arose (a component
+ * like {@code "Header"} or {@code "Member[3]"}, or a segment identifier like {@code "HD"}), and a
+ * human-readable {@code message}. Consumers enumerate these off a {@link GenerationResult.Failure}
+ * rather than parsing a flattened exception string.
+ */
+public record GenerationError(Phase phase, String location, String message) {
+
+    public GenerationError {
+        Objects.requireNonNull(phase, "phase");
+        Objects.requireNonNull(location, "location");
+        Objects.requireNonNull(message, "message");
+    }
+
+    /** The generation stage a {@link GenerationError} arose in. */
+    public enum Phase {
+        /** The document's structure or configuration was invalid before serialization was attempted. */
+        BUILD,
+        /** A value could not be serialized into a conformant X12 segment. */
+        RENDER
+    }
+
+    /** A single-line rendering — {@code PHASE | location | message} — for log and exception surfaces. */
+    public String formatted() {
+        return phase + " | " + location + " | " + message;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/GenerationResult.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/GenerationResult.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834;
+
+import java.util.List;
+
+/**
+ * The outcome of {@link X834Document#generateDocument()}: <em>either</em> the finished X12 834
+ * <em>or</em> the complete list of reasons it could not be produced — never both, never neither.
+ *
+ * <p>This is the single failure-reporting channel for generation. Rather than throw on the first
+ * problem, generation accumulates every problem it can (all build-time checks, every member's
+ * assembly, every delimiter-unsafe value) into one {@link Failure}, so the source can be fixed in a
+ * single round-trip instead of one failed generation at a time.
+ */
+public sealed interface GenerationResult {
+
+    /** Generation succeeded; {@link #document()} is the complete X12 834 string. */
+    record Success(String document) implements GenerationResult {}
+
+    /** Generation failed; {@link #errors()} lists every reason, accumulated in one pass. */
+    record Failure(List<GenerationError> errors) implements GenerationResult {
+        public Failure {
+            errors = List.copyOf(errors);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/X834Document.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/X834Document.java
@@ -7,31 +7,34 @@
  */
 package com.fastChickensHR.edi.x834;
 
+import com.fastChickensHR.edi.x834.GenerationError.Phase;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.header.Header;
 import com.fastChickensHR.edi.x834.loop2000.Member;
 import com.fastChickensHR.edi.x834.loop2000.X834MemberWriter;
 import com.fastChickensHR.edi.x834.trailer.Trailer;
-import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Represents an EDI 834 document for benefit enrollment and maintenance.
- * This class handles document structure, formatting, and validation.
+ *
+ * <p>Generation reports through exactly one channel: {@link #generateDocument()} returns a
+ * {@link GenerationResult} — {@link GenerationResult.Success} carrying the document, or
+ * {@link GenerationResult.Failure} carrying <em>every</em> reason it could not be produced. There is
+ * no separate {@code isValid()}/{@code getErrors()} accessor and no thrown exception: build-time
+ * (structure/configuration) and render-time (serialization) problems all surface as
+ * {@link GenerationError}s in the {@code Failure}.
  */
-@Getter
 public class X834Document {
     private final Header header;
     private final List<Member> members;
     private final List<Segment> additionalSegments;
-    private final List<String> buildErrors;
-    private final boolean isValid;
+    private final List<GenerationError> buildErrors;
     private final X834Context context;
     private final Trailer.Builder trailerBuilder;
 
@@ -45,53 +48,53 @@ public class X834Document {
         this.header = builder.header;
         this.members = builder.members;
         this.additionalSegments = builder.additionalSegments;
-        this.buildErrors = builder.buildErrors;
-        this.isValid = builder.isValid;
+        this.buildErrors = List.copyOf(builder.buildErrors);
         this.trailerBuilder = builder.trailerBuilder;
     }
 
     /**
-     * Checks if the document is valid
-     *
-     * @return true if the document is valid and can be generated
-     */
-    public boolean isValid() {
-        return isValid;
-    }
-
-    /**
-     * Returns any errors encountered during document building
-     *
-     * @return List of error messages
-     */
-    public List<String> getErrors() {
-        return buildErrors;
-    }
-
-    /**
-     * Generates the complete EDI document string if the document is valid.
+     * Generates the complete EDI 834 document, or reports why it could not be produced.
      * <p>
-     * Segment counts (SE01, GE01, IEA01) are computed automatically from the
-     * rendered document content and injected into the trailer before rendering.
+     * Segment counts (SE01, GE01, IEA01) are computed automatically from the rendered document
+     * content and injected into the trailer before rendering.
+     * <p>
+     * Problems are <em>accumulated, not thrown</em>: build-time structural/configuration failures
+     * (surfaced by {@link Builder#build()}) short-circuit rendering — a document whose structure
+     * never validated cannot be serialized to surface further problems — while within rendering,
+     * each member's assembly and each delimiter-unsafe value is collected independently so a single
+     * call reports every render-time problem at once.
      *
-     * @return An Optional containing the formatted EDI 834 document as a string,
-     * or empty if the document is invalid
+     * @return a {@link GenerationResult.Success} with the formatted 834, or a
+     * {@link GenerationResult.Failure} listing every {@link GenerationError}
      */
-    public Optional<String> generateDocument() throws ValidationException {
-        if (!isValid) {
-            return Optional.empty();
+    public GenerationResult generateDocument() {
+        // Build-time (structure/config) problems short-circuit render: a document whose structure
+        // never validated cannot be serialized to surface further problems.
+        if (!buildErrors.isEmpty()) {
+            return new GenerationResult.Failure(buildErrors);
         }
 
-        // Collect all body segments before the trailer
-        List<Segment> bodySegments = new ArrayList<>();
+        List<GenerationError> errors = new ArrayList<>();
 
+        // Assemble the ordered segment list, collecting — never throwing on — each failure so one
+        // pass reports every problem. Per-member assembly accumulates independently, so a bad
+        // Member[3] and a bad Member[7] both surface from a single generateDocument() call.
+        List<Segment> bodySegments = new ArrayList<>();
         if (header != null) {
-            bodySegments.addAll(header.generateSegments());
+            try {
+                bodySegments.addAll(header.generateSegments());
+            } catch (ValidationException e) {
+                errors.add(new GenerationError(Phase.RENDER, "Header", e.getMessage()));
+            }
         }
 
         X834MemberWriter memberWriter = new X834MemberWriter(context);
-        for (Member member : members) {
-            bodySegments.addAll(memberWriter.toSegments(member));
+        for (int i = 0; i < members.size(); i++) {
+            try {
+                bodySegments.addAll(memberWriter.toSegments(members.get(i)));
+            } catch (ValidationException e) {
+                errors.add(new GenerationError(Phase.RENDER, "Member[" + i + "]", e.getMessage()));
+            }
         }
 
         bodySegments.addAll(additionalSegments);
@@ -100,17 +103,24 @@ public class X834Document {
         // ISA (index 0) and GS (index 1) are outside the ST/SE envelope; +1 for SE itself.
         int transactionSegmentCount = bodySegments.size() - 2 + 1;
 
-        Trailer trailer = trailerBuilder
-                .setNumberOfIncludedSegments(String.valueOf(transactionSegmentCount))
-                .build();
-
         List<Segment> allSegments = new ArrayList<>(bodySegments);
-        allSegments.addAll(trailer.generateSegments());
+        try {
+            Trailer trailer = trailerBuilder
+                    .setNumberOfIncludedSegments(String.valueOf(transactionSegmentCount))
+                    .build();
+            allSegments.addAll(trailer.generateSegments());
+        } catch (ValidationException e) {
+            errors.add(new GenerationError(Phase.RENDER, "Trailer", e.getMessage()));
+        }
 
-        // Guarantee delimiter safety over the exact segment list about to be rendered,
-        // reading each segment's element values through the same accessor render() uses
-        // so this pass cannot drift from what is emitted (#160).
-        validateDelimiterSafety(allSegments);
+        // Guarantee delimiter safety over the exact segment list about to be rendered, reading each
+        // segment's element values through the same accessor render() uses so this pass cannot drift
+        // from what is emitted (#160). Each offending value is collected as its own error.
+        errors.addAll(delimiterViolations(allSegments));
+
+        if (!errors.isEmpty()) {
+            return new GenerationResult.Failure(errors);
+        }
 
         StringBuilder document = new StringBuilder();
         for (Segment segment : allSegments) {
@@ -118,29 +128,28 @@ public class X834Document {
             document.append(segment.render());
         }
 
-        return Optional.of(document.toString());
+        return new GenerationResult.Success(document.toString());
     }
 
     /**
-     * Rejects generation if any element value contains a character X12 reserves as a
-     * structural delimiter under the active {@link X834Context}.
+     * Collects a {@link GenerationError} for every element value that contains a character X12
+     * reserves as a structural delimiter under the active {@link X834Context}.
      * <p>
-     * X12 has no in-band escape mechanism (X12 RFI 2611), so a delimiter appearing inside
-     * an element value can only silently corrupt the interchange — {@code render()} would
-     * concatenate it verbatim, splitting one element or terminating a segment early. Rather
-     * than emit a malformed 834, this pass collects <em>every</em> offending value across the
-     * document and fails with one {@link ValidationException} naming each, so the source data
-     * can be fixed in a single round-trip.
+     * X12 has no in-band escape mechanism (X12 RFI 2611), so a delimiter appearing inside an element
+     * value can only silently corrupt the interchange — {@code render()} would concatenate it
+     * verbatim, splitting one element or terminating a segment early. Rather than emit a malformed
+     * 834, every offending value across the document is reported (each as its own error, located by
+     * segment identifier) so the source data can be fixed in a single round-trip.
      * <p>
-     * The pass inspects the same {@link Segment#getElementValues()} that {@code render()}
-     * concatenates, so it cannot miss or over-report what will actually be emitted. Note: no
-     * segment currently emits a composite (sub-element-delimited) element; if one is ever added,
-     * this guard must be taught to allow the sub-element separator inside that composite value.
+     * The pass inspects the same {@link Segment#getElementValues()} that {@code render()} concatenates,
+     * so it cannot miss or over-report what will actually be emitted. Note: no segment currently emits
+     * a composite (sub-element-delimited) element; if one is ever added, this guard must be taught to
+     * allow the sub-element separator inside that composite value.
      *
      * @param segments the full ordered segment list about to be rendered
-     * @throws ValidationException if one or more element values contain a reserved delimiter
+     * @return one {@link GenerationError} per offending element value, empty if all values are safe
      */
-    private void validateDelimiterSafety(List<Segment> segments) throws ValidationException {
+    private List<GenerationError> delimiterViolations(List<Segment> segments) {
         Map<Character, String> reserved = new LinkedHashMap<>();
         reserved.put(context.getElementSeparator(), "element separator");
         reserved.put(context.getSegmentTerminator(), "segment terminator");
@@ -149,7 +158,7 @@ public class X834Document {
             reserved.putIfAbsent(terminatorChar, "line terminator");
         }
 
-        List<String> violations = new ArrayList<>();
+        List<GenerationError> violations = new ArrayList<>();
         for (Segment segment : segments) {
             String[] values = segment.getElementValues();
             if (values == null) {
@@ -163,21 +172,14 @@ public class X834Document {
                 for (Map.Entry<Character, String> entry : reserved.entrySet()) {
                     int position = value.indexOf(entry.getKey());
                     if (position >= 0) {
-                        violations.add(String.format(
-                                "%s element %02d (\"%s\") contains the %s '%c' at position %d",
-                                segment.getSegmentIdentifier(), i + 1, value,
-                                entry.getValue(), entry.getKey(), position));
+                        violations.add(new GenerationError(Phase.RENDER, segment.getSegmentIdentifier(),
+                                String.format("element %02d (\"%s\") contains the %s '%c' at position %d",
+                                        i + 1, value, entry.getValue(), entry.getKey(), position)));
                     }
                 }
             }
         }
-
-        if (!violations.isEmpty()) {
-            throw new ValidationException(
-                    "Cannot generate 834: element values contain characters X12 reserves as "
-                            + "delimiters, and X12 has no escape mechanism — fix the source data. "
-                            + "Offending values:\n  - " + String.join("\n  - ", violations));
-        }
+        return violations;
     }
 
     /**
@@ -188,10 +190,8 @@ public class X834Document {
         private Trailer.Builder trailerBuilder;
         private final List<Member> members = new ArrayList<>();
         private final List<Segment> additionalSegments = new ArrayList<>();
-        private final List<String> buildErrors = new ArrayList<>();
-        private boolean isValid = true;
+        private final List<GenerationError> buildErrors = new ArrayList<>();
 
-        @Getter
         private final X834Context context;
 
         /**
@@ -276,48 +276,53 @@ public class X834Document {
         }
 
         /**
-         * Builds the final X834Document
+         * Builds the final X834Document, capturing every build-time (structure/configuration)
+         * problem as a {@link Phase#BUILD} {@link GenerationError}. Each component validates
+         * independently so a single {@code build()} surfaces every problem, not just the first to
+         * fail; the errors are then reported through {@link X834Document#generateDocument()}.
          *
          * @return The configured X834Document
          */
         public X834Document build() {
-            // Validate required components
             if (header == null) {
-                buildErrors.add("Header is required");
-                isValid = false;
+                buildErrors.add(new GenerationError(Phase.BUILD, "Header", "Header is required"));
             }
-
             if (trailerBuilder == null) {
-                buildErrors.add("Trailer is required");
-                isValid = false;
+                buildErrors.add(new GenerationError(Phase.BUILD, "Trailer", "Trailer is required"));
             }
-
             if (members.isEmpty()) {
-                buildErrors.add("At least one member is required");
-                isValid = false;
+                buildErrors.add(new GenerationError(Phase.BUILD, "Members", "At least one member is required"));
             }
 
-            // Additional validation
-            try {
-                context.validate();
-
-                if (header != null) {
-                    header.validate();
-                }
-
-                if (trailerBuilder != null) {
-                    trailerBuilder.build().validate();
-                }
-
-                for (Member member : members) {
-                    member.validate();
-                }
-            } catch (ValidationException e) {
-                buildErrors.add("Validation error: " + e.getMessage());
-                isValid = false;
+            // Each component validates independently so a single build() surfaces every
+            // configuration problem, not just the first to throw.
+            validate("Context", context::validate);
+            if (header != null) {
+                validate("Header", header::validate);
+            }
+            if (trailerBuilder != null) {
+                validate("Trailer", () -> trailerBuilder.build().validate());
+            }
+            for (int i = 0; i < members.size(); i++) {
+                validate("Member[" + i + "]", members.get(i)::validate);
             }
 
             return new X834Document(this);
+        }
+
+        /** Run one component's validation, recording any failure as a build-phase error. */
+        private void validate(String location, ValidatingStep step) {
+            try {
+                step.run();
+            } catch (ValidationException e) {
+                buildErrors.add(new GenerationError(Phase.BUILD, location, e.getMessage()));
+            }
+        }
+
+        /** A validation call that may fail with a {@link ValidationException}. */
+        @FunctionalInterface
+        private interface ValidatingStep {
+            void run() throws ValidationException;
         }
     }
 }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -30,6 +30,8 @@ import com.fastChickensHR.edi.x834.segments.Segment;
 import com.fastChickensHR.edi.x834.trailer.Trailer;
 import com.fastChickensHR.edi.x834.X834Context;
 import com.fastChickensHR.edi.x834.X834Document;
+import com.fastChickensHR.edi.x834.GenerationError;
+import com.fastChickensHR.edi.x834.GenerationResult;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -38,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * The 834 implementation of the {@link FileGenerator} seam: serializes a format-neutral
@@ -78,8 +81,15 @@ public final class X834FileGenerator implements FileGenerator {
                 document.addMember(member);
             }
 
-            return document.build().generateDocument().orElseThrow(() ->
-                    new IllegalStateException("834 generation produced no document (validation failed)"));
+            // The FileGenerator seam returns a String, so a failed result surfaces as the seam's
+            // unchecked exception — but carrying every reason, not swallowing them (#123).
+            return switch (document.build().generateDocument()) {
+                case GenerationResult.Success success -> success.document();
+                case GenerationResult.Failure failure -> throw new IllegalStateException(
+                        "Failed to generate 834:\n  - " + failure.errors().stream()
+                                .map(GenerationError::formatted)
+                                .collect(Collectors.joining("\n  - ")));
+            };
         } catch (ValidationException e) {
             throw new IllegalStateException("Failed to generate 834: " + e.getMessage(), e);
         }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/X834DocumentTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/X834DocumentTest.java
@@ -7,7 +7,7 @@
  */
 package com.fastChickensHR.edi.x834;
 
-import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.GenerationError.Phase;
 import com.fastChickensHR.edi.x834.header.Header;
 import com.fastChickensHR.edi.x834.loop2000.Member;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -45,6 +46,15 @@ class X834DocumentTest {
                 .build();
     }
 
+    private Header buildHeaderWithSponsor(String planSponsorName) {
+        return new Header.Builder(context)
+                .setReferenceIdentification("TEST834")
+                .setMasterPolicyNumber("TEST-POL-001")
+                .setPlanSponsorName(planSponsorName)
+                .setPayerName("TEST PAYER")
+                .build();
+    }
+
     private Member buildMinimalMember() {
         Member member = new Member();
         member.setMaintenanceTypeCode(MaintenanceTypeCode.ADDITION);
@@ -53,8 +63,24 @@ class X834DocumentTest {
         return member;
     }
 
+    /** Unwraps a successful generation, failing the test if it did not succeed. */
+    private static String assertSuccess(GenerationResult result) {
+        if (result instanceof GenerationResult.Success success) {
+            return success.document();
+        }
+        return fail("expected successful generation, got: " + result);
+    }
+
+    /** Unwraps a failed generation's error list, failing the test if it actually succeeded. */
+    private static List<GenerationError> assertFailure(GenerationResult result) {
+        if (result instanceof GenerationResult.Failure failure) {
+            return failure.errors();
+        }
+        return fail("expected failed generation, got: " + result);
+    }
+
     @Test
-    void singleMinimalMemberRendersExpected834() throws ValidationException {
+    void singleMinimalMemberRendersExpected834() {
         // The golden pins the whole builder-path document, including the SE01 transaction segment
         // count (ISA/GS sit outside the ST/SE envelope; header + one INS + SE == 8).
         X834Document doc = new X834Document.Builder(context)
@@ -63,14 +89,13 @@ class X834DocumentTest {
                 .addMember(buildMinimalMember())
                 .build();
 
-        assertTrue(doc.isValid(), "Document should be valid");
-        String output = doc.generateDocument().orElseThrow(() -> new AssertionError("document should generate"));
+        String output = assertSuccess(doc.generateDocument());
 
         TestFixtures.assertMatchesGolden("golden/builder-single-minimal-member.834", output);
     }
 
     @Test
-    void multipleMinimalMembersRenderExpected834() throws ValidationException {
+    void multipleMinimalMembersRenderExpected834() {
         // The golden pins a three-member document: SE01 grows by exactly one INS per member, while
         // GE01 and IEA01 stay at 1 — one transaction set inside one functional group inside one interchange.
         X834Document doc = new X834Document.Builder(context)
@@ -81,33 +106,25 @@ class X834DocumentTest {
                 .addMember(buildMinimalMember())
                 .build();
 
-        String output = doc.generateDocument().orElseThrow(() -> new AssertionError("document should generate"));
+        String output = assertSuccess(doc.generateDocument());
 
         TestFixtures.assertMatchesGolden("golden/builder-three-minimal-members.834", output);
     }
 
     @Test
-    void testDocumentRequiresTrailerBuilder() {
+    void missingTrailerFailsWithBuildErrorLocatedAtTrailer() {
         X834Document doc = new X834Document.Builder(context)
                 .withHeader(buildHeader())
                 .addMember(buildMinimalMember())
                 .build();
 
-        assertFalse(doc.isValid(), "Document without trailer should be invalid");
-        assertTrue(doc.getErrors().stream().anyMatch(e -> e.contains("Trailer")));
-    }
-
-    private Header buildHeaderWithSponsor(String planSponsorName) {
-        return new Header.Builder(context)
-                .setReferenceIdentification("TEST834")
-                .setMasterPolicyNumber("TEST-POL-001")
-                .setPlanSponsorName(planSponsorName)
-                .setPayerName("TEST PAYER")
-                .build();
+        List<GenerationError> errors = assertFailure(doc.generateDocument());
+        assertTrue(errors.stream().anyMatch(e -> e.phase() == Phase.BUILD && e.location().equals("Trailer")),
+                "a BUILD-phase error should be located at the Trailer");
     }
 
     @Test
-    void generateRejectsElementSeparatorInAValue() {
+    void rejectsElementSeparatorInAValue() {
         // The default element separator is '*'. A sponsor name carrying it would, unescaped,
         // split one N1 element into two — X12 has no escape mechanism, so generation must reject.
         X834Document doc = new X834Document.Builder(context)
@@ -116,13 +133,16 @@ class X834DocumentTest {
                 .addMember(buildMinimalMember())
                 .build();
 
-        ValidationException ex = assertThrows(ValidationException.class, doc::generateDocument);
-        assertTrue(ex.getMessage().contains("ACME*CORP"), "message should name the offending value");
-        assertTrue(ex.getMessage().contains("element separator"), "message should name the delimiter");
+        List<GenerationError> errors = assertFailure(doc.generateDocument());
+        assertTrue(errors.stream().allMatch(e -> e.phase() == Phase.RENDER), "delimiter violations are render-phase");
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("ACME*CORP")),
+                "an error should name the offending value");
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("element separator")),
+                "an error should name the delimiter");
     }
 
     @Test
-    void generateRejectsSegmentTerminatorInAValue() {
+    void rejectsSegmentTerminatorInAValue() {
         // The default segment terminator is '~'. Embedded in a value it would terminate the
         // segment early, truncating the interchange.
         X834Document doc = new X834Document.Builder(context)
@@ -131,13 +151,14 @@ class X834DocumentTest {
                 .addMember(buildMinimalMember())
                 .build();
 
-        ValidationException ex = assertThrows(ValidationException.class, doc::generateDocument);
-        assertTrue(ex.getMessage().contains("segment terminator"), "message should name the delimiter");
+        List<GenerationError> errors = assertFailure(doc.generateDocument());
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("segment terminator")),
+                "an error should name the delimiter");
     }
 
     @Test
-    void generateAggregatesEveryDelimiterViolationInOneException() {
-        // The pass collects all offending values across the document, so a single run fixes
+    void aggregatesEveryDelimiterViolationInOneResult() {
+        // The pass collects all offending values across the document, so a single run reports
         // them together rather than one failed generation at a time.
         X834Document doc = new X834Document.Builder(context)
                 .withHeader(buildHeaderWithSponsor("ACME*CORP~LLC"))
@@ -145,13 +166,15 @@ class X834DocumentTest {
                 .addMember(buildMinimalMember())
                 .build();
 
-        ValidationException ex = assertThrows(ValidationException.class, doc::generateDocument);
-        assertTrue(ex.getMessage().contains("element separator"), "should report the '*' violation");
-        assertTrue(ex.getMessage().contains("segment terminator"), "should report the '~' violation");
+        List<GenerationError> errors = assertFailure(doc.generateDocument());
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("element separator")),
+                "should report the '*' violation");
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("segment terminator")),
+                "should report the '~' violation");
     }
 
     @Test
-    void generateAcceptsDelimiterFreeValues() {
+    void acceptsDelimiterFreeValues() {
         // A document whose values carry no reserved delimiter still generates normally —
         // the guard rejects only genuine corruption.
         X834Document doc = new X834Document.Builder(context)
@@ -160,6 +183,6 @@ class X834DocumentTest {
                 .addMember(buildMinimalMember())
                 .build();
 
-        assertDoesNotThrow(doc::generateDocument);
+        assertInstanceOf(GenerationResult.Success.class, doc.generateDocument());
     }
 }


### PR DESCRIPTION
Resolves #163 (wayfinder map #159 — outbound 834 emission conformance).

## What

`X834Document` reported generation failure through **three** channels — `isValid()` + `getErrors()`, an empty `Optional` from `generateDocument()`, and a thrown `ValidationException`. This collapses them into **one**: `generateDocument()` returns a sealed `GenerationResult` (`Success(String document)` | `Failure(List<GenerationError>)`).

## Behavior

- **Accumulate, never bail-on-first.** `Failure` carries every problem: each build-time component (`Context`/`Header`/`Trailer`/`Member[i]`) validates independently, each member assembles independently at render time, and the #160 delimiter guard now contributes **one `GenerationError` per offending value** instead of a single thrown exception. Build-time problems short-circuit render (a structure that never validated can't be serialized).
- **Structured errors.** `GenerationError(Phase phase, String location, String message)`, `Phase { BUILD, RENDER }`; `location` is a free-form label (`"Header"`, `"Member[3]"`, `"HD"`).
- **Seam (#123 fix).** `X834FileGenerator.generate()` returns `String`, so a `Failure` becomes the `FileGenerator` seam's `IllegalStateException` — but the message now **enumerates every reason**. Previously the empty Optional was `.orElseThrow()`'d into a generic message and `getErrors()` was swallowed entirely — the #123 bug.
- `ValidationException` stays a checked, library-internal exception (still thrown by `render()`/`validate()`), now caught and collected rather than propagated.

## Verification

Success-path bytes are unchanged, so all goldens hold with **no regeneration**. `X834DocumentTest` rewritten to the result API. Full x834 suite: **3574 tests green.**

## New public types

`GenerationResult`, `GenerationError` (package `com.fastChickensHR.edi.x834`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)