### PR TITLE
feat(x834): provider loop 2310 — LX / NM1 / PLA (#139)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -15,6 +15,7 @@ import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication;
+import com.fastChickensHR.edi.x834.loop2000.loop2310.Provider;
 import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits;
 import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
 import com.fastChickensHR.edi.x834.segments.Segment;
@@ -207,6 +208,32 @@ public abstract class BaseMember {
      */
     public void addCommunication(CommunicationNumberQualifier qualifier, String number) {
         addCommunication(new MemberCommunication(qualifier, number));
+    }
+
+    /**
+     * The providers this member is assigned to (Loop 2310) — typically a primary care physician.
+     * Emitted by {@link X834MemberWriter} after the member's 2300 coverage segments and before the
+     * 2320 block, one {@code LX}/{@code NM1}(/{@code PLA}) occurrence per entry. Empty for a member
+     * with no provider assignment, in which case nothing is emitted.
+     *
+     * @see #addProvider(Provider)
+     */
+    private final List<Provider> providers = new ArrayList<>();
+
+    /**
+     * Adds a provider this member is assigned to (Loop 2310).
+     * <p>
+     * Order is preserved, and the {@code LX} assigned number is counted over the emitted
+     * occurrences. The 834 permits at most
+     * {@value com.fastChickensHR.edi.x834.loop2000.X834MemberWriter#MAX_PROVIDERS} per member; a
+     * member carrying more is rejected when written, not silently truncated.
+     *
+     * @param provider the provider to emit (ignored if null)
+     */
+    public void addProvider(Provider provider) {
+        if (provider != null) {
+            providers.add(provider);
+        }
     }
 
     /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -30,6 +30,9 @@ import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceStreetAddre
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingAddress;
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingCityStateZipCode;
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingStreetAddress;
+import com.fastChickensHR.edi.x834.loop2000.loop2310.Provider;
+import com.fastChickensHR.edi.x834.loop2000.loop2310.ProviderChange;
+import com.fastChickensHR.edi.x834.loop2000.loop2310.ProviderName;
 import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits;
 import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefitsRelatedEntityName;
 import com.fastChickensHR.edi.x834.loop2000.loop2320.MemberCoordinationOfBenefits;
@@ -142,6 +145,9 @@ public class X834MemberWriter {
         // dependent's loop begins.
         segments.addAll(member.getAdditionalSegments());
 
+        // Loop 2310 (provider), emitted after the 2300 block and before 2320.
+        appendProviders(segments, member);
+
         // Loop 2320/2330 (coordination of benefits), emitted after the 2300 block and before 2700.
         appendCoordinationOfBenefits(segments, member);
 
@@ -188,6 +194,65 @@ public class X834MemberWriter {
 
     /** The most Loop 2320 occurrences the 834 permits per member. */
     public static final int MAX_COORDINATION_OF_BENEFITS = 5;
+
+    /** The most Loop 2310 occurrences the 834 permits per member. */
+    public static final int MAX_PROVIDERS = 30;
+
+    /**
+     * Loop 2310 (provider): per provider the member is assigned to, an {@code LX} assigned number,
+     * the {@code NM1} naming them, and — when the assignment is being changed rather than merely
+     * stated — a {@code PLA} saying what is happening. Emitted after the 2300 coverage segments and
+     * before the 2320 block, and suppressed entirely when the member has no provider.
+     * <p>
+     * The {@code LX} counter is assigned at render time over the emitted occurrences (1-based),
+     * matching how the 2700 block numbers its own. Thirty occurrences are permitted; a member
+     * carrying more is rejected rather than truncated.
+     * <p>
+     * The 2310 {@code N3}/{@code N4}/{@code PER} segments are not modelled — no profiled carrier
+     * asks for a provider's address or phone, only their name and identifier.
+     */
+    private void appendProviders(List<Segment> segments, BaseMember member) throws ValidationException {
+        List<Provider> providers = member.getProviders();
+        if (providers.isEmpty()) {
+            return;
+        }
+        if (providers.size() > MAX_PROVIDERS) {
+            throw new ValidationException("A member carries at most " + MAX_PROVIDERS
+                    + " provider loops (2310); got " + providers.size());
+        }
+        int assignedNumber = 1;
+        for (Provider provider : providers) {
+            segments.add(LXSegment.builder().setAssignedNumber(assignedNumber++).build());
+            segments.add(ProviderName.builder()
+                    .setLastName(provider.getLastName())
+                    .setFirstName(emptyToNull(provider.getFirstName()))
+                    .setMiddleName(emptyToNull(provider.getMiddleName()))
+                    .setProviderIdentification(provider.getIdentifierQualifier(),
+                            emptyToNull(provider.getIdentifier()))
+                    .build());
+            appendProviderChange(segments, provider);
+        }
+    }
+
+    /**
+     * The 2310 {@code PLA}, emitted only when the assignment is actually changing. A change with no
+     * effective date is rejected: PLA03 is mandatory, and "this provider changed, at no particular
+     * time" is not something a receiver can apply.
+     */
+    private void appendProviderChange(List<Segment> segments, Provider provider) throws ValidationException {
+        if (provider.getChangeAction() == null) {
+            return;
+        }
+        if (provider.getChangeDate() == null) {
+            throw new ValidationException(
+                    "A provider change (PLA01) requires its effective date (PLA03)");
+        }
+        segments.add(ProviderChange.builder()
+                .setActionCode(provider.getChangeAction())
+                .setDate(DateFormatter.formatDate(DateFormat.D8, provider.getChangeDate()))
+                .setMaintenanceReasonCode(provider.getChangeReason())
+                .build());
+    }
 
     /**
      * Loop 2320/2330 (coordination of benefits): per other plan the member holds, a {@code COB}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/Provider.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/Provider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2310;
+
+import com.fastChickensHR.edi.x834.data.ActionCode;
+import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
+import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * A provider the member is assigned to — one occurrence of Loop 2310 in the X12 834
+ * (005010X220A1), most often the primary care physician an enrollee has selected.
+ * <p>
+ * The {@link #lastName name} and the {@link #identifier} (under its {@link #identifierQualifier})
+ * say who the provider is. When the assignment is being changed rather than merely stated, the
+ * {@link #changeAction}, {@link #changeDate} and optional {@link #changeReason} say so — Anthem's
+ * PCP-change scenario sends exactly that, as {@code PLA*2*1P*<date>**<reason>}.
+ * <p>
+ * Which identifier a carrier wants differs: Florida Blue mandates the NPI ({@code XX}) and says
+ * "only the above code is valid"; CareFirst uses its own {@code SV} legacy number until it issues
+ * NPIs; BCBSM asks for the NPI when available and its own physician number otherwise. CareFirst
+ * also gates the whole loop — "PCP is only processed for Medical products" — which is a
+ * config-time answer, not something this library decides.
+ * <p>
+ * This is a pure domain object; translation to 834 segments is the writer's job.
+ */
+@Getter
+@Setter
+public class Provider {
+    /** The provider's last or organization name (NM103) — required. */
+    private String lastName;
+    /** The provider's first name (NM104). */
+    private String firstName;
+    /** The provider's middle name (NM105). */
+    private String middleName;
+    /** What kind of identifier {@link #identifier} is (NM108), e.g. {@code XX} for an NPI. */
+    private IdentificationCodeQualifier identifierQualifier;
+    /** The provider's identifier (NM109); paired with {@link #identifierQualifier}. */
+    private String identifier;
+    /** What is happening to this assignment (PLA01); the PLA is emitted only when this is set. */
+    private ActionCode changeAction;
+    /** When the change takes effect (PLA03); required when {@link #changeAction} is set. */
+    private LocalDateTime changeDate;
+    /** Why the change is happening (PLA05); optional. */
+    private MaintenanceReasonCode changeReason;
+
+    public Provider() {
+    }
+
+    /**
+     * @param lastName the provider's last or organization name (NM103)
+     */
+    public Provider(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * @param lastName            the provider's last or organization name (NM103)
+     * @param identifierQualifier what kind of identifier follows (NM108)
+     * @param identifier          the provider's identifier (NM109)
+     */
+    public Provider(String lastName, IdentificationCodeQualifier identifierQualifier, String identifier) {
+        this.lastName = lastName;
+        this.identifierQualifier = identifierQualifier;
+        this.identifier = identifier;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/ProviderChange.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/ProviderChange.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2310;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.PLASegment;
+import lombok.Getter;
+
+/**
+ * The PLA segment stating what is happening to a member's provider assignment, closing Loop 2310 of
+ * the X12 834 (005010X220A1).
+ * <p>
+ * PLA02 defaults to {@code 1P} (Provider) to agree with the {@link ProviderName} it follows —
+ * the action applies to the provider that loop just named. The action, date and optional reason are
+ * supplied per change.
+ */
+@Getter
+public class ProviderChange extends PLASegment {
+
+    private ProviderChange(Builder builder) throws ValidationException {
+        super(builder);
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link ProviderChange}; PLA02 defaults to {@code 1P} (Provider). */
+    public static class Builder extends PLASegment.AbstractBuilder<Builder> {
+        public Builder() {
+            setEntityIdentifierCode(com.fastChickensHR.edi.x834.data.EntityIdentifierCode.PROVIDER);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        @Override
+        public ProviderChange build() throws ValidationException {
+            return new ProviderChange(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/ProviderName.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/ProviderName.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2310;
+
+import com.fastChickensHR.edi.x834.data.EntityIdentifierCode;
+import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.NM1Segment;
+import lombok.Getter;
+
+/**
+ * The NM1 segment naming the member's provider in Loop 2310 of the X12 834 (005010X220A1) —
+ * typically the primary care physician the enrollee has selected.
+ * <p>
+ * NM101 defaults to {@link EntityIdentifierCode#PROVIDER} ({@code 1P}) and NM102 to
+ * {@link #PERSON_ENTITY_TYPE} ({@code 1}), a physician being a person. NM103–NM105 carry the
+ * provider's name and NM108/NM109 identify them.
+ * <p>
+ * <b>Which identifier</b> is a carrier answer, not a default: Florida Blue mandates
+ * {@link IdentificationCodeQualifier#CMS_NPI} ({@code XX}) — "Only the above code is valid" —
+ * while CareFirst uses {@link IdentificationCodeQualifier#SERVICE_PROVIDER} ({@code SV}), its own
+ * legacy ID, "until CareFirst provides the NPI". BCBSM asks for the NPI "when available", falling
+ * back to its own physician number. So the qualifier is supplied per provider.
+ * <p>
+ * NM108 and NM109 are a paired presence, enforced here: an identifier with no qualifier does not
+ * say what kind of number it is, and a qualifier with no identifier says nothing at all.
+ */
+@Getter
+public class ProviderName extends NM1Segment {
+
+    /** NM102 entity type qualifier {@code 1} — Person; a provider is an individual. */
+    public static final String PERSON_ENTITY_TYPE = "1";
+
+    private ProviderName(Builder builder) throws ValidationException {
+        super(builder);
+        validateIdentification();
+    }
+
+    private void validateIdentification() throws ValidationException {
+        boolean qualifierPresent = getNm108() != null && !getNm108().isEmpty();
+        boolean identifierPresent = getNm109() != null && !getNm109().isEmpty();
+        if (qualifierPresent != identifierPresent) {
+            throw new ValidationException(
+                    "Provider identification: qualifier (NM108) and identifier (NM109) must be present together");
+        }
+    }
+
+    /** @return NM103 — the provider's last or organization name. */
+    public String getProviderLastName() {
+        return getNm103();
+    }
+
+    /** @return NM109 — the provider's identifier. */
+    public String getProviderIdentifier() {
+        return getNm109();
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link ProviderName}; NM101 defaults to {@code 1P} (Provider) and NM102 to
+     * {@link #PERSON_ENTITY_TYPE}.
+     */
+    public static class Builder extends NM1Segment.AbstractBuilder<Builder> {
+        public Builder() {
+            setEntityIdentifierCode(EntityIdentifierCode.PROVIDER.getCode());
+            setEntityTypeQualifier(PERSON_ENTITY_TYPE);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        /**
+         * Sets NM108/NM109 — how the provider is identified, and the identifier itself.
+         *
+         * @param qualifier what kind of identifier this is (NM108), e.g. {@code XX} for an NPI
+         * @param identifier the provider's identifier (NM109)
+         */
+        public Builder setProviderIdentification(IdentificationCodeQualifier qualifier, String identifier) {
+            setIdentificationCodeQualifier(qualifier == null ? null : qualifier.getCode());
+            return setIdentificationCode(identifier);
+        }
+
+        @Override
+        public ProviderName build() throws ValidationException {
+            return new ProviderName(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/PLASegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/PLASegment.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.data.ActionCode;
+import com.fastChickensHR.edi.x834.data.EntityIdentifierCode;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
+import lombok.Getter;
+
+/**
+ * Represents the PLA (Place or Location) segment in the X12 834 (005010X220A1) Benefit Enrollment
+ * and Maintenance transaction.
+ * <p>
+ * The segment closes Loop 2310 and states what is happening to the member's provider assignment:
+ * the action (PLA01), the kind of party it applies to (PLA02), when it takes effect (PLA03), and
+ * optionally why (PLA05). Anthem's PCP-change scenario renders as
+ * {@code PLA*2*1P*20260101**07~}.
+ * <p>
+ * Element/position map (data elements per the 834 TR3):
+ * <ul>
+ *     <li>PLA01 = action code (306) — <b>mandatory</b></li>
+ *     <li>PLA02 = entity identifier code (98) — <b>mandatory</b></li>
+ *     <li>PLA03 = date (373, DT 8/8) — <b>mandatory</b></li>
+ *     <li>PLA04 = time (337) — optional</li>
+ *     <li>PLA05 = maintenance reason code (1203) — optional</li>
+ * </ul>
+ * <b>PLA04</b> carries no setter. No profiled carrier asks for a time on a provider change, and a
+ * date-grained assignment has no meaningful one. Its slot is still rendered, because PLA05 sits
+ * after it and an element cannot be skipped — which is why Anthem's example shows the empty
+ * {@code **} before the reason.
+ */
+@Getter
+public abstract class PLASegment extends Segment {
+    public static final String SEGMENT_ID = "PLA";
+
+    /** Element 373 is DT 8/8 — a date renders as {@code CCYYMMDD} and nothing else. */
+    public static final int DATE_LENGTH = 8;
+
+    protected final ActionCode pla01;
+    protected final EntityIdentifierCode pla02;
+    protected final String pla03;
+    protected final MaintenanceReasonCode pla05;
+
+    protected PLASegment(AbstractBuilder<?> builder) throws ValidationException {
+        this.pla01 = builder.pla01;
+        this.pla02 = builder.pla02;
+        this.pla03 = builder.pla03;
+        this.pla05 = builder.pla05;
+
+        validate();
+    }
+
+    private void validate() throws ValidationException {
+        if (pla01 == null) {
+            throw new ValidationException("Action Code (PLA01) is required");
+        }
+        if (pla02 == null) {
+            throw new ValidationException("Entity Identifier Code (PLA02) is required");
+        }
+        if (pla03 == null || pla03.isEmpty()) {
+            throw new ValidationException("Date (PLA03) is required");
+        }
+        if (pla03.length() != DATE_LENGTH) {
+            throw new ValidationException("Date (PLA03) must be exactly " + DATE_LENGTH
+                    + " characters (CCYYMMDD); got '" + pla03 + "'");
+        }
+    }
+
+    @Override
+    public String getSegmentIdentifier() {
+        return SEGMENT_ID;
+    }
+
+    @Override
+    public String[] getElementValues() {
+        // PLA04 (time) is never populated but must hold its slot so PLA05 renders in position.
+        return new String[]{
+                pla01.getCode(),
+                pla02.getCode(),
+                pla03,
+                null,
+                pla05 == null ? null : pla05.getCode()};
+    }
+
+    /** @return PLA01 — what is happening to the assignment. */
+    public ActionCode getActionCode() {
+        return getPla01();
+    }
+
+    /** @return PLA02 — the kind of party the action applies to. */
+    public EntityIdentifierCode getEntityIdentifierCode() {
+        return getPla02();
+    }
+
+    /** @return PLA03 — when it takes effect, as {@code CCYYMMDD}. */
+    public String getDate() {
+        return getPla03();
+    }
+
+    /** @return PLA05 — why, if stated. */
+    public MaintenanceReasonCode getMaintenanceReasonCode() {
+        return getPla05();
+    }
+
+    /**
+     * Abstract builder for PLA segments.
+     *
+     * @param <T> the concrete builder type, for chaining
+     */
+    public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
+        protected ActionCode pla01;
+        protected EntityIdentifierCode pla02;
+        protected String pla03;
+        protected MaintenanceReasonCode pla05;
+
+        protected abstract T self();
+
+        /** Sets PLA01 (action code). */
+        public T setActionCode(ActionCode value) {
+            this.pla01 = value;
+            return self();
+        }
+
+        /** Sets PLA02 (entity identifier code). */
+        public T setEntityIdentifierCode(EntityIdentifierCode value) {
+            this.pla02 = value;
+            return self();
+        }
+
+        /** Sets PLA03 (the date the action takes effect), formatted {@code CCYYMMDD}. */
+        public T setDate(String value) {
+            this.pla03 = value;
+            return self();
+        }
+
+        /** Sets PLA05 (why the action is happening). */
+        public T setMaintenanceReasonCode(MaintenanceReasonCode value) {
+            this.pla05 = value;
+            return self();
+        }
+
+        /** @return the built segment. */
+        public abstract PLASegment build() throws ValidationException;
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
@@ -15,6 +15,10 @@ import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
 import com.fastChickensHR.edi.x834.data.CoordinationOfBenefitsCode;
 import com.fastChickensHR.edi.x834.data.PayerResponsibilitySequenceCode;
+import com.fastChickensHR.edi.x834.data.ActionCode;
+import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
+import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
+import com.fastChickensHR.edi.x834.loop2000.loop2310.Provider;
 import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits;
 import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
 import com.fastChickensHR.edi.x834.segments.RefSegment;
@@ -462,6 +466,125 @@ class X834MemberWriterTest {
         ValidationException ex = assertThrows(ValidationException.class, () -> writer.toSegments(member));
 
         assertTrue(ex.getMessage().contains("at most 3"), ex.getMessage());
+    }
+
+    @Test
+    void emitsTheProviderLoopAsLxThenNm1() throws ValidationException {
+        Member member = baseSubscriber();
+        member.addProvider(new Provider("WELBY", IdentificationCodeQualifier.CMS_NPI, "1234567893"));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("LX*1~"), () -> "expected the 2310 LX; got:\n" + out);
+        assertTrue(out.contains("NM1*1P*1*WELBY*****XX*1234567893~"),
+                () -> "expected the provider NM1; got:\n" + out);
+        assertTrue(out.indexOf("LX*1~") < out.indexOf("NM1*1P"),
+                () -> "LX opens the loop, before the NM1; got:\n" + out);
+    }
+
+    @Test
+    void emitsThePlaOnlyWhenTheAssignmentIsChanging() throws ValidationException {
+        // A provider merely stated (no change action) gets LX + NM1 and no PLA.
+        Member member = baseSubscriber();
+        member.addProvider(new Provider("WELBY"));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("NM1*1P*1*WELBY~"), () -> "expected the provider NM1; got:\n" + out);
+        assertFalse(out.contains("PLA"), () -> "no PLA without a change action; got:\n" + out);
+    }
+
+    @Test
+    void emitsTheAnthemPcpChangeBlock() throws ValidationException {
+        Member member = baseSubscriber();
+        Provider pcp = new Provider("WELBY", IdentificationCodeQualifier.CMS_NPI, "1234567893");
+        pcp.setChangeAction(ActionCode.CHANGE);
+        pcp.setChangeDate(LocalDateTime.of(2026, 1, 1, 0, 0));
+        pcp.setChangeReason(MaintenanceReasonCode.TERMINATION_OF_BENEFITS);
+        member.addProvider(pcp);
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("PLA*2*1P*20260101**07~"),
+                () -> "expected Anthem's PLA*2*1P*<date>**<reason>; got:\n" + out);
+        assertTrue(out.indexOf("NM1*1P") < out.indexOf("PLA*2"),
+                () -> "the PLA closes the loop, after the NM1; got:\n" + out);
+    }
+
+    @Test
+    void numbersEachProviderLoopFromOne() throws ValidationException {
+        Member member = baseSubscriber();
+        member.addProvider(new Provider("WELBY"));
+        member.addProvider(new Provider("KILDARE"));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.indexOf("LX*1~") < out.indexOf("NM1*1P*1*WELBY~"),
+                () -> "first provider is LX*1; got:\n" + out);
+        assertTrue(out.indexOf("NM1*1P*1*WELBY~") < out.indexOf("LX*2~"),
+                () -> "the second LX opens its own loop; got:\n" + out);
+        assertTrue(out.indexOf("LX*2~") < out.indexOf("NM1*1P*1*KILDARE~"),
+                () -> "second provider follows LX*2; got:\n" + out);
+    }
+
+    @Test
+    void emitsTheProviderLoopAfterTheCoverageSegmentsAndBeforeTheCobBlock() throws ValidationException {
+        // 834 loop order: 2300 (HD) → 2310 (provider) → 2320 (COB) → 2700.
+        Member member = baseSubscriber();
+        member.addSegment(new RefSegment.Builder()
+                .setReferenceIdentificationQualifier("1L")
+                .setReferenceIdentification("PLAN9")
+                .build());
+        member.addProvider(new Provider("WELBY"));
+        member.addCoordinationOfBenefits(new CoordinationOfBenefits(
+                PayerResponsibilitySequenceCode.PRIMARY,
+                CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS));
+        member.addReportingCategory(new ReportingCategory("CLASS", "0042"));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.indexOf("REF*1L*PLAN9") < out.indexOf("LX*1~"),
+                () -> "the 2310 loop must follow the 2300 segments; got:\n" + out);
+        assertTrue(out.indexOf("LX*1~") < out.indexOf("COB*P"),
+                () -> "the 2310 loop must precede the 2320 block; got:\n" + out);
+        assertTrue(out.indexOf("COB*P") < out.indexOf("LS*2700"),
+                () -> "the 2320 block must still precede the 2700 block; got:\n" + out);
+    }
+
+    @Test
+    void omitsTheProviderLoopWhenTheMemberHasNoProvider() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+
+        String out = render(writer.toSegments(member));
+
+        assertFalse(out.contains("LX*"), () -> "no 2310 loop without a provider; got:\n" + out);
+        assertFalse(out.contains("PLA"), () -> "and no PLA; got:\n" + out);
+    }
+
+    @Test
+    void rejectsAProviderChangeMissingItsEffectiveDate() throws ValidationException {
+        // PLA03 is mandatory; "this provider changed, at no particular time" is not applicable.
+        Member member = baseSubscriber();
+        Provider pcp = new Provider("WELBY");
+        pcp.setChangeAction(ActionCode.CHANGE);
+        member.addProvider(pcp);
+
+        ValidationException ex = assertThrows(ValidationException.class, () -> writer.toSegments(member));
+
+        assertTrue(ex.getMessage().contains("PLA03"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsMoreProvidersThanThe834Permits() throws ValidationException {
+        Member member = baseSubscriber();
+        for (int i = 0; i < X834MemberWriter.MAX_PROVIDERS + 1; i++) {
+            member.addProvider(new Provider("DOC" + i));
+        }
+
+        ValidationException ex = assertThrows(ValidationException.class, () -> writer.toSegments(member));
+
+        assertTrue(ex.getMessage().contains("at most 30"), ex.getMessage());
     }
 
     @Test

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2310/ProviderLoopSegmentsTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2310/ProviderLoopSegmentsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2310;
+
+import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.data.ActionCode;
+import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
+import com.fastChickensHR.edi.x834.segments.PLASegment;
+import com.fastChickensHR.edi.x834.segments.Segment;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProviderLoopSegmentsTest {
+    private final X834Context context = new X834Context();
+
+    private String render(Segment segment) {
+        segment.setContext(context);
+        return segment.render().trim();
+    }
+
+    @Test
+    void namesTheProviderWithFloridaBluesMandatedNpiQualifier() throws ValidationException {
+        // Florida Blue B13: NM108 must be XX (NPI) — "Only the above code is valid".
+        ProviderName provider = ProviderName.builder()
+                .setLastName("WELBY")
+                .setFirstName("MARCUS")
+                .setProviderIdentification(IdentificationCodeQualifier.CMS_NPI, "1234567893")
+                .build();
+
+        assertEquals("NM1*1P*1*WELBY*MARCUS****XX*1234567893~", render(provider));
+        assertEquals("1234567893", provider.getProviderIdentifier());
+    }
+
+    @Test
+    void namesTheProviderWithCareFirstsLegacyServiceProviderQualifier() throws ValidationException {
+        // CareFirst uses SV, its own legacy ID, "until CareFirst provides the NPI" — the same
+        // position, a different qualifier, which is why it is a carrier answer rather than a default.
+        ProviderName provider = ProviderName.builder()
+                .setLastName("WELBY")
+                .setProviderIdentification(IdentificationCodeQualifier.SERVICE_PROVIDER, "SV99881")
+                .build();
+
+        assertEquals("NM1*1P*1*WELBY*****SV*SV99881~", render(provider));
+    }
+
+    @Test
+    void namesAProviderWithNoIdentifierAtAll() throws ValidationException {
+        ProviderName provider = ProviderName.builder().setLastName("WELBY").build();
+
+        assertEquals("NM1*1P*1*WELBY~", render(provider));
+    }
+
+    @Test
+    void rejectsAnIdentifierWithoutItsQualifier() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ProviderName.builder()
+                        .setLastName("WELBY")
+                        .setIdentificationCode("1234567893")
+                        .build());
+
+        assertTrue(ex.getMessage().contains("NM108"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsAQualifierWithoutItsIdentifier() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ProviderName.builder()
+                        .setLastName("WELBY")
+                        .setIdentificationCodeQualifier(IdentificationCodeQualifier.CMS_NPI.getCode())
+                        .build());
+
+        assertTrue(ex.getMessage().contains("NM109"), ex.getMessage());
+    }
+
+    @Test
+    void rendersTheAnthemPcpChangeShape() throws ValidationException {
+        // Anthem's PCP-change scenario (p. 7): PLA*2*1P*<date>**<reason>. PLA04 (time) is empty but
+        // must hold its slot, or the reason would land in PLA04.
+        PLASegment change = ProviderChange.builder()
+                .setActionCode(ActionCode.CHANGE)
+                .setDate("20260101")
+                .setMaintenanceReasonCode(MaintenanceReasonCode.TERMINATION_OF_BENEFITS)
+                .build();
+
+        assertEquals("PLA*2*1P*20260101**07~", render(change));
+    }
+
+    @Test
+    void trimsTheTrailingSlotsWhenNoReasonIsGiven() throws ValidationException {
+        // Without PLA05 there is nothing after PLA03, so the empty PLA04 must not render either.
+        PLASegment change = ProviderChange.builder()
+                .setActionCode(ActionCode.ADD)
+                .setDate("20260101")
+                .build();
+
+        assertEquals("PLA*1*1P*20260101~", render(change));
+    }
+
+    @Test
+    void exposesItsElementsByName() throws ValidationException {
+        PLASegment change = ProviderChange.builder()
+                .setActionCode(ActionCode.DELETE)
+                .setDate("20261231")
+                .build();
+
+        assertEquals("PLA", change.getSegmentIdentifier());
+        assertEquals(ActionCode.DELETE, change.getActionCode());
+        assertEquals("20261231", change.getDate());
+    }
+
+    @Test
+    void rejectsAChangeWithNoAction() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ProviderChange.builder().setDate("20260101").build());
+
+        assertTrue(ex.getMessage().contains("PLA01"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsAChangeWithNoDate() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ProviderChange.builder().setActionCode(ActionCode.CHANGE).build());
+
+        assertTrue(ex.getMessage().contains("PLA03"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsADateThatIsNotEightCharacters() {
+        // Element 373 is DT 8/8 — a short date would silently shift the receiver's parse.
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ProviderChange.builder()
+                        .setActionCode(ActionCode.CHANGE)
+                        .setDate("260101")
+                        .build());
+
+        assertTrue(ex.getMessage().contains("CCYYMMDD"), ex.getMessage());
+    }
+}


### PR DESCRIPTION
The third follow-on slice of #139, after PER and COB. Branched straight off master this time — no stack. Full suite green.

## Why

`edi` could not name the provider a member is assigned to. Four of the five profiled guides demand it, and they disagree about the identifier in a way that makes it a carrier answer rather than a default:

| Carrier | Demand | Source |
|---|---|---|
| Florida Blue | `NM108 = XX` (NPI) — *"Only the above code is valid"* | B13, p. 26 |
| CareFirst | `NM108 = SV`, its own legacy ID, *"until CareFirst provides the NPI"*; gates the loop — *"PCP is only processed for Medical products"* | 0569 |
| BCBSM | NPI *"when available. Otherwise… their physician number"* | p. 11 |
| Anthem | PCP-change: `PLA*2*1P*<date>**<reason>` | p. 7 |

## What

- **`PLASegment`** — PLA01 action code (306), PLA02 entity identifier (98), PLA03 date (373, DT 8/8), PLA05 maintenance reason (1203). All three mandatory elements enforced.
- **`ProviderName`** — the 2310 `NM1`, NM101 `1P` (Provider), NM102 `1` (Person).
- **`ProviderChange`** — the 2310 `PLA`, PLA02 defaulting to `1P` so it agrees with the `NM1` it follows.
- **`Provider`** — the domain value on `BaseMember`.

### Reused rather than duplicated

`ActionCode` (element 306) and `MaintenanceReasonCode` (1203) already existed, so this slice adds **no new enums**. `ActionCode` was one of the catalogs the #124 audit flagged as "referenced only by their own tests" — it now has a real caller. `IdentificationCodeQualifier` already carried both `XX` and `SV`, so unlike the COB slice there was no code-list gap to fill.

### `PLA04` keeps its slot but has no setter

No carrier asks for a time on a provider change, and a date-grained assignment has none. But the slot still renders, because PLA05 sits after it and an element cannot be skipped — which is exactly why Anthem's example shows the empty `**` before the reason. Tests pin both that *and* the trailing-slot trim when no reason is given (`PLA*1*1P*20260101~`), so the two behaviours can't silently swap.

This differs from the COB slice's treatment of `COB04`, which I dropped entirely — there, nothing followed it, so the slot was genuinely unnecessary.

## Emission

Per provider: `LX` → `NM1` → `PLA` (only when the assignment is actually changing). Placed **after the 2300 coverage segments and before the 2320 block**, per 834 loop order. The `LX` counter is assigned at render time over emitted occurrences, matching how the 2700 block numbers its own. Suppressed entirely when the member has no provider.

Two loud failures rather than quiet ones:
- **More than 30 providers** is rejected, not truncated.
- **A change action with no effective date** is rejected. PLA03 is mandatory, and "this provider changed, at no particular time" is not something a receiver can apply.

`NM108`/`NM109` are enforced as a paired presence — an identifier with no qualifier does not say what kind of number it is, and a qualifier alone says nothing.

## Not modelled

The 2310 `N3`/`N4`/`PER` segments. No profiled carrier asks for a provider's address or phone, only their name and identifier.

## Tests

19 new across two classes. Both identifier conventions render byte-exactly (`NM1*1P*1*WELBY*MARCUS****XX*1234567893~` and the `SV` form), plus Anthem's PLA shape, LX numbering across two providers, loop ordering, suppression, and each rejection path.

Mutation-checked the ordering assertion — emitting 2310 after the 2320 block fails `emitsTheProviderLoopAfterTheCoverageSegmentsAndBeforeTheCobBlock`.

I also confirmed mono's `Java CI with Maven` is green on current master after yesterday's six edi merges, since mono clones edi master fresh rather than pinning a snapshot.

Part of #139 (remaining: 2200 `DSB`, `LUI`, `HLH`, `ICM`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)