### PR TITLE
feat(x834): coordination of benefits, Loop 2320/2330 (#139)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/CoordinationOfBenefitsCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/CoordinationOfBenefitsCode.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.data;
+
+import com.fastChickensHR.edi.x834.util.EdiCodeEnum;
+import com.fastChickensHR.edi.x834.util.EdiEnumLookup;
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * Code values for the X12 Coordination of Benefits Code (data element 1143), which states whether
+ * — and for whom — benefits are coordinated with another plan. In the X12 834 (005010X220A1) it
+ * appears as COB03.
+ *
+ * <p>The two answers carriers actually send sit at opposite ends of this list: BCBSM's Medicare
+ * block sends {@link #COORDINATION_OF_BENEFITS} (benefits are coordinated), while CareFirst sends
+ * {@link #NO_COORDINATION_OF_BENEFITS} on every medical and dental row — {@code COB*U**6~}. Note
+ * that {@link #UNKNOWN} here ({@code 5}) says the <em>coordination</em> is unknown, which is a
+ * different statement from {@link PayerResponsibilitySequenceCode#UNKNOWN} ({@code U}) in COB01
+ * saying the payer's <em>sequence</em> is unknown; CareFirst sends both at once.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a value
+ * from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
+ */
+@Getter
+public enum CoordinationOfBenefitsCode implements EdiCodeEnum {
+    COORDINATION_OF_BENEFITS("1", "Coordination of Benefits"),
+    COORDINATION_OF_BENEFITS_SPOUSE_ONLY("2", "Coordination of Benefits applies to Spouse Only"),
+    COORDINATION_OF_BENEFITS_SPOUSE_AND_DEPENDENTS("3", "Coordination of Benefits applies to Spouse and Dependents"),
+    COORDINATION_OF_BENEFITS_DEPENDENTS_ONLY("4", "Coordination of Benefits applies to Dependents Only"),
+    UNKNOWN("5", "Unknown"),
+    NO_COORDINATION_OF_BENEFITS("6", "No Coordination of Benefits"),
+    COORDINATION_OF_BENEFITS_SUBSCRIBER_ONLY("7", "Coordination of Benefits Applies to Subscriber Only"),
+    CONFLICT_IN_COORDINATION_OF_BENEFIT("8", "Conflict in Coordination of Benefit"),
+    COORDINATION_OF_BENEFITS_WHOLE_FAMILY("9", "Coordination of Benefits Applies to Whole Family");
+
+    private final String code;
+    private final String description;
+    private static final EdiEnumLookup<CoordinationOfBenefitsCode> LOOKUP;
+
+    static {
+        LOOKUP = new EdiEnumLookup<>(
+                CoordinationOfBenefitsCode.class,
+                "Coordination of Benefits Code",
+                Map.ofEntries(
+                        Map.entry("cob", COORDINATION_OF_BENEFITS),
+                        Map.entry("coordinated", COORDINATION_OF_BENEFITS),
+                        Map.entry("none", NO_COORDINATION_OF_BENEFITS),
+                        Map.entry("no cob", NO_COORDINATION_OF_BENEFITS),
+                        Map.entry("whole family", COORDINATION_OF_BENEFITS_WHOLE_FAMILY),
+                        Map.entry("conflict", CONFLICT_IN_COORDINATION_OF_BENEFIT)
+                )
+        );
+    }
+
+    CoordinationOfBenefitsCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    /**
+     * Gets a CoordinationOfBenefitsCode instance from any input string.
+     * Matches against codes, names, descriptions, and common variations.
+     *
+     * @param input the string to look up
+     * @return the matching CoordinationOfBenefitsCode
+     * @throws IllegalArgumentException if no match is found
+     */
+    public static CoordinationOfBenefitsCode fromString(String input) {
+        return LOOKUP.fromString(input);
+    }
+
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
+    @Override
+    public String toString() {
+        return code;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/PayerResponsibilitySequenceCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/PayerResponsibilitySequenceCode.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.data;
+
+import com.fastChickensHR.edi.x834.util.EdiCodeEnum;
+import com.fastChickensHR.edi.x834.util.EdiEnumLookup;
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * Code values for the X12 Payer Responsibility Sequence Number Code (data element 1138), which
+ * identifies a carrier's level of responsibility for paying a claim. In the X12 834
+ * (005010X220A1) it appears as COB01, stating where the other plan sits relative to this one.
+ *
+ * <p>Carriers use a small part of this list and gloss it in their own terms: BCBSM's Medicare
+ * coordination block accepts {@link #PRIMARY} ("Primary (Retired)") and {@link #SECONDARY}
+ * ("Secondary (Employed)"), while CareFirst sends {@link #UNKNOWN} on every row.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a value
+ * from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
+ */
+@Getter
+public enum PayerResponsibilitySequenceCode implements EdiCodeEnum {
+    PAYER_RESPONSIBILITY_FOUR("A", "Payer Responsibility Four"),
+    PAYER_RESPONSIBILITY_FIVE("B", "Payer Responsibility Five"),
+    PAYER_RESPONSIBILITY_SIX("C", "Payer Responsibility Six"),
+    PAYER_RESPONSIBILITY_SEVEN("D", "Payer Responsibility Seven"),
+    PAYER_RESPONSIBILITY_EIGHT("E", "Payer Responsibility Eight"),
+    PAYER_RESPONSIBILITY_NINE("F", "Payer Responsibility Nine"),
+    PAYER_RESPONSIBILITY_TEN("G", "Payer Responsibility Ten"),
+    PAYER_RESPONSIBILITY_ELEVEN("H", "Payer Responsibility Eleven"),
+    UNCONFIRMED("N", "Unconfirmed"),
+    NONCAPITATED_AGREEMENT("O", "Noncapitated Agreement"),
+    PRIMARY("P", "Primary"),
+    SECONDARY("S", "Secondary"),
+    TERTIARY("T", "Tertiary"),
+    UNKNOWN("U", "Unknown");
+
+    private final String code;
+    private final String description;
+    private static final EdiEnumLookup<PayerResponsibilitySequenceCode> LOOKUP;
+
+    static {
+        LOOKUP = new EdiEnumLookup<>(
+                PayerResponsibilitySequenceCode.class,
+                "Payer Responsibility Sequence Number Code",
+                Map.ofEntries(
+                        Map.entry("first", PRIMARY),
+                        Map.entry("second", SECONDARY),
+                        Map.entry("third", TERTIARY)
+                )
+        );
+    }
+
+    PayerResponsibilitySequenceCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    /**
+     * Gets a PayerResponsibilitySequenceCode instance from any input string.
+     * Matches against codes, names, descriptions, and common variations.
+     *
+     * @param input the string to look up
+     * @return the matching PayerResponsibilitySequenceCode
+     * @throws IllegalArgumentException if no match is found
+     */
+    public static PayerResponsibilitySequenceCode fromString(String input) {
+        return LOOKUP.fromString(input);
+    }
+
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
+    @Override
+    public String toString() {
+        return code;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/ReferenceIdentificationQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/ReferenceIdentificationQualifier.java
@@ -109,6 +109,7 @@ public enum ReferenceIdentificationQualifier implements EdiCodeEnum {
     CASE_NUMBER("3H", "Case Number"),
     PERSONAL_IDENTIFICATION_NUMBER("4A", "Personal Identification Number (PIN)"),
     CROSS_REFERENCE_NUMBER("6O", "Cross Reference Number"),
+    GROUP_NUMBER("6P", "Group Number"),
     PERSONAL_ID_NUMBER("ABB", "Personal ID Number"),
     NCPDP_PHARMACY_NUMBER("D3", "National Council for Prescription Drug Programs Pharmacy Number"),
     HEALTH_INSURANCE_CLAIM_NUMBER("F6", "Health Insurance Claim (HIC) Number"),

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -15,6 +15,7 @@ import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication;
+import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits;
 import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import lombok.Getter;
@@ -206,6 +207,32 @@ public abstract class BaseMember {
      */
     public void addCommunication(CommunicationNumberQualifier qualifier, String number) {
         addCommunication(new MemberCommunication(qualifier, number));
+    }
+
+    /**
+     * The other plans this member also holds (Loop 2320/2330). Emitted by {@link X834MemberWriter}
+     * after the member's 2300 coverage segments, one {@code COB}(/{@code REF}/{@code DTP}/2330
+     * {@code NM1}) block per entry. Empty for a member with no other coverage, in which case
+     * nothing is emitted.
+     *
+     * @see #addCoordinationOfBenefits(CoordinationOfBenefits)
+     */
+    private final List<CoordinationOfBenefits> coordinationOfBenefits = new ArrayList<>();
+
+    /**
+     * Adds another plan this member holds (Loop 2320).
+     * <p>
+     * Order is preserved. The 834 permits at most
+     * {@value com.fastChickensHR.edi.x834.loop2000.X834MemberWriter#MAX_COORDINATION_OF_BENEFITS}
+     * occurrences per member; a member carrying more is rejected when written, not silently
+     * truncated.
+     *
+     * @param cob the other coverage to emit (ignored if null)
+     */
+    public void addCoordinationOfBenefits(CoordinationOfBenefits cob) {
+        if (cob != null) {
+            coordinationOfBenefits.add(cob);
+        }
     }
 
     /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -18,6 +18,7 @@ import com.fastChickensHR.edi.x834.segments.RefSegment;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import com.fastChickensHR.edi.x834.X834Context;
 import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
+import com.fastChickensHR.edi.x834.data.DateTimeQualifier;
 import com.fastChickensHR.edi.x834.loop2000.data.BenefitStatusCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberDateQualifier;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication;
@@ -29,6 +30,9 @@ import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceStreetAddre
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingAddress;
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingCityStateZipCode;
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingStreetAddress;
+import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits;
+import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefitsRelatedEntityName;
+import com.fastChickensHR.edi.x834.loop2000.loop2320.MemberCoordinationOfBenefits;
 import com.fastChickensHR.edi.x834.loop2000.loop2700.MemberReportingCategoryName;
 import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
 
@@ -138,6 +142,9 @@ public class X834MemberWriter {
         // dependent's loop begins.
         segments.addAll(member.getAdditionalSegments());
 
+        // Loop 2320/2330 (coordination of benefits), emitted after the 2300 block and before 2700.
+        appendCoordinationOfBenefits(segments, member);
+
         // Loop 2700/2710/2750 (member reporting categories), emitted after the 2300 block.
         appendReportingCategories(segments, member);
     }
@@ -178,6 +185,65 @@ public class X834MemberWriter {
 
     /** LS01/LE01 loop identifier for the Member Reporting Categories loop (2700). */
     private static final String REPORTING_CATEGORY_LOOP_ID = "2700";
+
+    /** The most Loop 2320 occurrences the 834 permits per member. */
+    public static final int MAX_COORDINATION_OF_BENEFITS = 5;
+
+    /**
+     * Loop 2320/2330 (coordination of benefits): per other plan the member holds, a {@code COB}
+     * followed by its optional group-number {@code REF}, its coordination {@code DTP*344}/
+     * {@code DTP*345} dates, and the 2330 {@code NM1} naming that plan. Emitted after the 2300
+     * coverage segments and before the 2700 block, and suppressed entirely when the member has no
+     * other coverage.
+     * <p>
+     * The 834 permits five occurrences. A member carrying more is rejected rather than truncated —
+     * dropping someone's other insurance would produce a file that reads as though they simply do
+     * not have it.
+     */
+    private void appendCoordinationOfBenefits(List<Segment> segments, BaseMember member)
+            throws ValidationException {
+        List<CoordinationOfBenefits> others = member.getCoordinationOfBenefits();
+        if (others.isEmpty()) {
+            return;
+        }
+        if (others.size() > MAX_COORDINATION_OF_BENEFITS) {
+            throw new ValidationException("A member carries at most " + MAX_COORDINATION_OF_BENEFITS
+                    + " coordination-of-benefits loops (2320); got " + others.size());
+        }
+        for (CoordinationOfBenefits other : others) {
+            segments.add(MemberCoordinationOfBenefits.builder()
+                    .setPayerResponsibility(other.getPayerResponsibility())
+                    .setReferenceIdentification(emptyToNull(other.getPolicyIdentifier()))
+                    .setCoordinationOfBenefitsCode(other.getBenefitsCoordination())
+                    .build());
+            if (!isBlank(other.getGroupNumber())) {
+                segments.add(new RefSegment.Builder()
+                        .setReferenceIdentificationQualifier(other.getGroupNumberQualifier())
+                        .setReferenceIdentification(other.getGroupNumber())
+                        .build());
+            }
+            addCobDateSegment(segments, DateTimeQualifier.COORDINATION_OF_BENEFITS_BEGIN, other.getBeginDate());
+            addCobDateSegment(segments, DateTimeQualifier.COORDINATION_OF_BENEFITS_END, other.getEndDate());
+            if (!isBlank(other.getRelatedEntityName())) {
+                segments.add(CoordinationOfBenefitsRelatedEntityName.builder()
+                        .setRelatedEntityName(other.getRelatedEntityName())
+                        .build());
+            }
+        }
+    }
+
+    /** A 2320 coordination date, emitted only when present. */
+    private void addCobDateSegment(List<Segment> segments, DateTimeQualifier qualifier, LocalDateTime date)
+            throws ValidationException {
+        if (date == null) {
+            return;
+        }
+        segments.add(new DTPSegment.Builder()
+                .setDateTimeQualifier(qualifier.getCode())
+                .setDateTimeFormat(DateFormat.D8)
+                .setDateTimePeriod(date, DateFormat.D8)
+                .build());
+    }
 
     /** Loop 2100A NM1 (member name). Emitted when a last name is present. */
     private void appendMemberName(List<Segment> segments, BaseMember member) throws ValidationException {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/CoordinationOfBenefits.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/CoordinationOfBenefits.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2320;
+
+import com.fastChickensHR.edi.x834.data.CoordinationOfBenefitsCode;
+import com.fastChickensHR.edi.x834.data.PayerResponsibilitySequenceCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Another plan this member also holds — one occurrence of Loop 2320 (with its 2330) in the X12 834
+ * (005010X220A1).
+ * <p>
+ * {@link #payerResponsibility} says where that plan sits in the payment order and
+ * {@link #benefitsCoordination} whether benefits are coordinated at all; together they are the
+ * carrier's answer to "does this person have other coverage, and does it pay first?". The rest is
+ * detail about that plan: its {@link #policyIdentifier}, the {@link #groupNumber} it is held under,
+ * the dates the coordination is {@link #beginDate in force}, and the
+ * {@link #relatedEntityName name} of the plan itself.
+ * <p>
+ * The two shapes profiled carriers ask for sit at opposite ends of the range. BCBSM's Medicare
+ * block populates nearly all of it — {@code COB*S*<MBI>*1~}, {@code DTP*344}/{@code 345}, and a
+ * 2330 naming {@code MEDICARE PART A}. CareFirst wants only the bare statement, on every medical
+ * and dental row: {@code COB*U**6~}.
+ * <p>
+ * This is a pure domain object; translation to 834 segments is the writer's job.
+ */
+@Getter
+@Setter
+public class CoordinationOfBenefits {
+
+    /** REF01 qualifier {@code 6P} — Group Number; the default for the 2320 group-number REF. */
+    public static final String DEFAULT_GROUP_NUMBER_QUALIFIER = "6P";
+
+    /** Where the other payer sits in the payment order (COB01) — required. */
+    private PayerResponsibilitySequenceCode payerResponsibility;
+    /** The other plan's policy identifier (COB02); BCBSM carries the Medicare MBI here. */
+    private String policyIdentifier;
+    /** Whether benefits are coordinated, and for whom (COB03). */
+    private CoordinationOfBenefitsCode benefitsCoordination;
+    /** The group number the other plan is held under (2320 {@code REF} REF02). */
+    private String groupNumber;
+    /** The REF qualifier for {@link #groupNumber} (REF01); defaults to {@code 6P}. */
+    private String groupNumberQualifier = DEFAULT_GROUP_NUMBER_QUALIFIER;
+    /** When coordination begins (2320 {@code DTP*344}). */
+    private LocalDateTime beginDate;
+    /** When coordination ends (2320 {@code DTP*345}). */
+    private LocalDateTime endDate;
+    /** The other plan's name (2330 {@code NM1} NM103), e.g. {@code MEDICARE PART A}. */
+    private String relatedEntityName;
+
+    public CoordinationOfBenefits() {
+    }
+
+    /**
+     * @param payerResponsibility  where the other payer sits in the payment order (COB01)
+     * @param benefitsCoordination whether benefits are coordinated, and for whom (COB03)
+     */
+    public CoordinationOfBenefits(PayerResponsibilitySequenceCode payerResponsibility,
+                                  CoordinationOfBenefitsCode benefitsCoordination) {
+        this.payerResponsibility = payerResponsibility;
+        this.benefitsCoordination = benefitsCoordination;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/CoordinationOfBenefitsRelatedEntityName.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/CoordinationOfBenefitsRelatedEntityName.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2320;
+
+import com.fastChickensHR.edi.x834.data.EntityIdentifierCode;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.NM1Segment;
+import lombok.Getter;
+
+/**
+ * The NM1 segment naming the other plan in Loop 2330 of the X12 834 (005010X220A1) — the entity
+ * whose coverage the enclosing 2320 {@code COB} coordinates with.
+ * <p>
+ * NM101 defaults to {@link EntityIdentifierCode#INSURER} ({@code IN}) and NM102 to
+ * {@link #NON_PERSON_ENTITY} ({@code 2}), since the other plan is an organization rather than a
+ * person. NM103 carries its name.
+ * <p>
+ * That name is a carrier-specific literal rather than a code, which is exactly why it is supplied
+ * per occurrence: for the same Medicare concept BCBSM's BCN product wants {@code MEDA}/{@code MEDB},
+ * its Medicare Advantage product wants {@code MEDICARE PART A}/{@code MEDICARE PART B}, and a third
+ * carrier asks for the insurance company's own name.
+ */
+@Getter
+public class CoordinationOfBenefitsRelatedEntityName extends NM1Segment {
+
+    /** NM102 entity type qualifier {@code 2} — Non-Person Entity; the other plan is an organization. */
+    public static final String NON_PERSON_ENTITY = "2";
+
+    private CoordinationOfBenefitsRelatedEntityName(Builder builder) throws ValidationException {
+        super(builder);
+    }
+
+    /** @return NM103 — the other plan's name. */
+    public String getRelatedEntityName() {
+        return getNm103();
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link CoordinationOfBenefitsRelatedEntityName}; NM101 defaults to {@code IN}
+     * (Insurer) and NM102 to {@link #NON_PERSON_ENTITY}.
+     */
+    public static class Builder extends NM1Segment.AbstractBuilder<Builder> {
+        public Builder() {
+            setEntityIdentifierCode(EntityIdentifierCode.INSURER.getCode());
+            setEntityTypeQualifier(NON_PERSON_ENTITY);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        /** Sets NM103 (the other plan's name). */
+        public Builder setRelatedEntityName(String value) {
+            return setLastName(value);
+        }
+
+        @Override
+        public CoordinationOfBenefitsRelatedEntityName build() throws ValidationException {
+            return new CoordinationOfBenefitsRelatedEntityName(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/MemberCoordinationOfBenefits.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/MemberCoordinationOfBenefits.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2320;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.COBSegment;
+import lombok.Getter;
+
+/**
+ * The COB segment that opens Loop 2320 of the X12 834 (005010X220A1) — this member's coordination
+ * with another plan.
+ * <p>
+ * Nothing is defaulted: both answers carriers send are deliberate statements, and guessing either
+ * would put words in a carrier's mouth. BCBSM's Medicare block renders as
+ * {@code COB*S*<MBI>*1~} and CareFirst's every-row form as {@code COB*U**6~}.
+ */
+@Getter
+public class MemberCoordinationOfBenefits extends COBSegment {
+
+    private MemberCoordinationOfBenefits(Builder builder) throws ValidationException {
+        super(builder);
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link MemberCoordinationOfBenefits}. */
+    public static class Builder extends COBSegment.AbstractBuilder<Builder> {
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        @Override
+        public MemberCoordinationOfBenefits build() throws ValidationException {
+            return new MemberCoordinationOfBenefits(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/COBSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/COBSegment.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.data.CoordinationOfBenefitsCode;
+import com.fastChickensHR.edi.x834.data.PayerResponsibilitySequenceCode;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import lombok.Getter;
+
+/**
+ * Represents the COB (Coordination of Benefits) segment in the X12 834 (005010X220A1) Benefit
+ * Enrollment and Maintenance transaction.
+ * <p>
+ * The segment opens Loop 2320 and says how this member's coverage relates to another plan they
+ * also hold: where the other payer sits in the payment order (COB01), that plan's identifier
+ * (COB02), and whether benefits are coordinated at all (COB03).
+ * <p>
+ * Element/position map (data elements per the 834 TR3):
+ * <ul>
+ *     <li>COB01 = payer responsibility sequence number code (1138)</li>
+ *     <li>COB02 = reference identification — the other plan's policy number (127, AN 1/50)</li>
+ *     <li>COB03 = coordination of benefits code (1143)</li>
+ * </ul>
+ * <b>COB04</b> (service type code, element 1365) is <em>not</em> modelled. It is a repeating
+ * element, a shape this library's flat element rendering has no mechanism for, and no profiled
+ * carrier asks for it. Leaving the position unemittable is preferable to emitting it wrongly.
+ * <p>
+ * X12 marks every COB element optional, but a COB carrying no payer responsibility says nothing a
+ * receiver can act on, so COB01 is required here.
+ */
+@Getter
+public abstract class COBSegment extends Segment {
+    public static final String SEGMENT_ID = "COB";
+
+    /** Element 127 is AN 1/50 — a longer policy identifier cannot be represented. */
+    public static final int MAX_REFERENCE_IDENTIFICATION_LENGTH = 50;
+
+    protected final PayerResponsibilitySequenceCode cob01;
+    protected final String cob02;
+    protected final CoordinationOfBenefitsCode cob03;
+
+    protected COBSegment(AbstractBuilder<?> builder) throws ValidationException {
+        this.cob01 = builder.cob01;
+        this.cob02 = builder.cob02;
+        this.cob03 = builder.cob03;
+
+        validate();
+    }
+
+    private void validate() throws ValidationException {
+        if (cob01 == null) {
+            throw new ValidationException("Payer Responsibility Sequence Number Code (COB01) is required");
+        }
+        if (cob02 != null && cob02.length() > MAX_REFERENCE_IDENTIFICATION_LENGTH) {
+            throw new ValidationException("Reference Identification (COB02) must be "
+                    + MAX_REFERENCE_IDENTIFICATION_LENGTH + " characters or less");
+        }
+    }
+
+    @Override
+    public String getSegmentIdentifier() {
+        return SEGMENT_ID;
+    }
+
+    @Override
+    public String[] getElementValues() {
+        return new String[]{
+                cob01.getCode(),
+                cob02,
+                cob03 == null ? null : cob03.getCode()};
+    }
+
+    /** @return COB01 — where the other payer sits in the payment order. */
+    public PayerResponsibilitySequenceCode getPayerResponsibility() {
+        return getCob01();
+    }
+
+    /** @return COB02 — the other plan's policy identifier. */
+    public String getReferenceIdentification() {
+        return getCob02();
+    }
+
+    /** @return COB03 — whether benefits are coordinated, and for whom. */
+    public CoordinationOfBenefitsCode getCoordinationOfBenefitsCode() {
+        return getCob03();
+    }
+
+    /**
+     * Abstract builder for COB segments.
+     *
+     * @param <T> the concrete builder type, for chaining
+     */
+    public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
+        protected PayerResponsibilitySequenceCode cob01;
+        protected String cob02;
+        protected CoordinationOfBenefitsCode cob03;
+
+        protected abstract T self();
+
+        /** Sets COB01 (payer responsibility sequence number code). */
+        public T setPayerResponsibility(PayerResponsibilitySequenceCode value) {
+            this.cob01 = value;
+            return self();
+        }
+
+        /** Sets COB02 (the other plan's policy identifier). */
+        public T setReferenceIdentification(String value) {
+            this.cob02 = value;
+            return self();
+        }
+
+        /** Sets COB03 (coordination of benefits code). */
+        public T setCoordinationOfBenefitsCode(CoordinationOfBenefitsCode value) {
+            this.cob03 = value;
+            return self();
+        }
+
+        /** @return the built segment. */
+        public abstract COBSegment build() throws ValidationException;
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/data/CoordinationOfBenefitsCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/data/CoordinationOfBenefitsCodeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.data;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CoordinationOfBenefitsCodeTest {
+
+    @ParameterizedTest
+    @EnumSource(CoordinationOfBenefitsCode.class)
+    void resolvesFromCodeNameAndDescription(CoordinationOfBenefitsCode constant) {
+        assertEquals(constant, CoordinationOfBenefitsCode.fromString(constant.getCode()));
+        assertEquals(constant, CoordinationOfBenefitsCode.fromString(constant.name()));
+        assertEquals(constant, CoordinationOfBenefitsCode.fromString(constant.getDescription()));
+    }
+
+    @Test
+    void codesAreUnique() {
+        Map<String, CoordinationOfBenefitsCode> byCode = new HashMap<>();
+        for (CoordinationOfBenefitsCode constant : CoordinationOfBenefitsCode.values()) {
+            CoordinationOfBenefitsCode prior = byCode.put(constant.getCode(), constant);
+            assertNull(prior, () -> "duplicate code '" + constant.getCode() + "'");
+        }
+    }
+
+    /** Element 1143 is the complete 1–9 list; the two the profiled carriers send are 1 and 6. */
+    @ParameterizedTest
+    @CsvSource({
+            "1,COORDINATION_OF_BENEFITS",
+            "2,COORDINATION_OF_BENEFITS_SPOUSE_ONLY",
+            "3,COORDINATION_OF_BENEFITS_SPOUSE_AND_DEPENDENTS",
+            "4,COORDINATION_OF_BENEFITS_DEPENDENTS_ONLY",
+            "5,UNKNOWN",
+            "6,NO_COORDINATION_OF_BENEFITS",
+            "7,COORDINATION_OF_BENEFITS_SUBSCRIBER_ONLY",
+            "8,CONFLICT_IN_COORDINATION_OF_BENEFIT",
+            "9,COORDINATION_OF_BENEFITS_WHOLE_FAMILY"})
+    void mapsEachCodeToItsElement1143Meaning(String code, CoordinationOfBenefitsCode expected) {
+        assertEquals(expected, CoordinationOfBenefitsCode.fromString(code));
+    }
+
+    /**
+     * COB03's {@code 5} (coordination unknown) is a different statement from COB01's {@code U}
+     * (payer sequence unknown), and the two elements must not be conflated — CareFirst sends
+     * {@code U} in COB01 alongside {@code 6} in COB03.
+     */
+    @Test
+    void unknownHereIsCob03sFiveNotCob01sU() {
+        assertEquals("5", CoordinationOfBenefitsCode.UNKNOWN.getCode());
+        assertEquals("U", PayerResponsibilitySequenceCode.UNKNOWN.getCode());
+    }
+
+    @Test
+    void toStringIsTheRawCode() {
+        assertEquals("6", CoordinationOfBenefitsCode.NO_COORDINATION_OF_BENEFITS.toString());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "not-a-real-value", "0"})
+    void rejectsNullEmptyAndUnknown(String input) {
+        assertThrows(IllegalArgumentException.class, () -> CoordinationOfBenefitsCode.fromString(input));
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/data/PayerResponsibilitySequenceCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/data/PayerResponsibilitySequenceCodeTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.data;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PayerResponsibilitySequenceCodeTest {
+
+    @ParameterizedTest
+    @EnumSource(PayerResponsibilitySequenceCode.class)
+    void resolvesFromCodeNameAndDescription(PayerResponsibilitySequenceCode constant) {
+        assertEquals(constant, PayerResponsibilitySequenceCode.fromString(constant.getCode()));
+        assertEquals(constant, PayerResponsibilitySequenceCode.fromString(constant.name()));
+        assertEquals(constant, PayerResponsibilitySequenceCode.fromString(constant.getDescription()));
+    }
+
+    @Test
+    void codesAreUnique() {
+        Map<String, PayerResponsibilitySequenceCode> byCode = new HashMap<>();
+        for (PayerResponsibilitySequenceCode constant : PayerResponsibilitySequenceCode.values()) {
+            PayerResponsibilitySequenceCode prior = byCode.put(constant.getCode(), constant);
+            assertNull(prior, () -> "duplicate code '" + constant.getCode() + "'");
+        }
+    }
+
+    /** The complete element 1138 list — note it skips I–M and Q–R. */
+    @ParameterizedTest
+    @CsvSource({
+            "A,PAYER_RESPONSIBILITY_FOUR", "B,PAYER_RESPONSIBILITY_FIVE", "C,PAYER_RESPONSIBILITY_SIX",
+            "D,PAYER_RESPONSIBILITY_SEVEN", "E,PAYER_RESPONSIBILITY_EIGHT", "F,PAYER_RESPONSIBILITY_NINE",
+            "G,PAYER_RESPONSIBILITY_TEN", "H,PAYER_RESPONSIBILITY_ELEVEN", "N,UNCONFIRMED",
+            "O,NONCAPITATED_AGREEMENT", "P,PRIMARY", "S,SECONDARY", "T,TERTIARY", "U,UNKNOWN"})
+    void mapsEachCodeToItsElement1138Meaning(String code, PayerResponsibilitySequenceCode expected) {
+        assertEquals(expected, PayerResponsibilitySequenceCode.fromString(code));
+    }
+
+    /** The three the profiled carriers send: BCBSM's {P, S} and CareFirst's U. */
+    @Test
+    void carriesTheCodesTheProfiledCarriersDemand() {
+        assertEquals("P", PayerResponsibilitySequenceCode.PRIMARY.getCode());
+        assertEquals("S", PayerResponsibilitySequenceCode.SECONDARY.getCode());
+        assertEquals("U", PayerResponsibilitySequenceCode.UNKNOWN.getCode());
+    }
+
+    @Test
+    void toStringIsTheRawCode() {
+        assertEquals("S", PayerResponsibilitySequenceCode.SECONDARY.toString());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "not-a-real-value", "I", "Q"})
+    void rejectsNullEmptyAndUnknown(String input) {
+        assertThrows(IllegalArgumentException.class, () -> PayerResponsibilitySequenceCode.fromString(input));
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
@@ -13,7 +13,11 @@ import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.data.CoordinationOfBenefitsCode;
+import com.fastChickensHR.edi.x834.data.PayerResponsibilitySequenceCode;
+import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits;
 import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
+import com.fastChickensHR.edi.x834.segments.RefSegment;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import org.junit.jupiter.api.Test;
 
@@ -458,6 +462,144 @@ class X834MemberWriterTest {
         ValidationException ex = assertThrows(ValidationException.class, () -> writer.toSegments(member));
 
         assertTrue(ex.getMessage().contains("at most 3"), ex.getMessage());
+    }
+
+    @Test
+    void emitsTheCareFirstEveryRowCobStatement() throws ValidationException {
+        Member member = baseSubscriber();
+        member.addCoordinationOfBenefits(new CoordinationOfBenefits(
+                PayerResponsibilitySequenceCode.UNKNOWN,
+                CoordinationOfBenefitsCode.NO_COORDINATION_OF_BENEFITS));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("COB*U**6~"),
+                () -> "expected CareFirst's bare every-row COB; got:\n" + out);
+    }
+
+    @Test
+    void emitsTheFullBcbsmMedicareCobBlockInLoopOrder() throws ValidationException {
+        // BCBSM's Medicare block: COB, then the group-number REF*6P, the 344/345 coordination
+        // dates, and the 2330 NM1 naming the other plan.
+        Member member = baseSubscriber();
+        CoordinationOfBenefits medicare = new CoordinationOfBenefits(
+                PayerResponsibilitySequenceCode.SECONDARY,
+                CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS);
+        medicare.setPolicyIdentifier("1EG4TE5MK73");
+        medicare.setGroupNumber("GRP001");
+        medicare.setBeginDate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        medicare.setEndDate(LocalDateTime.of(2026, 12, 31, 0, 0));
+        medicare.setRelatedEntityName("MEDICARE PART A");
+        member.addCoordinationOfBenefits(medicare);
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("COB*S*1EG4TE5MK73*1~"), () -> "expected the COB; got:\n" + out);
+        assertTrue(out.contains("REF*6P*GRP001~"), () -> "expected the group-number REF*6P; got:\n" + out);
+        assertTrue(out.contains("DTP*344*D8*20260101~"), () -> "expected COB begin DTP*344; got:\n" + out);
+        assertTrue(out.contains("DTP*345*D8*20261231~"), () -> "expected COB end DTP*345; got:\n" + out);
+        assertTrue(out.contains("NM1*IN*2*MEDICARE PART A~"), () -> "expected the 2330 NM1; got:\n" + out);
+
+        assertTrue(out.indexOf("COB*S") < out.indexOf("REF*6P"), () -> "REF follows COB; got:\n" + out);
+        assertTrue(out.indexOf("REF*6P") < out.indexOf("DTP*344"), () -> "DTP follows REF; got:\n" + out);
+        assertTrue(out.indexOf("DTP*345") < out.indexOf("NM1*IN"), () -> "2330 NM1 closes the loop; got:\n" + out);
+    }
+
+    @Test
+    void emitsTheCobBlockAfterTheCoverageSegmentsAndBeforeTheReportingCategories() throws ValidationException {
+        // 834 loop order: 2300 (HD) → 2320/2330 (COB) → 2700 (reporting categories).
+        Member member = baseSubscriber();
+        member.addSegment(new RefSegment.Builder()
+                .setReferenceIdentificationQualifier("1L")
+                .setReferenceIdentification("PLAN9")
+                .build());
+        member.addCoordinationOfBenefits(new CoordinationOfBenefits(
+                PayerResponsibilitySequenceCode.PRIMARY,
+                CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS));
+        member.addReportingCategory(new ReportingCategory("CLASS", "0042"));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.indexOf("REF*1L*PLAN9") < out.indexOf("COB*P"),
+                () -> "the 2320 block must follow the 2300 segments; got:\n" + out);
+        assertTrue(out.indexOf("COB*P") < out.indexOf("LS*2700"),
+                () -> "the 2320 block must precede the 2700 block; got:\n" + out);
+    }
+
+    @Test
+    void emitsOneBlockPerOtherPlanInOrder() throws ValidationException {
+        // BCBSM repeats the Medicare loop up to twice — Part A and Part B.
+        Member member = baseSubscriber();
+        CoordinationOfBenefits partA = new CoordinationOfBenefits(
+                PayerResponsibilitySequenceCode.PRIMARY, CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS);
+        partA.setRelatedEntityName("MEDA");
+        CoordinationOfBenefits partB = new CoordinationOfBenefits(
+                PayerResponsibilitySequenceCode.SECONDARY, CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS);
+        partB.setRelatedEntityName("MEDB");
+        member.addCoordinationOfBenefits(partA);
+        member.addCoordinationOfBenefits(partB);
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.indexOf("NM1*IN*2*MEDA~") < out.indexOf("NM1*IN*2*MEDB~"),
+                () -> "expected both loops, in the order added; got:\n" + out);
+        assertTrue(out.indexOf("COB*P") < out.indexOf("NM1*IN*2*MEDA~")
+                        && out.indexOf("NM1*IN*2*MEDA~") < out.indexOf("COB*S"),
+                () -> "each 2330 must stay inside its own 2320; got:\n" + out);
+    }
+
+    @Test
+    void omitsTheCobBlockWhenTheMemberHasNoOtherCoverage() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+
+        String out = render(writer.toSegments(member));
+
+        assertFalse(out.contains("COB"),
+                () -> "no 2320 block for a member with no other coverage; got:\n" + out);
+    }
+
+    @Test
+    void omitsTheOptionalCobPartsThatAreAbsent() throws ValidationException {
+        Member member = baseSubscriber();
+        member.addCoordinationOfBenefits(new CoordinationOfBenefits(
+                PayerResponsibilitySequenceCode.PRIMARY,
+                CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS));
+
+        String out = render(writer.toSegments(member));
+
+        assertFalse(out.contains("REF*6P"), () -> "no REF without a group number; got:\n" + out);
+        assertFalse(out.contains("DTP*344"), () -> "no DTP without a begin date; got:\n" + out);
+        assertFalse(out.contains("NM1*IN"), () -> "no 2330 without a related entity name; got:\n" + out);
+    }
+
+    @Test
+    void honorsACustomGroupNumberQualifier() throws ValidationException {
+        Member member = baseSubscriber();
+        CoordinationOfBenefits other = new CoordinationOfBenefits(
+                PayerResponsibilitySequenceCode.PRIMARY, CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS);
+        other.setGroupNumber("SUB77");
+        other.setGroupNumberQualifier("ZZ");
+        member.addCoordinationOfBenefits(other);
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("REF*ZZ*SUB77~"),
+                () -> "expected the caller's own REF qualifier; got:\n" + out);
+    }
+
+    @Test
+    void rejectsMoreOtherPlansThanThe834Permits() throws ValidationException {
+        Member member = baseSubscriber();
+        for (int i = 0; i < X834MemberWriter.MAX_COORDINATION_OF_BENEFITS + 1; i++) {
+            member.addCoordinationOfBenefits(new CoordinationOfBenefits(
+                    PayerResponsibilitySequenceCode.PRIMARY,
+                    CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS));
+        }
+
+        ValidationException ex = assertThrows(ValidationException.class, () -> writer.toSegments(member));
+
+        assertTrue(ex.getMessage().contains("at most 5"), ex.getMessage());
     }
 
     @Test

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2320/MemberCoordinationOfBenefitsTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2320/MemberCoordinationOfBenefitsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2320;
+
+import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.data.CoordinationOfBenefitsCode;
+import com.fastChickensHR.edi.x834.data.PayerResponsibilitySequenceCode;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.COBSegment;
+import com.fastChickensHR.edi.x834.segments.Segment;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MemberCoordinationOfBenefitsTest {
+    private final X834Context context = new X834Context();
+
+    private String render(Segment segment) {
+        segment.setContext(context);
+        return segment.render().trim();
+    }
+
+    @Test
+    void rendersTheCareFirstEveryRowForm() throws ValidationException {
+        // CareFirst puts COB*U**6~ on every medical and dental row: payer sequence unknown, and
+        // explicitly no coordination. COB02 is absent, so the element renders empty rather than
+        // being trimmed away — COB03 after it has to keep its position.
+        COBSegment cob = MemberCoordinationOfBenefits.builder()
+                .setPayerResponsibility(PayerResponsibilitySequenceCode.UNKNOWN)
+                .setCoordinationOfBenefitsCode(CoordinationOfBenefitsCode.NO_COORDINATION_OF_BENEFITS)
+                .build();
+
+        assertEquals("COB*U**6~", render(cob));
+    }
+
+    @Test
+    void rendersTheBcbsmMedicareForm() throws ValidationException {
+        // BCBSM's Medicare block: S for Secondary (Employed), the MBI in COB02, and 1 for
+        // "benefits are coordinated".
+        COBSegment cob = MemberCoordinationOfBenefits.builder()
+                .setPayerResponsibility(PayerResponsibilitySequenceCode.SECONDARY)
+                .setReferenceIdentification("1EG4TE5MK73")
+                .setCoordinationOfBenefitsCode(CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS)
+                .build();
+
+        assertEquals("COB*S*1EG4TE5MK73*1~", render(cob));
+    }
+
+    @Test
+    void trimsTrailingAbsentElements() throws ValidationException {
+        // COB01 alone is a legal statement; the empty COB02/COB03 must not render as "COB*P**~".
+        COBSegment cob = MemberCoordinationOfBenefits.builder()
+                .setPayerResponsibility(PayerResponsibilitySequenceCode.PRIMARY)
+                .build();
+
+        assertEquals("COB*P~", render(cob));
+    }
+
+    @Test
+    void exposesItsElementsByName() throws ValidationException {
+        COBSegment cob = MemberCoordinationOfBenefits.builder()
+                .setPayerResponsibility(PayerResponsibilitySequenceCode.PRIMARY)
+                .setReferenceIdentification("POL123")
+                .setCoordinationOfBenefitsCode(CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS)
+                .build();
+
+        assertEquals("COB", cob.getSegmentIdentifier());
+        assertEquals(PayerResponsibilitySequenceCode.PRIMARY, cob.getPayerResponsibility());
+        assertEquals("POL123", cob.getReferenceIdentification());
+        assertEquals(CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS, cob.getCoordinationOfBenefitsCode());
+    }
+
+    @Test
+    void rejectsACobWithNoPayerResponsibility() {
+        // X12 marks COB01 optional, but a COB saying nothing about payment order is not actionable.
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberCoordinationOfBenefits.builder()
+                        .setCoordinationOfBenefitsCode(CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS)
+                        .build());
+
+        assertTrue(ex.getMessage().contains("COB01"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsAPolicyIdentifierLongerThanElement127Allows() {
+        String tooLong = "X".repeat(COBSegment.MAX_REFERENCE_IDENTIFICATION_LENGTH + 1);
+
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberCoordinationOfBenefits.builder()
+                        .setPayerResponsibility(PayerResponsibilitySequenceCode.PRIMARY)
+                        .setReferenceIdentification(tooLong)
+                        .build());
+
+        assertTrue(ex.getMessage().contains("50"), ex.getMessage());
+    }
+
+    @Test
+    void relatedEntityNamesTheOtherPlanAsANonPersonInsurer() throws ValidationException {
+        // The same Medicare concept is a different literal per carrier — BCN wants MEDA, Medicare
+        // Advantage wants MEDICARE PART A — so the name is supplied, not defaulted.
+        CoordinationOfBenefitsRelatedEntityName entity = CoordinationOfBenefitsRelatedEntityName.builder()
+                .setRelatedEntityName("MEDICARE PART A")
+                .build();
+
+        assertEquals("NM1*IN*2*MEDICARE PART A~", render(entity));
+        assertEquals("MEDICARE PART A", entity.getRelatedEntityName());
+    }
+}


### PR DESCRIPTION
The second follow-on slice of #139. Full suite green.

> ⚠️ **Stack is now 3 deep**: #189 → #190 (PER) → this. Merge in that order; GitHub retargets each automatically. Worth landing the stack before I take another slice.

## Why

`edi` had no way to say a member holds other coverage — no `COB`, no coordination dates, no way to name the other plan. Demand across the profiled guides:

| Carrier | Shape | Source |
|---|---|---|
| CareFirst | `COB*U**6~` on **every** medical and dental row | 0569 — "appears on every coverage in every example" |
| BCBSM Medicare | `COB01 ∈ {P,S}`, `COB02` = MBI, `COB03 = 1`, `DTP*344`/`345`, loop ×2, `REF*6P` group number, 2330 name | 0558 pp. 18, 22 |
| Florida Blue | **retired** COB in 2019 | 0560 |

Florida Blue's retirement is why nothing here is defaulted: whether to emit a COB at all is a carrier answer.

## Grounding

Per the "re-fetch element facts, never trust prose" lesson, I pulled both code lists from the published elements rather than recalling them — and that mattered:

- **Element 1143** is 1–9, and `5` is **"Unknown"** while `6` is **"No Coordination of Benefits"**. CareFirst's `COB*U**6` is therefore *not* "unknown coordination" — it is `U` (payer **sequence** unknown) in COB01 alongside `6` (definitively **no** coordination) in COB03. Two different unknowns in one segment; a test pins that they don't get conflated.
- **Element 1138** is 14 codes and genuinely **skips I–M and Q–R**.
- **`6P` = "Group Number"** in element 128 — see below.

## What

- **`PayerResponsibilitySequenceCode`** (1138) and **`CoordinationOfBenefitsCode`** (1143) — complete lists.
- **`COBSegment`** — COB01/02/03. X12 marks every element optional, but a COB with no payer responsibility says nothing a receiver can act on, so COB01 is required here (documented as a library-level requirement beyond X12).
- **`MemberCoordinationOfBenefits`** (2320) and **`CoordinationOfBenefitsRelatedEntityName`** (2330 `NM1*IN*2*<name>`). The 2330 name is supplied per occurrence, never defaulted — the same Medicare concept is `MEDA` for BCN and `MEDICARE PART A` for Medicare Advantage, which is precisely why it is a carrier answer.
- **`CoordinationOfBenefits`** — the domain value on `BaseMember`, mirroring `ReportingCategory`/`MemberCommunication`.

### `COB04` deliberately not modelled

Service Type Code (element 1365) is a **repeating** element — a shape this library's flat `String[] getElementValues()` has no mechanism for — and no profiled carrier asks for it. Leaving the position unemittable is better than emitting it wrongly, and is consistent with #139's own premise that a question may only exist for a position `edi` can actually emit.

### Drive-by: `ReferenceIdentificationQualifier` was missing `6P`

BCBSM's 2320 group-number `REF*6P` threw `Invalid Reference Identification Qualifier value: 6P` — the enum jumps `6O` → `ABB`. Added `GROUP_NUMBER("6P", "Group Number")`, description verified against the published element 128. Same class of code-list gap #141 corrected.

## Emission

`COB` → optional `REF*6P` → `DTP*344` → `DTP*345` → 2330 `NM1`, one block per other plan, **after the 2300 coverage segments and before the 2700 block** per 834 loop order. Suppressed entirely when the member has none. Five occurrences permitted; a sixth is **rejected**, because dropping someone's other insurance would produce a file that reads as though they simply do not have it.

## Tests

70 new across four classes. Both carrier shapes render byte-exactly, including `COB*U**6~` — where COB02 is empty *between* two present elements, so it must render as an empty element rather than being trimmed (a separate test pins that a trailing absent element *is* trimmed: `COB*P~`).

I mutation-checked the loop-order assertion — emitting the 2320 block after 2700 fails `emitsTheCobBlockAfterTheCoverageSegmentsAndBeforeTheReportingCategories`.

## Note on the merged spec ring

#142 landed on master while this was in flight, and generation now fails on values violating their position. I checked `X834Spec.atSegment`: it is **fail-open** (unknown position → `Optional.empty()` → unchecked), so `COB` will not be rejected post-merge. Publishing the 2320/2330 positions into `X834Spec` is a natural follow-on, not a blocker.

Part of #139 (remaining: 2310, 2200 `DSB`, `LUI`, `HLH`, `ICM`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)