### PR TITLE
feat(x834): member communications PER in Loop 2100A (#139)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/CommunicationNumberQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/CommunicationNumberQualifier.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.data;
+
+import com.fastChickensHR.edi.x834.util.EdiCodeEnum;
+import com.fastChickensHR.edi.x834.util.EdiEnumLookup;
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * Code values for the X12 Communication Number Qualifier (data element 365), which states what
+ * kind of communication number the element that follows it carries. In the X12 834
+ * (005010X220A1) it appears as PER03, PER05 and PER07, each qualifying the number in the
+ * PER04/PER06/PER08 that follows it.
+ *
+ * <p>This is the 834 subset — the qualifiers the TR3 permits on a member communications
+ * {@code PER}. Carriers select from it per product: BCBSM MembersEdge asks for
+ * {@code EM}/{@code HP}/{@code WP} and its Medicare Advantage product for
+ * {@code AP}/{@code CP}/{@code EM}/{@code HP}/{@code TE}, while Anthem sends {@code HP} plus
+ * {@code EM}.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a value
+ * from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
+ */
+@Getter
+public enum CommunicationNumberQualifier implements EdiCodeEnum {
+    ALTERNATE_TELEPHONE("AP", "Alternate Telephone"),
+    CELLULAR_PHONE("CP", "Cellular Phone"),
+    ELECTRONIC_MAIL("EM", "Electronic Mail"),
+    TELEPHONE_EXTENSION("EX", "Telephone Extension"),
+    FACSIMILE("FX", "Facsimile"),
+    HOME_PHONE("HP", "Home Phone Number"),
+    TELEPHONE("TE", "Telephone"),
+    WORK_PHONE("WP", "Work Phone Number");
+
+    private final String code;
+    private final String description;
+    private static final EdiEnumLookup<CommunicationNumberQualifier> LOOKUP;
+
+    static {
+        LOOKUP = new EdiEnumLookup<>(
+                CommunicationNumberQualifier.class,
+                "Communication Number Qualifier",
+                Map.ofEntries(
+                        Map.entry("email", ELECTRONIC_MAIL),
+                        Map.entry("e-mail", ELECTRONIC_MAIL),
+                        Map.entry("home", HOME_PHONE),
+                        Map.entry("work", WORK_PHONE),
+                        Map.entry("office", WORK_PHONE),
+                        Map.entry("cell", CELLULAR_PHONE),
+                        Map.entry("mobile", CELLULAR_PHONE),
+                        Map.entry("fax", FACSIMILE),
+                        Map.entry("phone", TELEPHONE),
+                        Map.entry("extension", TELEPHONE_EXTENSION)
+                )
+        );
+    }
+
+    CommunicationNumberQualifier(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    /**
+     * Gets a CommunicationNumberQualifier instance from any input string.
+     * Matches against codes, names, descriptions, and common variations.
+     *
+     * @param input the string to look up
+     * @return the matching CommunicationNumberQualifier
+     * @throws IllegalArgumentException if no match is found
+     */
+    public static CommunicationNumberQualifier fromString(String input) {
+        return LOOKUP.fromString(input);
+    }
+
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
+    @Override
+    public String toString() {
+        return code;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -7,12 +7,14 @@
  */
 package com.fastChickensHR.edi.x834.loop2000;
 
+import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.loop2000.data.EmploymentStatusCode;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication;
 import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import lombok.Getter;
@@ -69,19 +71,21 @@ public abstract class BaseMember {
     protected LocalDateTime coverageEndDate;
     protected IndividualRelationshipCode relationshipCode;
     /**
-     * The member's telephone number.
+     * The member's telephone number, emitted in the Loop 2100A {@code PER} under
+     * {@link CommunicationNumberQualifier#HOME_PHONE} — the qualifier carriers most often ask for
+     * (Anthem's worked examples send {@code PER*IP**HP*<phone>}).
      *
-     * <p><b>Not serialized.</b> A member's communications contact belongs in a Loop 2100A {@code PER}
-     * segment, and no {@code PER} class exists yet, so no writer emits this — a value set here does
-     * not reach the wire. Kept because the field is the natural home for it once {@code PER} support
-     * lands (FastChickensHR/edi#139).
+     * <p>A convenience for the common case. To send the number under a different qualifier — work,
+     * cellular, alternate — add a {@link MemberCommunication} instead; an explicit communication
+     * for a qualifier takes precedence over this field.
      */
     protected String phoneNumber;
     /**
-     * The member's email address.
+     * The member's email address, emitted in the Loop 2100A {@code PER} under
+     * {@link CommunicationNumberQualifier#ELECTRONIC_MAIL}.
      *
-     * <p><b>Not serialized.</b> See {@link #phoneNumber} — both await Loop 2100A {@code PER}
-     * (FastChickensHR/edi#139).
+     * <p>The same convenience as {@link #phoneNumber}, and overridden the same way by an explicit
+     * {@link MemberCommunication}.
      */
     protected String email;
 
@@ -164,6 +168,45 @@ public abstract class BaseMember {
      * Empty for a member that carries none, in which case no block is emitted.
      */
     private final List<ReportingCategory> reportingCategories = new ArrayList<>();
+
+    /**
+     * This member's communication numbers (Loop 2100A {@code PER}). Emitted by
+     * {@link X834MemberWriter} as a single {@code PER} carrying one qualifier/number pair per
+     * entry, after the member's {@code NM1}. Empty for a member that carries none, in which case
+     * no {@code PER} is emitted.
+     *
+     * @see #addCommunication(MemberCommunication)
+     */
+    private final List<MemberCommunication> communications = new ArrayList<>();
+
+    /**
+     * Adds a way to reach this member (Loop 2100A {@code PER}).
+     * <p>
+     * Order is preserved and determines which element pair each occupies — the first added
+     * becomes PER03/04, then PER05/06, then PER07/08. An explicit communication takes precedence
+     * over the {@link #phoneNumber}/{@link #email} conveniences when both name the same
+     * qualifier. The 834 permits at most
+     * {@value com.fastChickensHR.edi.x834.segments.PERSegment#MAX_COMMUNICATION_PAIRS} per
+     * member; a member carrying more is rejected when written, not silently truncated.
+     *
+     * @param communication the communication number to emit (ignored if null)
+     */
+    public void addCommunication(MemberCommunication communication) {
+        if (communication != null) {
+            communications.add(communication);
+        }
+    }
+
+    /**
+     * Adds a way to reach this member — convenience for
+     * {@link #addCommunication(MemberCommunication)}.
+     *
+     * @param qualifier what kind of number this is (PER03/05/07)
+     * @param number    the number itself (PER04/06/08)
+     */
+    public void addCommunication(CommunicationNumberQualifier qualifier, String number) {
+        addCommunication(new MemberCommunication(qualifier, number));
+    }
 
     /**
      * Adds a reporting category (one Loop 2710/2750 occurrence) to this member. Order is

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -17,8 +17,11 @@ import com.fastChickensHR.edi.x834.segments.LXSegment;
 import com.fastChickensHR.edi.x834.segments.RefSegment;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
 import com.fastChickensHR.edi.x834.loop2000.data.BenefitStatusCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberDateQualifier;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunicationsNumbers;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberDemographics;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberName;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceCityStateZipCode;
@@ -118,10 +121,11 @@ public class X834MemberWriter {
         addDateSegment(segments, MemberDateQualifier.COVERAGE_BEGIN, member.getCoverageStartDate());
         addDateSegment(segments, MemberDateQualifier.COVERAGE_END, member.getCoverageEndDate());
 
-        // Loop 2100A (member detail): NM1 name, N3/N4 residence address, DMG demographics —
-        // in the order required by the 834 spec. Each is emitted only when its source data is
-        // present, so a member carrying only INS-level data renders exactly as before.
+        // Loop 2100A (member detail): NM1 name, PER communications, N3/N4 residence address,
+        // DMG demographics — in the order required by the 834 spec. Each is emitted only when its
+        // source data is present, so a member carrying only INS-level data renders exactly as before.
         appendMemberName(segments, member);
+        appendCommunications(segments, member);
         appendResidenceAddress(segments, member);
         appendDemographics(segments, member);
 
@@ -191,6 +195,56 @@ public class X834MemberWriter {
             name.setIdentificationCodeQualifier(idQualifier).setIdentificationCode(id);
         }
         segments.add(name.build());
+    }
+
+    /**
+     * Loop 2100A PER (member communications numbers): a single {@code PER*IP} carrying one
+     * qualifier/number pair per channel the member has, emitted after the {@code NM1}. Suppressed
+     * when the member has no way to be reached.
+     * <p>
+     * The member's explicit {@link MemberCommunication}s come first, in the order they were added.
+     * The {@code phoneNumber} and {@code email} conveniences then contribute {@code HP} and
+     * {@code EM} — but only when no explicit communication already claims that qualifier, so a
+     * member given both a {@code phoneNumber} and an explicit work number does not emit the same
+     * channel twice. Precedence is the explicit one's: it says which qualifier the caller meant.
+     * <p>
+     * A PER carries at most three pairs, and a member with more is rejected by the builder rather
+     * than truncated — losing a member's fourth contact number silently is the class of bug this
+     * whole segment exists to end.
+     */
+    private void appendCommunications(List<Segment> segments, BaseMember member) throws ValidationException {
+        List<MemberCommunication> channels = new ArrayList<>();
+        for (MemberCommunication communication : member.getCommunications()) {
+            if (communication != null && communication.getQualifier() != null
+                    && !isBlank(communication.getNumber())) {
+                channels.add(communication);
+            }
+        }
+        addConvenience(channels, CommunicationNumberQualifier.HOME_PHONE, member.getPhoneNumber());
+        addConvenience(channels, CommunicationNumberQualifier.ELECTRONIC_MAIL, member.getEmail());
+
+        if (channels.isEmpty()) {
+            return;
+        }
+        MemberCommunicationsNumbers.Builder per = MemberCommunicationsNumbers.builder();
+        for (MemberCommunication channel : channels) {
+            per.addCommunicationNumber(channel.getQualifier(), channel.getNumber());
+        }
+        segments.add(per.build());
+    }
+
+    /** Adds a {@code phoneNumber}/{@code email} convenience unless an explicit channel claims its qualifier. */
+    private static void addConvenience(List<MemberCommunication> channels,
+                                       CommunicationNumberQualifier qualifier, String number) {
+        if (isBlank(number)) {
+            return;
+        }
+        for (MemberCommunication channel : channels) {
+            if (channel.getQualifier() == qualifier) {
+                return;
+            }
+        }
+        channels.add(new MemberCommunication(qualifier, number));
     }
 
     /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberCommunication.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberCommunication.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * One way to reach a member — a single qualifier/number pair of the Loop 2100A {@code PER} in the
+ * X12 834 (005010X220A1).
+ * <p>
+ * The {@link #qualifier} states what kind of number this is (home phone, email, cellular, …) and
+ * {@link #number} is the number itself. A member may carry several; the writer emits them as the
+ * PER03/04, PER05/06 and PER07/08 pairs of a single {@code PER} segment, which is why the 834
+ * permits at most {@value com.fastChickensHR.edi.x834.segments.PERSegment#MAX_COMMUNICATION_PAIRS}
+ * per member.
+ * <p>
+ * Which channels a carrier wants is a per-carrier choice rather than a fixed list — BCBSM
+ * MembersEdge asks for email, home and work; its Medicare Advantage product for alternate,
+ * cellular, email, home and telephone — so the qualifier is supplied per occurrence.
+ * <p>
+ * This is a pure domain object; translation to 834 segments is the writer's job.
+ */
+@Getter
+@Setter
+public class MemberCommunication {
+    /** What kind of number this is (PER03/05/07) — required. */
+    private CommunicationNumberQualifier qualifier;
+    /** The number itself (PER04/06/08) — required. */
+    private String number;
+
+    public MemberCommunication() {
+    }
+
+    /**
+     * @param qualifier what kind of number this is (PER03/05/07)
+     * @param number    the number itself (PER04/06/08)
+     */
+    public MemberCommunication(CommunicationNumberQualifier qualifier, String number) {
+        this.qualifier = qualifier;
+        this.number = number;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberCommunicationsNumbers.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberCommunicationsNumbers.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.PERSegment;
+import lombok.Getter;
+
+/**
+ * The PER (Member Communications Numbers) segment in Loop 2100A of the X12 834
+ * (005010X220A1).
+ * <p>
+ * PER01 is fixed to {@link #INSURED_PARTY} — the member named by the 2100A {@code NM1} is the
+ * contact — and PER02 (contact name) is left absent, since that member is already named by the
+ * preceding {@code NM1}. What varies is the up-to-three qualifier/number pairs, added with
+ * {@link PERSegment.AbstractBuilder#addCommunicationNumber}. A carrier requiring a home phone
+ * and an email therefore renders as {@code PER*IP**HP*5551234567*EM*a@b.com~}.
+ */
+@Getter
+public class MemberCommunicationsNumbers extends PERSegment {
+
+    /**
+     * PER01 contact function code {@code IP} — Insured Party. The 834 names the member itself as
+     * the contact for its own communication numbers.
+     */
+    public static final String INSURED_PARTY = "IP";
+
+    private MemberCommunicationsNumbers(Builder builder) throws ValidationException {
+        super(builder);
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link MemberCommunicationsNumbers}; PER01 defaults to {@link #INSURED_PARTY}. */
+    public static class Builder extends PERSegment.AbstractBuilder<Builder> {
+        public Builder() {
+            this.per01 = INSURED_PARTY;
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        @Override
+        public MemberCommunicationsNumbers build() throws ValidationException {
+            return new MemberCommunicationsNumbers(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/PERSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/PERSegment.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import lombok.Getter;
+
+/**
+ * Represents the PER (Administrative Communications Contact) segment in the X12 834
+ * (005010X220A1) Benefit Enrollment and Maintenance transaction.
+ * <p>
+ * The segment carries the communication numbers for the party named in the enclosing loop:
+ * a contact function code, then up to three qualifier/number pairs. In the 834 it appears in
+ * Loop 2100A as the member's communications numbers (see
+ * {@code com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunicationsNumbers}).
+ * <p>
+ * Element/position map (data elements per the 834 TR3):
+ * <ul>
+ *     <li>PER01 = contact function code (366)</li>
+ *     <li>PER02 = contact name (93)</li>
+ *     <li>PER03 = communication number qualifier (365)</li>
+ *     <li>PER04 = communication number (364)</li>
+ *     <li>PER05 = communication number qualifier (365)</li>
+ *     <li>PER06 = communication number (364)</li>
+ *     <li>PER07 = communication number qualifier (365)</li>
+ *     <li>PER08 = communication number (364)</li>
+ * </ul>
+ * PER09 is Not Used in the 834 and is not modelled.
+ * <p>
+ * X12 syntax rules P0304, P0506 and P0708 make each qualifier/number a <em>paired presence</em>:
+ * within a pair, if either side is present the other is required. A lone qualifier would render
+ * as a dangling {@code *HP} tail and a lone number as {@code **555...}, both non-conformant, so
+ * both are rejected at build time.
+ */
+@Getter
+public abstract class PERSegment extends Segment {
+    public static final String SEGMENT_ID = "PER";
+
+    /** Element 364 is AN 1/256 — a longer communication number cannot be represented. */
+    public static final int MAX_COMMUNICATION_NUMBER_LENGTH = 256;
+
+    /** The most qualifier/number pairs one PER can carry (PER03/04, PER05/06, PER07/08). */
+    public static final int MAX_COMMUNICATION_PAIRS = 3;
+
+    protected final String per01;
+    protected final String per02;
+    protected final CommunicationNumberQualifier per03;
+    protected final String per04;
+    protected final CommunicationNumberQualifier per05;
+    protected final String per06;
+    protected final CommunicationNumberQualifier per07;
+    protected final String per08;
+
+    protected PERSegment(AbstractBuilder<?> builder) throws ValidationException {
+        this.per01 = builder.per01;
+        this.per02 = builder.per02;
+        this.per03 = builder.per03;
+        this.per04 = builder.per04;
+        this.per05 = builder.per05;
+        this.per06 = builder.per06;
+        this.per07 = builder.per07;
+        this.per08 = builder.per08;
+
+        validate();
+    }
+
+    private void validate() throws ValidationException {
+        if (per01 == null || per01.isEmpty()) {
+            throw new ValidationException("Contact Function Code (PER01) is required");
+        }
+        validatePair(per03, per04, "P0304", "PER03", "PER04");
+        validatePair(per05, per06, "P0506", "PER05", "PER06");
+        validatePair(per07, per08, "P0708", "PER07", "PER08");
+        if (per03 == null && per05 == null && per07 == null) {
+            throw new ValidationException(
+                    "PER carries no communication number; at least one qualifier/number pair is required");
+        }
+    }
+
+    private static void validatePair(CommunicationNumberQualifier qualifier, String number,
+                                     String rule, String qualifierPosition, String numberPosition)
+            throws ValidationException {
+        boolean numberPresent = number != null && !number.isEmpty();
+        if ((qualifier != null) != numberPresent) {
+            throw new ValidationException("PER rule " + rule + ": Communication Number Qualifier ("
+                    + qualifierPosition + ") and Communication Number (" + numberPosition
+                    + ") must be present together");
+        }
+        if (numberPresent && number.length() > MAX_COMMUNICATION_NUMBER_LENGTH) {
+            throw new ValidationException("Communication Number (" + numberPosition + ") must be "
+                    + MAX_COMMUNICATION_NUMBER_LENGTH + " characters or less");
+        }
+    }
+
+    @Override
+    public String getSegmentIdentifier() {
+        return SEGMENT_ID;
+    }
+
+    @Override
+    public String[] getElementValues() {
+        return new String[]{
+                per01,
+                per02,
+                per03 == null ? null : per03.getCode(),
+                per04,
+                per05 == null ? null : per05.getCode(),
+                per06,
+                per07 == null ? null : per07.getCode(),
+                per08};
+    }
+
+    /** @return PER01 — contact function code. */
+    public String getContactFunctionCode() {
+        return getPer01();
+    }
+
+    /** @return PER02 — contact name. */
+    public String getContactName() {
+        return getPer02();
+    }
+
+    /**
+     * Abstract builder for PER segments.
+     *
+     * @param <T> the concrete builder type, for chaining
+     */
+    public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
+        protected String per01;
+        protected String per02;
+        protected CommunicationNumberQualifier per03;
+        protected String per04;
+        protected CommunicationNumberQualifier per05;
+        protected String per06;
+        protected CommunicationNumberQualifier per07;
+        protected String per08;
+
+        protected abstract T self();
+
+        /** Sets PER01 (contact function code). */
+        public T setContactFunctionCode(String value) {
+            this.per01 = value;
+            return self();
+        }
+
+        /** Sets PER02 (contact name). */
+        public T setContactName(String value) {
+            this.per02 = value;
+            return self();
+        }
+
+        /**
+         * Sets the next free qualifier/number pair — PER03/04, then PER05/06, then PER07/08.
+         * <p>
+         * Callers state <em>which</em> channels a member has, not which element positions they
+         * occupy, so the pairs fill in call order. A PER carries at most
+         * {@link #MAX_COMMUNICATION_PAIRS}; a fourth is rejected rather than dropped, because
+         * silently discarding a communication number is the data loss this segment exists to end.
+         *
+         * @param qualifier the communication number qualifier (PER03/05/07)
+         * @param number    the communication number it qualifies (PER04/06/08)
+         * @throws ValidationException if the segment already carries {@link #MAX_COMMUNICATION_PAIRS}
+         */
+        public T addCommunicationNumber(CommunicationNumberQualifier qualifier, String number)
+                throws ValidationException {
+            if (per03 == null) {
+                per03 = qualifier;
+                per04 = number;
+            } else if (per05 == null) {
+                per05 = qualifier;
+                per06 = number;
+            } else if (per07 == null) {
+                per07 = qualifier;
+                per08 = number;
+            } else {
+                throw new ValidationException("A PER segment carries at most "
+                        + MAX_COMMUNICATION_PAIRS + " communication numbers");
+            }
+            return self();
+        }
+
+        /** @return the built segment. */
+        public abstract PERSegment build() throws ValidationException;
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/data/CommunicationNumberQualifierTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/data/CommunicationNumberQualifierTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.data;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CommunicationNumberQualifierTest {
+
+    /**
+     * Every constant resolves from its own X12 code, its enum name, and its description — the three
+     * round-trips {@link com.fastChickensHR.edi.x834.util.EdiEnumLookup} registers for each constant.
+     */
+    @ParameterizedTest
+    @EnumSource(CommunicationNumberQualifier.class)
+    void resolvesFromCodeNameAndDescription(CommunicationNumberQualifier constant) {
+        assertEquals(constant, CommunicationNumberQualifier.fromString(constant.getCode()));
+        assertEquals(constant, CommunicationNumberQualifier.fromString(constant.name()));
+        assertEquals(constant, CommunicationNumberQualifier.fromString(constant.getDescription()));
+    }
+
+    /** Every constant has a distinct code, so none is unreachable by code in the shared lookup. */
+    @Test
+    void codesAreUnique() {
+        Map<String, CommunicationNumberQualifier> byCode = new HashMap<>();
+        for (CommunicationNumberQualifier constant : CommunicationNumberQualifier.values()) {
+            CommunicationNumberQualifier prior = byCode.put(constant.getCode(), constant);
+            assertNull(prior, () -> "duplicate code '" + constant.getCode() + "'");
+        }
+    }
+
+    /**
+     * The 834 subset the carriers profiled in this project actually ask for: BCBSM MembersEdge
+     * {@code EM}/{@code HP}/{@code WP}, its Medicare Advantage product
+     * {@code AP}/{@code CP}/{@code EM}/{@code HP}/{@code TE}, and Anthem {@code HP} + {@code EM}.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"AP", "CP", "EM", "EX", "FX", "HP", "TE", "WP"})
+    void carriesTheCodesTheProfiledCarriersDemand(String code) {
+        assertEquals(code, CommunicationNumberQualifier.fromString(code).getCode());
+    }
+
+    /** The human-friendly aliases callers actually type resolve to the right constant. */
+    @ParameterizedTest
+    @MethodSource("aliases")
+    void resolvesFromCommonAliases(String input, CommunicationNumberQualifier expected) {
+        assertEquals(expected, CommunicationNumberQualifier.fromString(input));
+    }
+
+    private static Stream<Arguments> aliases() {
+        return Stream.of(
+                Arguments.of("email", CommunicationNumberQualifier.ELECTRONIC_MAIL),
+                Arguments.of("e-mail", CommunicationNumberQualifier.ELECTRONIC_MAIL),
+                Arguments.of("home", CommunicationNumberQualifier.HOME_PHONE),
+                Arguments.of("work", CommunicationNumberQualifier.WORK_PHONE),
+                Arguments.of("office", CommunicationNumberQualifier.WORK_PHONE),
+                Arguments.of("cell", CommunicationNumberQualifier.CELLULAR_PHONE),
+                Arguments.of("mobile", CommunicationNumberQualifier.CELLULAR_PHONE),
+                Arguments.of("fax", CommunicationNumberQualifier.FACSIMILE),
+                Arguments.of("phone", CommunicationNumberQualifier.TELEPHONE),
+                Arguments.of("extension", CommunicationNumberQualifier.TELEPHONE_EXTENSION));
+    }
+
+    /** The enum renders as its raw X12 code, so it drops straight into an element. */
+    @Test
+    void toStringIsTheRawCode() {
+        assertEquals("HP", CommunicationNumberQualifier.HOME_PHONE.toString());
+    }
+
+    /** Null, blank, and unrecognized input are rejected, not silently defaulted. */
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "not-a-real-value"})
+    void rejectsNullEmptyAndUnknown(String input) {
+        assertThrows(IllegalArgumentException.class, () -> CommunicationNumberQualifier.fromString(input));
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
@@ -8,6 +8,7 @@
 package com.fastChickensHR.edi.x834.loop2000;
 
 import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
@@ -21,6 +22,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class X834MemberWriterTest {
@@ -353,5 +355,127 @@ class X834MemberWriterTest {
 
         assertTrue(out.contains("REF*DX*0042~"),
                 () -> "expected the REF to use the category's own qualifier; got:\n" + out);
+    }
+
+    @Test
+    void emitsMemberCommunicationsPerFromExplicitChannels() throws ValidationException {
+        Member member = baseSubscriber();
+        member.addCommunication(CommunicationNumberQualifier.ELECTRONIC_MAIL, "jane@example.com");
+        member.addCommunication(CommunicationNumberQualifier.WORK_PHONE, "5559876543");
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("PER*IP**EM*jane@example.com*WP*5559876543~"),
+                () -> "expected one PER carrying both channels in order; got:\n" + out);
+    }
+
+    @Test
+    void emitsPhoneNumberAndEmailUnderTheirConventionalQualifiers() throws ValidationException {
+        // The phoneNumber/email conveniences finally reach the wire: HP and EM. Before PER support
+        // existed they were settable but never serialized, so the values vanished silently.
+        Member member = baseSubscriber();
+        member.setPhoneNumber("5551234567");
+        member.setEmail("jane@example.com");
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("PER*IP**HP*5551234567*EM*jane@example.com~"),
+                () -> "expected phoneNumber as HP and email as EM; got:\n" + out);
+    }
+
+    @Test
+    void anExplicitChannelTakesPrecedenceOverTheConvenienceField() throws ValidationException {
+        // A caller who says "this number is a work phone" means it; phoneNumber must not also add
+        // the same person's number a second time under HP.
+        Member member = baseSubscriber();
+        member.addCommunication(CommunicationNumberQualifier.HOME_PHONE, "5550001111");
+        member.setPhoneNumber("5551234567");
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("PER*IP**HP*5550001111~"),
+                () -> "expected the explicit HP channel to win; got:\n" + out);
+        assertFalse(out.contains("5551234567"),
+                () -> "the convenience field should not add a second HP; got:\n" + out);
+    }
+
+    @Test
+    void emitsThePerAfterTheNm1AndBeforeTheResidenceAddress() throws ValidationException {
+        // 834 Loop 2100A order: NM1, PER, N3, N4, DMG.
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.setPhoneNumber("5551234567");
+        member.setAddressLine1("1 MAIN ST");
+        member.setCity("ANYTOWN");
+        member.setState("MN");
+        member.setZipCode("55555");
+        member.setBirthDate(LocalDateTime.of(1990, 5, 4, 0, 0));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.indexOf("NM1*IL") < out.indexOf("PER*IP"),
+                () -> "PER must follow the member NM1; got:\n" + out);
+        assertTrue(out.indexOf("PER*IP") < out.indexOf("N3*"),
+                () -> "PER must precede the residence N3; got:\n" + out);
+        assertTrue(out.indexOf("N4*") < out.indexOf("DMG*"),
+                () -> "N4 must still precede DMG; got:\n" + out);
+    }
+
+    @Test
+    void omitsThePerWhenTheMemberHasNoWayToBeReached() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+
+        String out = render(writer.toSegments(member));
+
+        assertFalse(out.contains("PER"),
+                () -> "no PER for a member carrying no communication numbers; got:\n" + out);
+    }
+
+    @Test
+    void ignoresAnIncompleteChannelRatherThanEmittingADanglingQualifier() throws ValidationException {
+        // A qualifier with no number would violate X12 rule P0304; it is skipped, and with nothing
+        // else to say the PER is suppressed entirely rather than rendered empty.
+        Member member = baseSubscriber();
+        member.addCommunication(CommunicationNumberQualifier.HOME_PHONE, "");
+
+        String out = render(writer.toSegments(member));
+
+        assertFalse(out.contains("PER"),
+                () -> "an empty number contributes no channel; got:\n" + out);
+    }
+
+    @Test
+    void rejectsAMemberCarryingMoreChannelsThanOnePerCanHold() throws ValidationException {
+        // The 834 permits three. A fourth is a loud failure rather than a silently dropped
+        // contact number — the data-loss class this segment exists to end.
+        Member member = baseSubscriber();
+        member.addCommunication(CommunicationNumberQualifier.ELECTRONIC_MAIL, "jane@example.com");
+        member.addCommunication(CommunicationNumberQualifier.HOME_PHONE, "5551234567");
+        member.addCommunication(CommunicationNumberQualifier.WORK_PHONE, "5559876543");
+        member.addCommunication(CommunicationNumberQualifier.CELLULAR_PHONE, "5550000000");
+
+        ValidationException ex = assertThrows(ValidationException.class, () -> writer.toSegments(member));
+
+        assertTrue(ex.getMessage().contains("at most 3"), ex.getMessage());
+    }
+
+    @Test
+    void emitsAPerForEachDependentThatCarriesOne() throws ValidationException {
+        Member subscriber = baseSubscriber();
+        subscriber.setEmail("jane@example.com");
+        DependentMember dependent = new DependentMember();
+        dependent.setMemberIndicator(MemberIndicator.NOT_INSURED);
+        dependent.setRelationshipCode(IndividualRelationshipCode.CHILD);
+        dependent.setMaintenanceTypeCode(MaintenanceTypeCode.ADDITION);
+        dependent.setPhoneNumber("5552223333");
+        subscriber.addDependent(dependent);
+
+        String out = render(writer.toSegments(subscriber));
+
+        assertTrue(out.contains("PER*IP**EM*jane@example.com~"),
+                () -> "expected the subscriber's PER; got:\n" + out);
+        assertTrue(out.contains("PER*IP**HP*5552223333~"),
+                () -> "expected the dependent's own PER; got:\n" + out);
     }
 }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberCommunicationsNumbersTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberCommunicationsNumbersTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.PERSegment;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MemberCommunicationsNumbersTest {
+    private final X834Context context = new X834Context();
+
+    private String render(PERSegment segment) {
+        segment.setContext(context);
+        return segment.render().trim();
+    }
+
+    @Test
+    void rendersTheAnthemWorkedExampleShape() throws ValidationException {
+        // Anthem's guide sends PER*IP**HP*<phone> — PER01 IP, PER02 absent (the member is already
+        // named by the preceding NM1), then the qualifier/number pair.
+        PERSegment per = MemberCommunicationsNumbers.builder()
+                .addCommunicationNumber(CommunicationNumberQualifier.HOME_PHONE, "5551234567")
+                .build();
+
+        assertEquals("PER*IP**HP*5551234567~", render(per));
+    }
+
+    @Test
+    void carriesUpToThreeChannelsInCallOrder() throws ValidationException {
+        // BCBSM MembersEdge asks for EM/HP/WP — three channels in one PER, filling PER03/04,
+        // PER05/06 and PER07/08 in the order they were added.
+        PERSegment per = MemberCommunicationsNumbers.builder()
+                .addCommunicationNumber(CommunicationNumberQualifier.ELECTRONIC_MAIL, "jane@example.com")
+                .addCommunicationNumber(CommunicationNumberQualifier.HOME_PHONE, "5551234567")
+                .addCommunicationNumber(CommunicationNumberQualifier.WORK_PHONE, "5559876543")
+                .build();
+
+        assertEquals("PER*IP**EM*jane@example.com*HP*5551234567*WP*5559876543~", render(per));
+    }
+
+    @Test
+    void per01DefaultsToInsuredParty() throws ValidationException {
+        PERSegment per = MemberCommunicationsNumbers.builder()
+                .addCommunicationNumber(CommunicationNumberQualifier.TELEPHONE, "5551234567")
+                .build();
+
+        assertEquals("PER", per.getSegmentIdentifier());
+        assertEquals(MemberCommunicationsNumbers.INSURED_PARTY, per.getContactFunctionCode());
+    }
+
+    @Test
+    void rejectsAFourthChannelRatherThanDroppingIt() throws ValidationException {
+        MemberCommunicationsNumbers.Builder per = MemberCommunicationsNumbers.builder()
+                .addCommunicationNumber(CommunicationNumberQualifier.ELECTRONIC_MAIL, "jane@example.com")
+                .addCommunicationNumber(CommunicationNumberQualifier.HOME_PHONE, "5551234567")
+                .addCommunicationNumber(CommunicationNumberQualifier.WORK_PHONE, "5559876543");
+
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> per.addCommunicationNumber(CommunicationNumberQualifier.CELLULAR_PHONE, "5550000000"));
+
+        assertTrue(ex.getMessage().contains("at most 3"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsANumberWithoutItsQualifier() {
+        // X12 syntax rule P0304: a lone number would render as PER*IP***5551234567, which is
+        // non-conformant — the receiver cannot tell what kind of number it is.
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> new UnqualifiedPer().setContactFunctionCode("IP").build());
+
+        assertTrue(ex.getMessage().contains("P0304"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsAPerCarryingNoChannelAtAll() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberCommunicationsNumbers.builder().build());
+
+        assertTrue(ex.getMessage().contains("no communication number"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsACommunicationNumberLongerThanElement364Allows() {
+        String tooLong = "5".repeat(PERSegment.MAX_COMMUNICATION_NUMBER_LENGTH + 1);
+
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberCommunicationsNumbers.builder()
+                        .addCommunicationNumber(CommunicationNumberQualifier.HOME_PHONE, tooLong)
+                        .build());
+
+        assertTrue(ex.getMessage().contains("256"), ex.getMessage());
+    }
+
+    /** Sets PER04 without PER03, which the public builder's paired API cannot express. */
+    private static final class UnqualifiedPer extends PERSegment.AbstractBuilder<UnqualifiedPer> {
+        private UnqualifiedPer() {
+            this.per04 = "5551234567";
+        }
+
+        @Override
+        protected UnqualifiedPer self() {
+            return this;
+        }
+
+        @Override
+        public PERSegment build() throws ValidationException {
+            return new PERSegment(this) {
+            };
+        }
+    }
+}


### PR DESCRIPTION
Reopens #190, which GitHub auto-closed when its base branch (`refactor/x834-drop-vestigial-api-124`, now merged as #189) was deleted. Same commit, rebased onto current master — full review discussion is on #190.

The first follow-on slice of #139 — the `PER` segment handed over from the now-closed #138.7. Full suite green against master including the #142 spec ring.

## Why

`edi` had **no `PER` class at all** — confirmed by the 0617 spec-ring audit (§2.11.4, "no file, no references") and listed in the 0558 G17 un-emittable inventory. `BaseMember.phoneNumber`/`.email` were settable but never read, so a consumer's values vanished silently. This retires the "not serialized" caveat #189 just added to those fields.

Every profiled carrier wants it:

| Carrier | Qualifiers | Source |
|---|---|---|
| BCBSM MembersEdge | `EM`, `HP`, `WP` | `bcbsm-834.pdf` p. 15 |
| BCBSM Medicare Advantage | `AP`, `CP`, `EM`, `HP`, `TE` (`WP` removed 2020) | p. 21 |
| Anthem | `HP` + `EM` | pp. 9–11, 14 — examples send `PER*IP**HP*<phone>` |

## What

- **`CommunicationNumberQualifier`** (element 365) — the 834 subset `AP`/`CP`/`EM`/`EX`/`FX`/`HP`/`TE`/`WP`, exactly the codes 0617 §2.11.4 confirms present, so the list stays grounded rather than invented.
- **`PERSegment`** — PER01/02 plus three qualifier/number pairs at PER03/04, PER05/06, PER07/08. PER09 is Not Used in the 834 and is not modelled.
- **`MemberCommunicationsNumbers`** — the Loop 2100A PER. PER01 fixed to `IP` (Insured Party); PER02 deliberately absent, since the member is already named by the preceding `NM1`.
- **`MemberCommunication`** — the domain value on `BaseMember`, mirroring how `ReportingCategory` rides the member for 2700.

## Emission

One `PER` per member, **after the `NM1` and before the `N3`** per the TR3's 2100A ordering, suppressed when the member has no way to be reached.

Explicit `MemberCommunication`s come first in the order added. `phoneNumber` and `email` then contribute `HP` and `EM` — but only if no explicit channel already claims that qualifier, so the same channel is never emitted twice and the explicit qualifier, which states what the caller meant, wins.

## Conformance enforced, not assumed

- **X12 syntax rules P0304/P0506/P0708** — each qualifier/number is a paired presence; a lone qualifier or lone number is rejected.
- **Element 364 is AN 1/256** — a longer number is rejected.
- **A PER holds three pairs.** A member carrying a fourth **fails loudly** rather than dropping one. Silently discarding a contact number is precisely the data-loss class this segment exists to end.

## Tests

39 new across three classes: the Anthem worked-example shape renders byte-exactly, the BCBSM three-channel case fills all three pairs in call order, explicit-beats-convenience, 2100A ordering, suppression, and a dependent getting its own PER.

Mutation-checked the ordering assertion — moving `appendCommunications` after `appendDemographics` fails `emitsThePerAfterTheNm1AndBeforeTheResidenceAddress`.

## Deliberately not in this slice

`X834Location` render keys, so mono's kernel generate path can place these values — matching the 2700 slice's precedent of library capability first.

Part of #139 (remaining after this and #192: 2310, 2200 `DSB`, `LUI`, `HLH`, `ICM`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)