### PR TITLE
fix(flatfile): name headerless cells by position instead of dropping them (#152)

### DIFF
--- a/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFileParser.java
+++ b/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFileParser.java
@@ -34,6 +34,12 @@ import java.util.List;
  * {@link LinkedRows#RECORD_LEVEL_COLUMN} is present, the parser reconstructs nesting: {@code SUBRECORD}
  * rows attach as children of the {@code RECORD} row they follow, inverting {@link DelimitedFileGenerator}.
  * Empty cells produce no field (absence, not a blank value).
+ *
+ * <p><b>Headerless formats</b> ({@link DelimitedFormat#hasHeader()} {@code == false}) have no column
+ * names to read, so cells are addressed by <em>position</em>: the first column is {@code "1"}, the
+ * second {@code "2"}, and so on — 1-based, matching the element numbering the rest of this library
+ * speaks. A headerless file carries no {@link LinkedRows#RECORD_LEVEL_COLUMN} to recognise either, so
+ * it always parses flat; reconstructing nesting requires a header row.
  */
 public final class DelimitedFileParser implements FileParser {
 
@@ -52,13 +58,42 @@ public final class DelimitedFileParser implements FileParser {
     @Override
     public FileContent parse(String raw) {
         try (CSVParser parser = CSVParser.parse(raw == null ? "" : raw, format.parseFormat())) {
-            List<String> headers = parser.getHeaderNames();
-            boolean nested = headers.contains(LinkedRows.RECORD_LEVEL_COLUMN);
-            List<Record> records = nested ? parseNested(parser, headers) : parseFlat(parser, headers);
+            List<Record> records;
+            if (format.hasHeader()) {
+                List<String> headers = parser.getHeaderNames();
+                boolean nested = headers.contains(LinkedRows.RECORD_LEVEL_COLUMN);
+                records = nested ? parseNested(parser, headers) : parseFlat(parser, headers);
+            } else {
+                records = parsePositional(parser);
+            }
             return new FileContent(Direction.INBOUND, List.of(), records);
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to parse delimited file: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Reads a headerless file, naming each cell by its 1-based column position. Rows need not be the
+     * same width — each cell is named by where it actually sits.
+     */
+    private static List<Record> parsePositional(CSVParser parser) {
+        List<Record> records = new ArrayList<>();
+        for (CSVRecord row : parser) {
+            List<Field> fields = new ArrayList<>();
+            for (int i = 0; i < row.size(); i++) {
+                String value = row.get(i);
+                if (value != null && !value.isEmpty()) {
+                    fields.add(new Field(new Location(RecordLevel.RECORD, columnName(i)), value));
+                }
+            }
+            records.add(Record.of(fields));
+        }
+        return records;
+    }
+
+    /** The positional column name for a 0-based index: {@code "1"} for the first column. */
+    private static String columnName(int index) {
+        return String.valueOf(index + 1);
     }
 
     private static List<Record> parseFlat(CSVParser parser, List<String> headers) {

--- a/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFormat.java
+++ b/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFormat.java
@@ -133,6 +133,11 @@ public final class DelimitedFormat {
             return this;
         }
 
+        /**
+         * Whether files in this format carry a leading header row (the default). With {@code false}
+         * the generator omits it and the parser, having no column names to read, addresses cells by
+         * their 1-based position instead — see {@link DelimitedFileParser}.
+         */
         public Builder header(boolean header) {
             this.header = header;
             return this;

--- a/flatfile/src/test/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFormatTest.java
+++ b/flatfile/src/test/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFormatTest.java
@@ -68,15 +68,44 @@ class DelimitedFormatTest {
     }
 
     @Test
-    void headerlessParseCurrentlyDropsAllFields() {
-        // KNOWN BUG (FastChickensHR/edi#152): headerless generate works (above), but headerless parse
-        // has no column names, so every cell is dropped and each row becomes an empty Record — a silent
-        // data-loss asymmetry. Pinned as current behavior (a regression net) until the bug is fixed.
+    void headerlessParseNamesCellsByTheir1BasedColumnPosition() {
+        // Regression for FastChickensHR/edi#152: a headerless file has no column names to read, so
+        // every cell used to be dropped and each row became an empty Record — silent data loss.
+        // Cells are now addressed positionally, 1-based like the element numbering elsewhere.
         DelimitedFormat noHeader = DelimitedFormat.builder().header(false).build();
 
         List<Record> back = new DelimitedFileParser(noHeader).parse("1,Jane\n2,John\n").records();
 
-        assertEquals(List.of(Record.of(List.of()), Record.of(List.of())), back);
+        assertEquals(List.of(
+                Record.of(List.of(f(RECORD, "1", "1"), f(RECORD, "2", "Jane"))),
+                Record.of(List.of(f(RECORD, "1", "2"), f(RECORD, "2", "John")))), back);
+    }
+
+    @Test
+    void headerlessRoundTripsOnceTheColumnsArePositional() {
+        // The asymmetry #152 described is gone: what the headerless parser produces, the headerless
+        // generator writes back byte-identically.
+        DelimitedFormat noHeader = DelimitedFormat.builder().header(false).build();
+        String raw = "1,Jane\n2,John\n";
+
+        FileContent parsed = new DelimitedFileParser(noHeader).parse(raw);
+
+        assertEquals(raw, new DelimitedFileGenerator(noHeader).generate(
+                new FileContent(Direction.OUTBOUND, List.of(), parsed.records())));
+    }
+
+    @Test
+    void headerlessParseNamesEachCellByWhereItActuallySits() {
+        // Ragged rows are named by position, not by the widest row: a short row simply has no field
+        // for the columns it does not reach, and an empty cell stays absent rather than blank.
+        DelimitedFormat noHeader = DelimitedFormat.builder().header(false).build();
+
+        List<Record> back = new DelimitedFileParser(noHeader).parse("1,Jane,x\n2,,\n3\n").records();
+
+        assertEquals(List.of(
+                Record.of(List.of(f(RECORD, "1", "1"), f(RECORD, "2", "Jane"), f(RECORD, "3", "x"))),
+                Record.of(List.of(f(RECORD, "1", "2"))),
+                Record.of(List.of(f(RECORD, "1", "3")))), back);
     }
 
     @Test


### PR DESCRIPTION
Fixes the silent data-loss bug in #152. Full suite green.

## The bug

`DelimitedFormat.parseFormat()` only calls `setHeader().setSkipHeaderRecord(true)` when `header == true`. With `header == false`, Commons CSV parses positional records and `CSVParser.getHeaderNames()` returns an **empty list**. `DelimitedFileParser` then fed that empty list to `rowFields(...)`, whose loop is `for (String column : headers)` — with no headers it never emitted a field. So N data rows became N *empty* `Record`s, with no error.

Headerless **generate** was supported and tested (`headerlessFormatOmitsTheHeaderRow`), so the round trip was asymmetric: a file this module emits headerless could not be read back, and any inbound feed configured headerless lost all data silently.

## The fix

Headerless parse addresses cells by **position**, 1-based:

```java
DelimitedFormat noHeader = DelimitedFormat.builder().header(false).build();
new DelimitedFileParser(noHeader).parse("1,Jane\n2,John\n").records();
// [ Record[ Field(Location(RECORD,"1"), "1"), Field(Location(RECORD,"2"), "Jane") ],
//   Record[ Field(Location(RECORD,"1"), "2"), Field(Location(RECORD,"2"), "John") ] ]
```

1-based per the design decision on the issue: it matches the element numbering the rest of this library already speaks (`ISA01`, `NM102`, `HD05`), rather than introducing a second counting convention.

Each cell is named by **where it actually sits**, not by the widest row — so ragged rows need no padding, a short row simply has no field for columns it does not reach, and an empty cell stays absent rather than blank (consistent with the header-ful path).

A headerless file carries no recognisable `RECORD_LEVEL_COLUMN`, so it always parses flat; reconstructing nesting still requires a header row. That limitation is now documented on both `DelimitedFileParser` and the `DelimitedFormat.header(boolean)` knob rather than being implicit.

## Tests

`headerlessParseCurrentlyDropsAllFields` — which pinned the data loss as a regression net — becomes `headerlessParseNamesCellsByTheir1BasedColumnPosition`, asserting the fix. Joined by:
- `headerlessRoundTripsOnceTheColumnsArePositional` — parse → generate is byte-identical, closing the asymmetry the issue described.
- `headerlessParseNamesEachCellByWhereItActuallySits` — ragged rows and empty cells.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)