### PR TITLE
docs: consumer-neutral JavaDoc + post-rename vocabulary sweep (#119, #125)

### DIFF
--- a/core/src/main/java/com/fastChickensHR/edi/core/Direction.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/Direction.java
@@ -7,7 +7,10 @@
  */
 package com.fastChickensHR.edi.core;
 
-/** Whether a {@link FileContent} flows into fastChickens (parsed) or out to a vendor (emitted). */
+/**
+ * Whether a {@link FileContent} flows into the consuming application (parsed) or out to a trading
+ * partner (emitted).
+ */
 public enum Direction {
     INBOUND,
     OUTBOUND

--- a/core/src/main/java/com/fastChickensHR/edi/core/FileContent.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/FileContent.java
@@ -12,8 +12,8 @@ import java.util.List;
 /**
  * The format-neutral, fully-resolved file a {@link FileGenerator} serializes (or a {@link FileParser}
  * produces). An ordered tree: file-level {@code fileFields} (header/trailer, once per file) plus
- * one {@link Record} per subject. This is the pivot between the app's requirements engine and a
- * format's dialect — the app speaks only this, and each format interprets the {@link Location}s.
+ * one {@link Record} per subject. This is the pivot between the consuming application and a
+ * format's dialect — the caller speaks only this, and each format interprets the {@link Location}s.
  */
 public record FileContent(Direction direction, List<Field> fileFields, List<Record> records) {
     public FileContent {

--- a/core/src/main/java/com/fastChickensHR/edi/core/FileGenerator.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/FileGenerator.java
@@ -10,9 +10,9 @@ package com.fastChickensHR.edi.core;
 /**
  * The outbound seam: a format's pure serializer. Given a fully-resolved {@link FileContent}, produce
  * the file's text in that format's dialect — interpreting each {@link Location} into its own tokens
- * (834: Location &rarr; loop/segment/element; CSV: Location &rarr; column). Implementations hold no
- * domain logic; all resolution happened upstream in the app's requirements engine. The kernel
- * <em>programs to</em> this interface; the format modules (edi-834, edi-csv) implement it.
+ * (834: Location &rarr; loop/segment/element; delimited: Location &rarr; column). Implementations hold
+ * no domain logic; all resolution happened upstream in the consuming application. The kernel
+ * <em>programs to</em> this interface; the format modules (x834, flatfile) implement it.
  */
 public interface FileGenerator {
     String generate(FileContent file);

--- a/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFileParser.java
+++ b/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFileParser.java
@@ -25,12 +25,12 @@ import java.util.List;
  * The delimited flat-file implementation of the {@link FileParser} seam: reads a header-row delimited
  * file (CSV by default, or any {@link DelimitedFormat}) into a format-neutral {@link FileContent}. A
  * delimited file is the <em>Flat</em> shape — one line per record — so each data row becomes one
- * {@link Record} and each non-empty cell becomes a {@link Field} whose {@link Location} location is the
+ * {@link Record} and each non-empty cell becomes a {@link Field} whose {@link Location} name is the
  * column name.
  *
  * <p>The parser is intentionally dumb: it knows columns and cells, not domain meaning. In a plain flat
  * file every row is a top-level {@link Record} whose fields sit at {@link RecordLevel#RECORD} — the
- * inbound Field Map assigns each column's data element downstream. When the reserved
+ * consuming application assigns each column's data element downstream. When the reserved
  * {@link LinkedRows#RECORD_LEVEL_COLUMN} is present, the parser reconstructs nesting: {@code SUBRECORD}
  * rows attach as children of the {@code RECORD} row they follow, inverting {@link DelimitedFileGenerator}.
  * Empty cells produce no field (absence, not a blank value).

--- a/flatfile/src/test/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFileParserTest.java
+++ b/flatfile/src/test/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFileParserTest.java
@@ -25,7 +25,7 @@ class DelimitedFileParserTest {
     private final DelimitedFileParser parser = new DelimitedFileParser();
 
     @Test
-    void parsesFlatCsvIntoRecordsOfColumnPlacements() {
+    void parsesFlatCsvIntoRecordsOfColumnFields() {
         String csv = "employeeId,firstName,lastName\nE1,Jane,Doe\nE2,John,\n";
 
         FileContent file = parser.parse(csv);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -47,10 +47,10 @@ import java.util.stream.Collectors;
 /**
  * The 834 implementation of the {@link FileGenerator} seam: serializes a format-neutral
  * {@link FileContent} into an X12 834 document. It holds no domain logic — every Value has already
- * been resolved upstream by the app's requirements engine. It only interprets each
+ * been resolved upstream by the consuming application. It only interprets each
  * {@link com.fastChickensHR.edi.core.Location} (via {@link X834Location}) onto the library's own typed
  * builders (`X834Context`, `Header`, `Member`, `HealthCoverage`, `RefSegment`), so the emitted bytes
- * match the legacy converter path by construction.
+ * are by construction what those builders produce.
  *
  * <p>Structure produced: the header/envelope (from file fields), then one {@link Member} per
  * Record (dependents attached as child members), then — after all members, in Record order — each
@@ -275,7 +275,7 @@ public final class X834FileGenerator implements FileGenerator {
                 .build());
     }
 
-    /** Index a Record's non-omitted fields by their location (a built-in position is unique). */
+    /** Index a Record's non-omitted fields by their location (a built-in location is unique). */
     private static Map<String, String> byLocation(List<Field> fields) {
         Map<String, String> map = new LinkedHashMap<>();
         for (Field field : fields) {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
@@ -8,10 +8,10 @@
 package com.fastChickensHR.edi.x834.generate;
 
 /**
- * The 834 dialect's {@code Location.location} vocabulary — the contract between the app (which builds
- * a {@link com.fastChickensHR.edi.core.FileContent}) and {@link X834FileGenerator} (which serializes it).
- * Each constant names <em>where</em> a resolved value goes; the generator maps it onto the library's
- * typed builders so the wire output is identical to the legacy converter path.
+ * The 834 dialect's {@code Location.name} vocabulary — the contract between the consuming application
+ * (which builds a {@link com.fastChickensHR.edi.core.FileContent}) and {@link X834FileGenerator} (which
+ * serializes it). Each constant names <em>where</em> a resolved value goes; the generator maps it onto
+ * the library's own typed builders, so the wire output is exactly what those builders emit.
  *
  * <p>File-level keys feed the envelope/header ({@code fileFields}); member-level keys feed each
  * subscriber/dependent Record. Custom REF extensions use the {@link #REF_EXTENSION_PREFIX} + qualifier

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/INSSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/INSSegment.java
@@ -189,6 +189,7 @@ public abstract class INSSegment extends Segment {
         return getIns13();
     }
 
+    /** Builds the Loop 2000 {@link INSSegment} that opens each member's enrollment loop. */
     @Setter
     @Accessors(chain = true)
     public static class Builder {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/MemberIdentificationNumber.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/MemberIdentificationNumber.java
@@ -29,6 +29,10 @@ public class MemberIdentificationNumber extends RefSegment {
         return new MemberIdentificationNumber.Builder();
     }
 
+    /**
+     * Builds the member-identification REF, defaulting REF01 to
+     * {@link MemberIdentificationNumber#DEFAULT_ENTITY_IDENTIFIER_CODE}.
+     */
     @Accessors(chain = true)
     public static class Builder extends RefSegment.AbstractBuilder<MemberIdentificationNumber.Builder> {
         public Builder() {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/MemberLevelDates.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/MemberLevelDates.java
@@ -23,6 +23,7 @@ public class MemberLevelDates extends DTPSegment {
         super(builder);
     }
 
+    /** Builds a Loop 2000 member-level date DTP — the qualifier (DTP01) selects which date. */
     public static class Builder extends DTPSegment.AbstractBuilder<Builder> {
         public Builder(X834Context context) {
             super();

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/MemberPolicyNumber.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/MemberPolicyNumber.java
@@ -29,6 +29,10 @@ public class MemberPolicyNumber extends RefSegment {
         return new MemberPolicyNumber.Builder();
     }
 
+    /**
+     * Builds the member policy-number REF, defaulting REF01 to
+     * {@link MemberPolicyNumber#DEFAULT_ENTITY_IDENTIFIER_CODE}.
+     */
     @Accessors(chain = true)
     public static class Builder extends RefSegment.AbstractBuilder<MemberPolicyNumber.Builder> {
         public Builder() {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/SubscriberNumber.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/SubscriberNumber.java
@@ -33,6 +33,10 @@ public class SubscriberNumber extends RefSegment {
         return new SubscriberNumber.Builder();
     }
 
+    /**
+     * Builds the subscriber-number REF, defaulting REF01 to
+     * {@link SubscriberNumber#DEFAULT_ENTITY_IDENTIFIER_CODE}.
+     */
     @Accessors(chain = true)
     public static class Builder extends RefSegment.AbstractBuilder<SubscriberNumber.Builder> {
         public Builder() {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberDemographics.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberDemographics.java
@@ -24,6 +24,7 @@ public class MemberDemographics extends DMGSegment {
         super(builder);
     }
 
+    /** Builds the Loop 2100A member DMG; DMG01 (date format) and DMG02 (birth date) are required. */
     public static class Builder extends AbstractBuilder<Builder> {
 
         protected void validate() throws ValidationException {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberName.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberName.java
@@ -30,6 +30,7 @@ public class MemberName extends NM1Segment {
         return new Builder();
     }
 
+    /** Builds the Loop 2100A member NM1, defaulting NM102 to {@link MemberName#PERSON_ENTITY_TYPE}. */
     @Accessors(chain = true)
     public static class Builder extends NM1Segment.AbstractBuilder<MemberName.Builder> {
         public Builder() {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/DTPSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/DTPSegment.java
@@ -169,6 +169,7 @@ public abstract class DTPSegment extends Segment {
         }
     }
 
+    /** Builds a plain {@link DTPSegment} — use a loop-specific subclass when one exists. */
     public static class Builder extends AbstractBuilder<Builder> {
         @Override
         protected Builder self() {

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/generate/X834FileGeneratorTest.java
@@ -34,7 +34,7 @@ class X834FileGeneratorTest {
     private final X834FileGenerator generator = new X834FileGenerator();
 
     @Test
-    void emitsAWellFormed834FromAPlannedFile() {
+    void emitsAWellFormed834FromAFileContent() {
         List<Field> envelope = List.of(
                 file(X834Location.SENDER_ID, "SENDER123"),
                 file(X834Location.RECEIVER_ID, "RECV456"),

--- a/x999/src/main/java/com/fastChickensHR/edi/x999/X999.java
+++ b/x999/src/main/java/com/fastChickensHR/edi/x999/X999.java
@@ -9,7 +9,7 @@ package com.fastChickensHR.edi.x999;
 
 /**
  * The 999 (and 997) acknowledgment dialect's {@code Location.name} vocabulary — the tokens
- * {@link X999FileParser} emits so a consumer (the ack poller) can read the acknowledgment by location,
+ * {@link X999FileParser} emits so a consumer correlating acknowledgments can read one by location,
  * the mirror of how the 834 generator reads its own {@link com.fastChickensHR.edi.core.Location}s.
  *
  * <p>File-level fields describe the acknowledged <em>functional group</em> (the reply is one group per


### PR DESCRIPTION
Doc-only sweep closing the two documentation issues from the #118 fresh-eyes audit. No behavior change; full suite green.

## #125 — public JavaDoc described one private consumer's architecture

This is a public, generic library, but several JavaDocs explained the seams in terms of one consuming application's internals. Rephrased to consumer-neutral language:

| File | Was | Now |
|---|---|---|
| `core/FileContent` | "the pivot between the app's **requirements engine**" | "the pivot between the **consuming application**" |
| `core/FileGenerator` | "resolution happened upstream in the app's **requirements engine**" | "…upstream in the **consuming application**" |
| `core/Direction` | "flows into **fastChickens**" | "flows into the **consuming application**" / "out to a **trading partner**" |
| `x834/X834FileGenerator` | "match the **legacy converter path** by construction" | "are by construction what those builders produce" |
| `x834/X834Location` | "identical to the **legacy converter path**" | "exactly what those builders emit" |
| `flatfile/DelimitedFileParser` | "the inbound **Field Map** assigns…" | "the **consuming application** assigns…" |
| `x999/X999` | "a consumer (**the ack poller**)" | "a consumer **correlating acknowledgments**" |

## #119 — vocabulary residue from the renames

- **Stale module names** — `FileGenerator`: `(edi-834, edi-csv)` → `(x834, flatfile)`. The dialect example in the same sentence now reads "delimited" rather than "CSV", following the #133 `csv` → `flatfile.delimited` hard-rename.
- **`Location.location` → `Location.name`** — `X834Location` and `DelimitedFileParser` both carried the doubled/stale phrasing; `x999/X999` already had it right and is now the shared form.
- **Pre-rename term in a comment** — `X834FileGenerator.byLocation`: "a built-in **position** is unique" → "location".
- **Pre-rename terms in test names** — `emitsAWellFormed834FromAPlannedFile` → `emitsAWellFormed834FromAFileContent`; `parsesFlatCsvIntoRecordsOfColumnPlacements` → `parsesFlatCsvIntoRecordsOfColumnFields`.
- **JavaDoc gaps** — added the 8 missing class-level docs on public inner `Builder`s (`DTPSegment`, `INSSegment`, `MemberIdentificationNumber`, `MemberLevelDates`, `MemberPolicyNumber`, `SubscriberNumber`, `MemberDemographics`, `MemberName`). Each states what it builds and any element it defaults, with `{@link}`s qualified to the enclosing class so they resolve from inside the nested Builder.

As #119 noted, prose use of "emitted" for X12 segments was deliberately left alone — that is normal X12 English, not API-vocabulary drift.

Closes #119
Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)