### PR TITLE
fix(x834): tier EdiEnumLookup registration so aliases cannot shadow constants (#157)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/IdentificationCodeQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/IdentificationCodeQualifier.java
@@ -292,7 +292,6 @@ public enum IdentificationCodeQualifier implements EdiCodeEnum {
                         Map.entry("tax id", EIN),
 
                         Map.entry("zip", ZIP_CODE),
-                        Map.entry("postal code", ZIP_CODE),
 
                         Map.entry("npi", CMS_NPI),
                         Map.entry("national provider identifier", CMS_NPI),

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionSetPurposeCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionSetPurposeCode.java
@@ -131,7 +131,6 @@ public enum TransactionSetPurposeCode implements EdiCodeEnum {
                         Map.entry("copy", DUPLICATE),
                         Map.entry("replicate", DUPLICATE),
 
-                        Map.entry("status update", STATUS),
                         Map.entry("status check", STATUS),
 
                         Map.entry("inquiry", REQUEST),

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MemberDateQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MemberDateQualifier.java
@@ -162,7 +162,6 @@ public enum MemberDateQualifier implements EdiCodeEnum {
                         Map.entry("term", TERMINATION),
                         Map.entry("terminated", TERMINATION),
                         Map.entry("termination date", TERMINATION),
-                        Map.entry("employment end", TERMINATION),
                         Map.entry("separation", TERMINATION),
 
                         Map.entry("qualifying event", COBRA_QUALIFYING_EVENT),

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/util/EdiEnumLookup.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/util/EdiEnumLookup.java
@@ -14,6 +14,26 @@ import java.util.Map;
 /**
  * Utility class that helps with unified enum lookups.
  * Provides a standard way to find enum values from any string input.
+ *
+ * <p>Normalization is lossy by design (lowercase, {@code _}/space/{@code -} stripped), so
+ * near-identical strings collide. Keys are therefore registered in tiers, upholding two invariants:
+ * <b>every constant is reachable by its own name</b>, and <b>every code resolves to a constant that
+ * actually carries that code</b>. A convenience key can never displace either.
+ *
+ * <ol>
+ *   <li><b>Enum names are authoritative</b> — registered first. Two constants whose names normalize
+ *       alike would leave one permanently unreachable, so that throws at construction.</li>
+ *   <li><b>Codes are authoritative but may be shared</b> — several constants legitimately carry one
+ *       X12 code (an enum that names member-level synonyms over a shared code list, say, where the
+ *       wire output is identical either way). The first in declaration order wins. A code that would
+ *       instead resolve to a constant carrying a <em>different</em> code is real ambiguity, and
+ *       throws.</li>
+ *   <li><b>Descriptions are best-effort</b> — registered only when the key is still free. Two
+ *       constants may share one once normalized, since X12 code lists are transcribed verbatim
+ *       ("Long-term Care" vs "Long Term Care"); the loser stays reachable by name and code.</li>
+ *   <li><b>Additional mappings (aliases) are best-effort</b> — likewise free-keys-only, so an alias
+ *       can never displace a constant's own name, code or description.</li>
+ * </ol>
  */
 public final class EdiEnumLookup<T extends Enum<T> & EdiCodeEnum> {
 
@@ -27,6 +47,8 @@ public final class EdiEnumLookup<T extends Enum<T> & EdiCodeEnum> {
      * @param enumClass          the Class object of the enum type
      * @param enumName           the name of the enum type (for error messages)
      * @param additionalMappings optional additional text mappings to enum constants
+     * @throws IllegalArgumentException if two constants would claim the same normalized name, or if
+     *                                  a code would resolve to a constant carrying a different code
      */
     public EdiEnumLookup(Class<T> enumClass, String enumName, Map<String, T> additionalMappings) {
         this.enumClass = enumClass;
@@ -35,18 +57,37 @@ public final class EdiEnumLookup<T extends Enum<T> & EdiCodeEnum> {
         Map<String, T> map = new HashMap<>();
 
         for (T constant : enumClass.getEnumConstants()) {
-            map.put(normalizeText(constant.getCode()), constant);
+            String key = normalizeText(constant.name());
+            T existing = map.putIfAbsent(key, constant);
+            if (existing != null) {
+                throw new IllegalArgumentException(shadowed(constant, "name", constant.name(), key, existing));
+            }
+        }
 
-            map.put(normalizeText(constant.name()), constant);
-            map.put(normalizeText(constant.getDescription()), constant);
+        for (T constant : enumClass.getEnumConstants()) {
+            String key = normalizeText(constant.getCode());
+            T existing = map.putIfAbsent(key, constant);
+            if (existing != null && !existing.getCode().equals(constant.getCode())) {
+                throw new IllegalArgumentException(shadowed(constant, "code", constant.getCode(), key, existing));
+            }
+        }
+
+        for (T constant : enumClass.getEnumConstants()) {
+            map.putIfAbsent(normalizeText(constant.getDescription()), constant);
         }
 
         if (additionalMappings != null) {
             additionalMappings.forEach((key, value) ->
-                    map.put(normalizeText(key), value));
+                    map.putIfAbsent(normalizeText(key), value));
         }
 
         this.lookupMap = Collections.unmodifiableMap(map);
+    }
+
+    private String shadowed(T constant, String kind, String raw, String normalized, T existing) {
+        return enumName + ": " + constant.name() + " " + kind + " '" + raw + "' normalizes to '"
+                + normalized + "', already claimed by " + existing.name()
+                + " — one of them would be unreachable";
     }
 
     /**

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/data/IdentificationCodeQualifierTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/data/IdentificationCodeQualifierTest.java
@@ -34,7 +34,7 @@ class IdentificationCodeQualifierTest {
      * constant's code, name, or description silently collides with another's in the shared lookup map.
      */
     @ParameterizedTest
-    @EnumSource(value = IdentificationCodeQualifier.class, mode = EnumSource.Mode.EXCLUDE, names = "POSTAL_CODE")
+    @EnumSource(IdentificationCodeQualifier.class)
     void resolvesFromCodeNameAndDescription(IdentificationCodeQualifier constant) {
         assertEquals(constant, IdentificationCodeQualifier.fromString(constant.getCode()));
         assertEquals(constant, IdentificationCodeQualifier.fromString(constant.name()));
@@ -42,20 +42,20 @@ class IdentificationCodeQualifierTest {
     }
 
     /**
-     * Surfaced collision (pinned as current behavior, not fixed under this test-only wave): the alias
-     * {@code "postal code" -> ZIP_CODE} normalizes to {@code "postalcode"}, which is exactly what
-     * {@link IdentificationCodeQualifier#POSTAL_CODE}'s enum name normalizes to. Because additional
-     * mappings are applied after the per-constant entries, {@code POSTAL_CODE} is unreachable by its own
-     * name (it resolves to {@link #ZIP_CODE}); its code {@code "AA"} and description still resolve
-     * correctly. Owner follow-up: drop or re-point the ambiguous alias.
+     * Regression for #157: the alias {@code "postal code" -> ZIP_CODE} normalizes to
+     * {@code "postalcode"}, exactly what {@link IdentificationCodeQualifier#POSTAL_CODE}'s enum name
+     * normalizes to. Applied on top of the per-constant entries it made that constant unreachable by
+     * its own name. Aliases are now registered last and only onto free keys, so the name wins; the
+     * shadowing alias has since been removed as the dead entry it became.
      */
     @Test
-    void postalCodeNameIsShadowedByZipCodeAlias() {
+    void postalCodeIsReachableByItsOwnNameNotTheZipAlias() {
         assertEquals(IdentificationCodeQualifier.POSTAL_CODE, IdentificationCodeQualifier.fromString("AA"));
         assertEquals(IdentificationCodeQualifier.POSTAL_CODE,
                 IdentificationCodeQualifier.fromString(IdentificationCodeQualifier.POSTAL_CODE.getDescription()));
-        assertEquals(IdentificationCodeQualifier.ZIP_CODE, IdentificationCodeQualifier.fromString("postal code"));
-        assertEquals(IdentificationCodeQualifier.ZIP_CODE, IdentificationCodeQualifier.fromString("POSTAL_CODE"));
+        assertEquals(IdentificationCodeQualifier.POSTAL_CODE, IdentificationCodeQualifier.fromString("POSTAL_CODE"));
+        assertEquals(IdentificationCodeQualifier.POSTAL_CODE, IdentificationCodeQualifier.fromString("postal code"));
+        assertEquals(IdentificationCodeQualifier.ZIP_CODE, IdentificationCodeQualifier.fromString("zip"));
     }
 
     /** The human-friendly aliases callers actually type resolve to the right constant. */
@@ -78,7 +78,6 @@ class IdentificationCodeQualifierTest {
                 Arguments.of("employer id", IdentificationCodeQualifier.EIN),
                 Arguments.of("tax id", IdentificationCodeQualifier.EIN),
                 Arguments.of("zip", IdentificationCodeQualifier.ZIP_CODE),
-                Arguments.of("postal code", IdentificationCodeQualifier.ZIP_CODE),
                 Arguments.of("npi", IdentificationCodeQualifier.CMS_NPI),
                 Arguments.of("national provider identifier", IdentificationCodeQualifier.CMS_NPI),
                 Arguments.of("upin", IdentificationCodeQualifier.UPIN),

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/data/TransactionSetPurposeCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/data/TransactionSetPurposeCodeTest.java
@@ -32,7 +32,7 @@ class TransactionSetPurposeCodeTest {
      * also guarantees no constant's code, name, or description silently collides with another's.
      */
     @ParameterizedTest
-    @EnumSource(value = TransactionSetPurposeCode.class, mode = EnumSource.Mode.EXCLUDE, names = "STATUS_UPDATE")
+    @EnumSource(TransactionSetPurposeCode.class)
     void resolvesFromCodeNameAndDescription(TransactionSetPurposeCode constant) {
         assertEquals(constant, TransactionSetPurposeCode.fromString(constant.getCode()));
         assertEquals(constant, TransactionSetPurposeCode.fromString(constant.name()));
@@ -40,18 +40,18 @@ class TransactionSetPurposeCodeTest {
     }
 
     /**
-     * Surfaced collision (pinned as current behavior, not fixed under this test-only wave): the alias
-     * {@code "status update" -> STATUS} shadows {@link TransactionSetPurposeCode#STATUS_UPDATE}, whose
-     * own name and description both normalize to {@code "statusupdate"} as well. Because additional
-     * mappings are applied after the per-constant entries, {@code STATUS_UPDATE} is reachable only by
-     * its code {@code "SU"}; by name or description it currently resolves to {@link #STATUS}. Owner
-     * follow-up: drop or re-point the ambiguous alias so {@code STATUS_UPDATE} is reachable by name.
+     * Regression for #157: the alias {@code "status update" -> STATUS} used to be applied on top of the
+     * per-constant entries and so claimed {@code "statusupdate"} — exactly what
+     * {@link TransactionSetPurposeCode#STATUS_UPDATE}'s own name and description normalize to — leaving
+     * that constant reachable only by its code {@code "SU"}. Aliases are now registered last and only
+     * onto free keys, so the constant's own identifiers win and the alias (since removed) could not
+     * displace them even if re-added.
      */
     @Test
-    void statusUpdateNameIsShadowedByStatusAlias() {
+    void statusUpdateIsReachableByItsOwnNameNotTheStatusAlias() {
         assertEquals(TransactionSetPurposeCode.STATUS_UPDATE, TransactionSetPurposeCode.fromString("SU"));
-        assertEquals(TransactionSetPurposeCode.STATUS, TransactionSetPurposeCode.fromString("status update"));
-        assertEquals(TransactionSetPurposeCode.STATUS, TransactionSetPurposeCode.fromString("STATUS_UPDATE"));
+        assertEquals(TransactionSetPurposeCode.STATUS_UPDATE, TransactionSetPurposeCode.fromString("STATUS_UPDATE"));
+        assertEquals(TransactionSetPurposeCode.STATUS_UPDATE, TransactionSetPurposeCode.fromString("status update"));
     }
 
     /** The human-friendly aliases callers actually type resolve to the right constant. */
@@ -84,7 +84,6 @@ class TransactionSetPurposeCodeTest {
                 Arguments.of("verified", TransactionSetPurposeCode.CONFIRMATION),
                 Arguments.of("copy", TransactionSetPurposeCode.DUPLICATE),
                 Arguments.of("replicate", TransactionSetPurposeCode.DUPLICATE),
-                Arguments.of("status update", TransactionSetPurposeCode.STATUS),
                 Arguments.of("status check", TransactionSetPurposeCode.STATUS),
                 Arguments.of("inquiry", TransactionSetPurposeCode.REQUEST),
                 Arguments.of("asking", TransactionSetPurposeCode.REQUEST),

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/MemberDateQualifierTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/data/MemberDateQualifierTest.java
@@ -116,7 +116,7 @@ class MemberDateQualifierTest {
                 Arguments.of("term", MemberDateQualifier.TERMINATION),
                 Arguments.of("terminated", MemberDateQualifier.TERMINATION),
                 Arguments.of("termination date", MemberDateQualifier.TERMINATION),
-                Arguments.of("employment end", MemberDateQualifier.TERMINATION),
+                Arguments.of("employment end", MemberDateQualifier.ELIGIBILITY_END),
                 Arguments.of("separation", MemberDateQualifier.TERMINATION),
                 Arguments.of("qualifying event", MemberDateQualifier.COBRA_QUALIFYING_EVENT),
                 Arguments.of("cobra event", MemberDateQualifier.COBRA_QUALIFYING_EVENT),

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/util/EdiEnumLookupTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/util/EdiEnumLookupTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The registration-tier contract of {@link EdiEnumLookup} (#157). Normalization is lossy — lowercase
+ * with {@code _}, space and {@code -} stripped — so distinct identifiers routinely collide. These
+ * examples pin which one wins, using purpose-built fixture enums rather than a production code list
+ * so the contract stays legible when a real enum's codes change.
+ */
+class EdiEnumLookupTest {
+
+    /**
+     * A constant is always reachable by its own enum name, even when a later alias normalizes to the
+     * same key. This is the shape of the three shadowing bugs #157 was filed for.
+     */
+    @Test
+    void anAliasNeverShadowsAConstantsOwnName() {
+        EdiEnumLookup<Purpose> lookup = new EdiEnumLookup<>(Purpose.class, "Purpose",
+                Map.of("status update", Purpose.STATUS));
+
+        assertEquals(Purpose.STATUS_UPDATE, lookup.fromString("STATUS_UPDATE"));
+        assertEquals(Purpose.STATUS_UPDATE, lookup.fromString("status update"));
+        assertEquals(Purpose.STATUS, lookup.fromString("ST"));
+    }
+
+    /** Nor a constant's own description — descriptions are registered before aliases. */
+    @Test
+    void anAliasNeverShadowsAConstantsOwnDescription() {
+        EdiEnumLookup<Purpose> lookup = new EdiEnumLookup<>(Purpose.class, "Purpose",
+                Map.of("employment end", Purpose.STATUS));
+
+        assertEquals(Purpose.EMPLOYMENT_STOP, lookup.fromString("Employment End"));
+        assertEquals(Purpose.EMPLOYMENT_STOP, lookup.fromString("employment end"));
+    }
+
+    /** An alias whose key is free still resolves — the tiering only blocks displacement. */
+    @Test
+    void aFreeKeyedAliasStillResolves() {
+        EdiEnumLookup<Purpose> lookup = new EdiEnumLookup<>(Purpose.class, "Purpose",
+                Map.of("status check", Purpose.STATUS));
+
+        assertEquals(Purpose.STATUS, lookup.fromString("status check"));
+    }
+
+    /**
+     * Two constants may share one description once normalized — X12 code lists are transcribed
+     * verbatim, so "Long-term Care" and "Long Term Care" legitimately coexist. The first in
+     * declaration order claims the key; the other stays reachable by its code and name.
+     */
+    @Test
+    void aSharedDescriptionLeavesBothConstantsReachableByCodeAndName() {
+        EdiEnumLookup<Care> lookup = new EdiEnumLookup<>(Care.class, "Care", null);
+
+        assertEquals(Care.LONG_TERM_CARE, lookup.fromString("Long-term Care"));
+        assertEquals(Care.LONG_TERM_CARE, lookup.fromString("Long Term Care"));
+
+        assertEquals(Care.LONG_TERM_CARE_LTC, lookup.fromString("LTC"));
+        assertEquals(Care.LONG_TERM_CARE_LTC, lookup.fromString("LONG_TERM_CARE_LTC"));
+        assertEquals(Care.LONG_TERM_CARE, lookup.fromString("AJ"));
+    }
+
+    /**
+     * Several constants may carry one X12 code — an enum that names member-level synonyms over a
+     * shared code list emits identical bytes either way, so the first wins and both keep their names.
+     */
+    @Test
+    void constantsMayShareOneCodeAndStayReachableByName() {
+        EdiEnumLookup<Dates> lookup = new EdiEnumLookup<>(Dates.class, "Dates", null);
+
+        assertEquals(Dates.EFFECTIVE, lookup.fromString("303"));
+        assertEquals(Dates.EFFECTIVE, lookup.fromString("EFFECTIVE"));
+        assertEquals(Dates.MAINTENANCE_EFFECTIVE, lookup.fromString("MAINTENANCE_EFFECTIVE"));
+    }
+
+    /** Two constants whose names normalize alike would leave one unreachable, so construction fails. */
+    @Test
+    void collidingNamesFailFast() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> new EdiEnumLookup<>(CollidingNames.class, "Colliding Names", null));
+
+        assertTrue(thrown.getMessage().contains("unreachable"), thrown.getMessage());
+        assertTrue(thrown.getMessage().contains("Colliding Names"), thrown.getMessage());
+    }
+
+    /** A code resolving to a constant that carries a different code is real ambiguity, not a synonym. */
+    @Test
+    void aCodeThatWouldResolveToADifferentlyCodedConstantFailsFast() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> new EdiEnumLookup<>(CodeShadowsName.class, "Code Shadows Name", null));
+
+        assertTrue(thrown.getMessage().contains("unreachable"), thrown.getMessage());
+    }
+
+    /** Unknown, null and blank input are rejected rather than silently defaulted. */
+    @Test
+    void rejectsUnknownInput() {
+        EdiEnumLookup<Purpose> lookup = new EdiEnumLookup<>(Purpose.class, "Purpose", null);
+
+        assertThrows(IllegalArgumentException.class, () -> lookup.fromString("not-a-real-value"));
+        assertThrows(IllegalArgumentException.class, () -> lookup.fromString(null));
+        assertThrows(IllegalArgumentException.class, () -> lookup.fromString("   "));
+        assertNotNull(lookup.fromString("ST"));
+    }
+
+    private enum Purpose implements EdiCodeEnum {
+        STATUS("ST", "Status"),
+        STATUS_UPDATE("SU", "Status Update"),
+        EMPLOYMENT_STOP("337", "Employment End");
+
+        private final String code;
+        private final String description;
+
+        Purpose(String code, String description) {
+            this.code = code;
+            this.description = description;
+        }
+
+        @Override
+        public String getCode() {
+            return code;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+    }
+
+    private enum Care implements EdiCodeEnum {
+        LONG_TERM_CARE("AJ", "Long-term Care"),
+        LONG_TERM_CARE_LTC("LTC", "Long Term Care");
+
+        private final String code;
+        private final String description;
+
+        Care(String code, String description) {
+            this.code = code;
+            this.description = description;
+        }
+
+        @Override
+        public String getCode() {
+            return code;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+    }
+
+    /** Both constants deliberately carry code {@code 303}, as a synonym layer over a shared code list. */
+    private enum Dates implements EdiCodeEnum {
+        EFFECTIVE("303", "Maintenance Effective"),
+        MAINTENANCE_EFFECTIVE("303", "Maintenance Effective");
+
+        private final String code;
+        private final String description;
+
+        Dates(String code, String description) {
+            this.code = code;
+            this.description = description;
+        }
+
+        @Override
+        public String getCode() {
+            return code;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+    }
+
+    /** {@code ZIP_CODE} and {@code ZIPCODE} both normalize to {@code zipcode}. */
+    private enum CollidingNames implements EdiCodeEnum {
+        ZIP_CODE("AA", "Zip"),
+        ZIPCODE("BB", "Postal");
+
+        private final String code;
+        private final String description;
+
+        CollidingNames(String code, String description) {
+            this.code = code;
+            this.description = description;
+        }
+
+        @Override
+        public String getCode() {
+            return code;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+    }
+
+    /** {@code SU}'s code is claimed by the constant literally named {@code SU}, which carries {@code XX}. */
+    private enum CodeShadowsName implements EdiCodeEnum {
+        SU("XX", "Named like another's code"),
+        STATUS_UPDATE("SU", "Status Update");
+
+        private final String code;
+        private final String description;
+
+        CodeShadowsName(String code, String description) {
+            this.code = code;
+            this.description = description;
+        }
+
+        @Override
+        public String getCode() {
+            return code;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+    }
+}


### PR DESCRIPTION
Fixes the whole class of bug behind #157, rather than only the three instances it listed. Full suite green (3612 tests).

## Root cause

`EdiEnumLookup` built its map by registering every constant's code/name/description, then applying the alias map **on top** — last write wins. Since `normalizeText` lowercases and strips `_`, spaces and `-`, near-identical strings collide, and an alias could silently claim a key that a real constant needed.

## The policy (per the design decision on the issue)

Registration is now tiered, upholding two invariants: **every constant is reachable by its own name**, and **every code resolves to a constant that actually carries that code**.

| Tier | Source | Rule |
|---|---|---|
| 1 | enum names | authoritative — a duplicate throws at construction |
| 2 | codes | authoritative, but **shareable**: several constants may carry one code, first in declaration order wins. A code that would resolve to a *differently-coded* constant throws |
| 3 | descriptions | registered only onto a free key |
| 4 | aliases | registered only onto a free key |

Tier 2 is deliberately not strict. `MemberDateQualifier` is a synonym layer over `DateTimeQualifier`: `EFFECTIVE` and `MAINTENANCE_EFFECTIVE` both carry `303`, and `TERMINATION` and `EXPIRATION` both carry `036` (already commented "Same code as EXPIRATION" in the source). Those emit identical bytes whichever wins, so first-wins is safe and both stay reachable by name. A strict rule would have forced edits to TR3-verbatim code lists that #141 had just made byte-exact.

## Instances

- **`TransactionSetPurposeCode`** — alias `"status update" -> STATUS` claimed `statusupdate`; `STATUS_UPDATE` was reachable only by code `SU`. Fixed.
- **`IdentificationCodeQualifier`** — alias `"postal code" -> ZIP_CODE` shadowed `POSTAL_CODE`'s own name. Fixed.
- **`InsuranceLineCode`** — **already fixed on trunk.** #141's code-list corrections deleted the mislabeled `AJ` "Long-term Care" constant (1205 defines `AJ` as Medicare Risk), leaving a single `LONG_TERM_CARE("LTC", "Long-Term Care")`. Nothing to reconcile; its test needed no exclusion and still passes.
- **`MemberDateQualifier`** — ⚠️ **a fourth instance this change surfaced.** The alias `"employment end" -> TERMINATION` (036, Expiration) was shadowing `ELIGIBILITY_END`'s *own description* — that constant maps to `DateTimeQualifier.EMPLOYMENT_END`, whose description is literally "Employment End" (337). `"employment end"` now resolves to 337, which is also the semantically correct answer.

The three shadowing aliases are removed as the dead entries they became under the new tiering.

## Tests

- The three tests that **pinned** the shadowing as current behavior are inverted into regression tests asserting the constant is now reachable, and their `@EnumSource(mode = EXCLUDE, names = ...)` exclusions are dropped — so the exhaustive code/name/description round-trip now covers **every** constant in those enums.
- New `EdiEnumLookupTest` covers each tier directly against purpose-built fixture enums (rather than a production code list, so the contract stays legible when a real enum's codes change): alias-cannot-shadow-name, alias-cannot-shadow-description, free-keyed-alias-still-resolves, shared-description, shared-code, and the two fail-fast paths.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)