### PR TITLE
feat(x834): back generation with the published spec — charset, lengths, code membership (#188)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
@@ -8,6 +8,7 @@
 package com.fastChickensHR.edi.x834;
 
 import com.fastChickensHR.edi.x834.dates.DateFormat;
+import com.fastChickensHR.edi.x834.spec.CharacterClass;
 import com.fastChickensHR.edi.x834.dates.DateFormatter;
 import com.fastChickensHR.edi.x834.dates.TimeFormat;
 import com.fastChickensHR.edi.x834.constants.ElementSeparator;
@@ -60,6 +61,13 @@ public class X834Context {
     private LocalDateTime documentDate;
     private DateFormat dateFormat;
     private TimeFormat timeFormat;
+    /**
+     * The character set this interchange's data may draw from — a property of the interchange, not of
+     * any element, since it is what the receiving partner agreed to accept. Defaults to
+     * {@link CharacterClass#EXTENDED}, the wider of X12's two named sets: narrowing it to
+     * {@link CharacterClass#BASIC} rejects lower case and {@code @}, which some partners require.
+     */
+    private CharacterClass characterClass;
 
     // Constants
     /** Interchange control version (ISA12) for the 5010 release: {@code "00501"}. */
@@ -84,6 +92,7 @@ public class X834Context {
         this.subElementSeparator = SubElementSeparator.GREATER_THAN;
         this.lineTerminator = LineTerminator.LF;
         this.transactionSetControlNumber = "0001";
+        this.characterClass = CharacterClass.EXTENDED;
     }
 
     /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/X834Document.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/X834Document.java
@@ -9,6 +9,9 @@ package com.fastChickensHR.edi.x834;
 
 import com.fastChickensHR.edi.x834.GenerationError.Phase;
 import com.fastChickensHR.edi.x834.segments.Segment;
+import com.fastChickensHR.edi.x834.spec.CharacterClass;
+import com.fastChickensHR.edi.x834.spec.ElementSpec;
+import com.fastChickensHR.edi.x834.spec.X834Spec;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.header.Header;
 import com.fastChickensHR.edi.x834.loop2000.Member;
@@ -19,6 +22,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Represents an EDI 834 document for benefit enrollment and maintenance.
@@ -118,6 +122,11 @@ public class X834Document {
         // from what is emitted (#160). Each offending value is collected as its own error.
         errors.addAll(delimiterViolations(allSegments));
 
+        // Backstop the same segment list against what the standard says about each position it fills:
+        // the interchange's character set, the element's length bounds, and — where the position is
+        // coded — membership of its code list (#188).
+        errors.addAll(specViolations(allSegments));
+
         if (!errors.isEmpty()) {
             return new GenerationResult.Failure(errors);
         }
@@ -180,6 +189,79 @@ public class X834Document {
             }
         }
         return violations;
+    }
+
+    /**
+     * Collects a {@link GenerationError} for every element value that contradicts what
+     * {@link X834Spec} publishes about the position it is being written into.
+     * <p>
+     * Three checks, all driven from the published {@link ElementSpec} rather than hand-written per
+     * segment, so a position is enforced because the standard describes it and not because its builder
+     * happened to take an enum:
+     * <ul>
+     *   <li><strong>Character set</strong> — every value must draw from the interchange's
+     *       {@link X834Context#getCharacterClass() character set}. Applies to every value, including the
+     *       positions this library publishes no spec for, since the set is the partner's agreement about
+     *       the whole interchange.</li>
+     *   <li><strong>Length</strong> — the element's own bounds. A value that has been padded to width
+     *       (the fixed-width ISA elements) satisfies them by construction; one that overruns is reported
+     *       rather than silently truncated at render.</li>
+     *   <li><strong>Code membership</strong> — for a coded position, strictly, via
+     *       {@link ElementSpec#permits}. This is the only enforcement the raw-string positions
+     *       (DMG03, HD03, HD05, NM101) have ever had.</li>
+     * </ul>
+     * <p>
+     * This is a backstop, not a front line: a caller that pre-checks its data per member and holds the
+     * bad record never reaches here. What it guarantees is that a non-conformant 834 is never emitted
+     * silently — the last possible moment to notice, which is exactly where a guarantee belongs.
+     * <p>
+     * A position the library publishes no spec for is character-set checked and otherwise skipped; see
+     * {@link X834Spec} for what is unpublished and why.
+     *
+     * @param segments the full ordered segment list about to be rendered
+     * @return one {@link GenerationError} per offending element value, empty if every value conforms
+     */
+    private List<GenerationError> specViolations(List<Segment> segments) {
+        CharacterClass characterClass = context.getCharacterClass();
+        List<GenerationError> violations = new ArrayList<>();
+        for (Segment segment : segments) {
+            String[] values = segment.getElementValues();
+            if (values == null) {
+                continue;
+            }
+            for (int i = 0; i < values.length; i++) {
+                String value = values[i];
+                if (value == null || value.isEmpty()) {
+                    continue;
+                }
+                int ordinal = i + 1;
+                characterClass.firstViolation(value).ifPresent(position -> violations.add(error(segment, ordinal, value,
+                        "contains '%c' at position %d, which the %s character set does not permit"
+                                .formatted(value.charAt(position), position, characterClass))));
+
+                Optional<ElementSpec> published = X834Spec.atSegment(segment.getSegmentIdentifier(), ordinal);
+                if (published.isEmpty()) {
+                    continue;
+                }
+                ElementSpec spec = published.get();
+                if (value.length() < spec.minLength() || value.length() > spec.maxLength()) {
+                    violations.add(error(segment, ordinal, value,
+                            "is %d characters, outside element %s's %d/%d"
+                                    .formatted(value.length(), spec.elementId(), spec.minLength(), spec.maxLength())));
+                }
+                if (spec.isCoded() && !spec.permits(List.of(value)).ok()) {
+                    violations.add(error(segment, ordinal, value,
+                            "is not a code element %s permits".formatted(spec.elementId())));
+                }
+            }
+        }
+        return violations;
+    }
+
+    /** One violation, located by segment and element the way the delimiter pass locates its own. */
+    private static GenerationError error(Segment segment, int ordinal, String value, String problem) {
+        return new GenerationError(Phase.RENDER, segment.getSegmentIdentifier(),
+                "element %02d (\"%s\") %s".formatted(ordinal, value, problem));
     }
 
     /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/EntityIdentifierCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/EntityIdentifierCode.java
@@ -189,6 +189,8 @@ public enum EntityIdentifierCode implements EdiCodeEnum {
     EMPLOYER("36", "Employer"),
     INFORMATION_SOURCE("ACV", "Information Source"),
     MANAGED_CARE("QK", "Managed Care"),
+    /** NM101 of the 2100C mailing-address loop — the position this library already emits. */
+    POSTAL_MAILING_ADDRESS("31", "Postal Mailing Address"),
     PARTICIPANT("75", "Participant");
 
     private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/spec/X834Spec.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/spec/X834Spec.java
@@ -115,6 +115,44 @@ public final class X834Spec {
         return at(ElementPosition.parse(position));
     }
 
+    /**
+     * The spec for an element ordinal of a segment, <em>without</em> knowing which loop the segment sits
+     * in — what a renderer has to work with, since a segment instance carries its identifier and its
+     * element order but no loop identity ({@code N1} serves 1000A, 1000B and 1000C; {@code N3}/{@code N4}
+     * serve 2100A and 2100C).
+     *
+     * <p>Answers only when every loop publishing that segment ordinal agrees on the element — same
+     * number, name, type, lengths and codes — and empty otherwise. Today they always agree, because a
+     * segment's positions are declared once and reused across its loops; a test pins that. Should a
+     * future loop narrow one, this returns empty rather than guessing, and the position simply goes
+     * unchecked until the caller can supply a loop.
+     *
+     * <p>A composite element answers with its first component ({@code INS06} → the spec at
+     * {@code INS06-1}), which is what the segment renders into that slot while the 834 uses only C052-01.
+     */
+    public static Optional<ElementSpec> atSegment(String segment, int ordinal) {
+        List<ElementSpec> candidates = TABLE.values().stream()
+                .filter(spec -> spec.position().segment().equals(segment) && spec.position().ordinal() == ordinal)
+                .toList();
+        if (candidates.isEmpty()) {
+            return Optional.empty();
+        }
+        ElementSpec first = candidates.getFirst();
+        boolean agree = candidates.stream().allMatch(spec -> describes(spec, first));
+        return agree ? Optional.of(first) : Optional.empty();
+    }
+
+    /** Whether two specs say the same thing about their element, ignoring which position they sit at. */
+    private static boolean describes(ElementSpec one, ElementSpec other) {
+        return one.elementId().equals(other.elementId())
+                && one.name().equals(other.name())
+                && one.type() == other.type()
+                && one.minLength() == other.minLength()
+                && one.maxLength() == other.maxLength()
+                && one.codes().equals(other.codes())
+                && one.position().component() == other.position().component();
+    }
+
     /** Every published spec, in transaction-set order: envelope, header, loops, trailer. */
     public static List<ElementSpec> all() {
         return List.copyOf(TABLE.values());

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/X834DocumentTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/X834DocumentTest.java
@@ -13,6 +13,7 @@ import com.fastChickensHR.edi.x834.loop2000.Member;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.spec.CharacterClass;
 import com.fastChickensHR.edi.x834.testsupport.TestFixtures;
 import com.fastChickensHR.edi.x834.trailer.Trailer;
 import org.junit.jupiter.api.BeforeEach;
@@ -184,5 +185,112 @@ class X834DocumentTest {
                 .build();
 
         assertInstanceOf(GenerationResult.Success.class, doc.generateDocument());
+    }
+
+    @Test
+    void interchangesSpeakTheExtendedCharacterSetUnlessNarrowed() {
+        // The default has to be the wider set: lower case is legal 834 content, and narrowing is the
+        // trading partner's choice to make, not the library's.
+        assertEquals(CharacterClass.EXTENDED, new X834Context().getCharacterClass());
+
+        X834Document doc = new X834Document.Builder(context)
+                .withHeader(buildHeaderWithSponsor("Acme Corp"))
+                .withTrailer(new Trailer.Builder(context))
+                .addMember(buildMinimalMember())
+                .build();
+
+        assertInstanceOf(GenerationResult.Success.class, doc.generateDocument());
+    }
+
+    @Test
+    void rejectsLowerCaseWhenTheInterchangeIsNarrowedToTheBasicSet() {
+        // Some partners accept only the basic set. The same document that generates above must now
+        // fail, naming the offending character and where in the value it sits.
+        context.setCharacterClass(CharacterClass.BASIC);
+        X834Document doc = new X834Document.Builder(context)
+                .withHeader(buildHeaderWithSponsor("Acme Corp"))
+                .withTrailer(new Trailer.Builder(context))
+                .addMember(buildMinimalMember())
+                .build();
+
+        List<GenerationError> errors = assertFailure(doc.generateDocument());
+        assertTrue(errors.stream().allMatch(e -> e.phase() == Phase.RENDER), "character-set violations are render-phase");
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("'c' at position 1")),
+                "an error should name the character and its position, got: " + errors);
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("BASIC")),
+                "an error should name the set that rejected it, got: " + errors);
+    }
+
+    @Test
+    void rejectsAValueLongerThanItsElementPermits() {
+        // NM103 is element 1035, AN 1/60, and nothing on the NM1 builder checks it — this is a
+        // position whose only length enforcement is the published spec.
+        Member member = buildMinimalMember();
+        member.setLastName("D".repeat(61));
+        X834Document doc = new X834Document.Builder(context)
+                .withHeader(buildHeader())
+                .withTrailer(new Trailer.Builder(context))
+                .addMember(member)
+                .build();
+
+        List<GenerationError> errors = assertFailure(doc.generateDocument());
+        assertTrue(errors.stream().anyMatch(e -> e.location().equals("NM1") && e.message().contains("element 1035")),
+                "an error should name the element whose bounds were exceeded, got: " + errors);
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("61 characters")),
+                "an error should say how long the value actually is, got: " + errors);
+    }
+
+    @Test
+    void rejectsACodeTheElementDoesNotPermit() {
+        // DMG03 takes a raw string all the way to the wire: before the spec ring, nothing anywhere
+        // checked that a gender was an element-1068 code.
+        Member member = buildMinimalMember();
+        member.setLastName("DOE");
+        member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
+        member.setGender("Q");
+        X834Document doc = new X834Document.Builder(context)
+                .withHeader(buildHeader())
+                .withTrailer(new Trailer.Builder(context))
+                .addMember(member)
+                .build();
+
+        List<GenerationError> errors = assertFailure(doc.generateDocument());
+        assertTrue(errors.stream().anyMatch(e -> e.location().equals("DMG") && e.message().contains("element 1068")),
+                "an error should name the element whose code list rejected the value, got: " + errors);
+    }
+
+    @Test
+    void acceptsACodeTheElementDoesPermit() {
+        Member member = buildMinimalMember();
+        member.setLastName("DOE");
+        member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
+        member.setGender("F");
+        X834Document doc = new X834Document.Builder(context)
+                .withHeader(buildHeader())
+                .withTrailer(new Trailer.Builder(context))
+                .addMember(member)
+                .build();
+
+        assertInstanceOf(GenerationResult.Success.class, doc.generateDocument());
+    }
+
+    @Test
+    void aggregatesSpecViolationsWithEachOtherAndWithDelimiterViolations() {
+        // One channel, one pass: a caller fixing its data should see every problem at once rather
+        // than one failed generation at a time.
+        Member member = buildMinimalMember();
+        member.setLastName("D".repeat(61));
+        member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
+        member.setGender("Q");
+        X834Document doc = new X834Document.Builder(context)
+                .withHeader(buildHeaderWithSponsor("ACME*CORP"))
+                .withTrailer(new Trailer.Builder(context))
+                .addMember(member)
+                .build();
+
+        List<GenerationError> errors = assertFailure(doc.generateDocument());
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("element separator")), "the delimiter violation");
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("element 1035")), "the length violation");
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("element 1068")), "the code violation");
     }
 }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/spec/X834SpecTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/spec/X834SpecTest.java
@@ -227,6 +227,88 @@ class X834SpecTest {
     }
 
     @Test
+    void everySegmentOrdinalMeansTheSameThingInEveryLoopThatPublishesIt() {
+        // A renderer sees a segment and an element index, never a loop. That is only safe while the
+        // loops agree about each ordinal — so assert it for the whole table rather than assuming it.
+        Map<String, List<ElementSpec>> byPositionWithinSegment = new LinkedHashMap<>();
+        for (ElementSpec spec : X834Spec.all()) {
+            ElementPosition position = spec.position();
+            String key = position.segment() + position.ordinal() + "-" + position.component();
+            byPositionWithinSegment.computeIfAbsent(key, k -> new ArrayList<>()).add(spec);
+        }
+
+        for (Map.Entry<String, List<ElementSpec>> entry : byPositionWithinSegment.entrySet()) {
+            List<ElementSpec> specs = entry.getValue();
+            ElementSpec first = specs.getFirst();
+            for (ElementSpec other : specs) {
+                assertEquals(first.elementId(), other.elementId(), entry.getKey() + " disagrees on element number");
+                assertEquals(first.type(), other.type(), entry.getKey() + " disagrees on type");
+                assertEquals(first.minLength(), other.minLength(), entry.getKey() + " disagrees on min length");
+                assertEquals(first.maxLength(), other.maxLength(), entry.getKey() + " disagrees on max length");
+                assertEquals(first.codes(), other.codes(), entry.getKey() + " disagrees on codes");
+            }
+        }
+    }
+
+    @Test
+    void everyOrdinalIsAnswerableWithoutALoopUnlessItsComponentsDisagree() {
+        Map<Integer, List<ElementSpec>> byOrdinal = new LinkedHashMap<>();
+        for (ElementSpec spec : X834Spec.all()) {
+            byOrdinal.computeIfAbsent(spec.position().ordinal(), k -> new ArrayList<>()).add(spec);
+        }
+
+        for (ElementSpec spec : X834Spec.all()) {
+            String segment = spec.position().segment();
+            int ordinal = spec.position().ordinal();
+            long distinctComponents = byOrdinal.get(ordinal).stream()
+                    .filter(candidate -> candidate.position().segment().equals(segment))
+                    .map(candidate -> candidate.position().component())
+                    .distinct()
+                    .count();
+            Optional<ElementSpec> answer = X834Spec.atSegment(segment, ordinal);
+            if (distinctComponents == 1) {
+                assertTrue(answer.isPresent(), segment + ordinal + " should be answerable without a loop");
+            } else {
+                assertTrue(answer.isEmpty(),
+                        segment + ordinal + " publishes several components, so one flat slot cannot be resolved");
+            }
+        }
+    }
+
+    @Test
+    void atSegmentRefusesAFlatSlotThatCouldHoldSeveralComponents() {
+        // DMG05 is the C056 composite and publishes three components, so a renderer holding only the
+        // flat DMG05 value gets no answer rather than the wrong one. INS06 publishes one, so it does.
+        assertTrue(X834Spec.atSegment("DMG", 5).isEmpty());
+        assertTrue(X834Spec.at("2100A DMG05-1").isPresent(), "the components are still published individually");
+    }
+
+    @Test
+    void atSegmentAnswersForASegmentSharedAcrossLoops() {
+        // N4 is published in 2100A and 2100C; a renderer holding only "N4" element 02 still gets an answer.
+        ElementSpec state = X834Spec.atSegment("N4", 2).orElseThrow();
+
+        assertEquals("156", state.elementId());
+        assertEquals(DataType.ID, state.type());
+    }
+
+    @Test
+    void atSegmentAnswersAComposteSlotWithItsFirstComponent() {
+        // The INS renders C052 into one flat slot, and the 834 uses only its first component.
+        ElementSpec medicarePlan = X834Spec.atSegment("INS", 6).orElseThrow();
+
+        assertEquals("1218", medicarePlan.elementId());
+        assertEquals(1, medicarePlan.position().component());
+    }
+
+    @Test
+    void atSegmentIsEmptyForAnythingUnpublished() {
+        assertTrue(X834Spec.atSegment("AMT", 1).isEmpty(), "a segment nothing emits");
+        assertTrue(X834Spec.atSegment("HD", 2).isEmpty(), "a position Not Used in the 220A1");
+        assertTrue(X834Spec.atSegment("INS", 99).isEmpty(), "an ordinal past the segment");
+    }
+
+    @Test
     void theTableIsImmutable() {
         assertThrows(UnsupportedOperationException.class, () -> X834Spec.all().clear());
         assertThrows(UnsupportedOperationException.class,


### PR DESCRIPTION
Closes #188, and with it the second half of #142. Slice 1 (#186) published the metadata; this drives generation from it.

## The gap

Enforcement was an accident of which builder happened to take an enum: code membership checked only where a setter routed through `Enum.fromString` (and *fuzzily* even there), lengths on a handful of elements, the character set nowhere. The positions partners constrain hardest — **DMG03, HD03, HD05, NM101** — are exactly the ones that take raw strings, so they had no enforcement at all.

## What lands

A pre-render pass beside the existing delimiter guard, walking the same segment list through the same `getElementValues()` that `render()` concatenates, reporting through the same single channel — each offending value its own `GenerationError`, so a caller fixing its data sees every problem in one round-trip.

| Check | Source of truth | Notes |
|---|---|---|
| Character set | `X834Context.characterClass`, default `EXTENDED` | Applies to **every** value, including positions with no published spec — the set is the partner's agreement about the whole interchange |
| Length | `ElementSpec.minLength/maxLength` | BGN02/REF02 stop allowing 80 characters of an element that is AN 1/50 |
| Code membership | `ElementSpec.permits`, strictly | The only enforcement the raw-string positions have ever had |

**Delimiter safety stays a separate rule** (already shipped in #160). A delimiter may not appear in data whatever set the partner picked, and `*` and `:` are `BASIC` members — membership can never be the delimiter check.

`EXTENDED` is the default deliberately: lower case is legal 834 content, and narrowing is the partner's call. A test pins the default alongside the `BASIC` rejection so a future change to it can't pass quietly.

## The loop problem, and how it's resolved

A segment knows its identifier and its element order but **never its loop** — `N1` serves 1000A/1000B/1000C, `N3`/`N4` serve 2100A/2100C. Rather than thread loop identity through ~20 segment classes, the pass resolves positions with `X834Spec.atSegment(segment, ordinal)`, which answers **only when every loop publishing that ordinal agrees** about the element (number, name, type, lengths, codes).

They all agree today — a segment's positions are declared once and reused across its loops — and a test asserts that across the whole table rather than assuming it. If a future loop narrows one, the lookup returns empty and that position goes **unchecked rather than checked wrongly**. Same conservatism for a flat slot that could hold several published components: `DMG05` (the C056 composite, three components) is refused, while `INS06` — where the 834 uses only C052-01 — resolves to that component.

## It earned itself on the first run

The pass rejected **this library's own 2100C mailing address**: `NM101` emits `31` (Postal Mailing Address) and `EntityIdentifierCode` did not carry it. #141 added the six other missing 834 codes (`TV`, `BO`, `IL`, `74`, `36`, `QK`) and missed the one the library itself writes. Added here, verified against the published 005010 element 98.

That is the whole argument for the backstop in one incident: the code list, the emission and the audit all disagreed, and nothing noticed until something checked the wire against the spec.

## Blast radius

**One** existing test changed behaviour across the whole 3686-test suite — the mailing-address golden above — and it was a genuine bug, not a fixture that needed relaxing. Nothing else in the corpus violates the standard it claims to implement.

## Verification

- Full reactor green: **3686 tests**, 12 new.
- Mutation-checked: commenting out the pass fails 4 of the new tests; the earlier version of the agreement test was itself wrong (it grouped composite components together) and the real table caught it.
- New tests cover: default is EXTENDED · BASIC rejects lower case naming the character *and its index* · over-long NM103 naming element 1035 · non-code DMG03 naming element 1068 · the conforming counterpart of each · all three violation kinds aggregating with a delimiter violation in one result · loop-agreement across the table · `atSegment` for shared segments, composites and unpublished positions.

## Scope note

The issue body (written from the research doc's §4) says character-set *and delimiter* safety are checked nowhere. The delimiter half shipped in #160 after that audit was written; only the charset half was missing. Corrected on the issue.

`TextUtils.padRight`'s silent truncation is untouched — it pads, and the length check now catches what it would have truncated, so changing its contract is a separable call.
