### PR TITLE
feat(x834): member income ICM in Loop 2100A (#139)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/FrequencyCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/FrequencyCode.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.data;
+
+import com.fastChickensHR.edi.x834.util.EdiCodeEnum;
+import com.fastChickensHR.edi.x834.util.EdiEnumLookup;
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * Code values for the X12 Frequency Code (data element 594), which states the period an amount or
+ * quantity covers. In the X12 834 (005010X220A1) it appears as ICM01, saying over what period the
+ * member's income in ICM02 is earned — a wage of 2000 means nothing until you know whether that is
+ * weekly, monthly or annual.
+ *
+ * <p>No default value is defined for this element, and none is assumed here: guessing the period of
+ * someone's pay would silently misstate their income by an order of magnitude.
+ * {@link #fromString(String)} resolves a value from its code, enum name, description, or a common
+ * synonym, and throws {@link IllegalArgumentException} when the input matches none.
+ */
+@Getter
+public enum FrequencyCode implements EdiCodeEnum {
+    ANNUALIZED("0", "Annualized; 12-month equivalent"),
+    WEEKLY("1", "Weekly"),
+    BIWEEKLY("2", "Biweekly"),
+    SEMIMONTHLY("3", "Semimonthly"),
+    MONTHLY("4", "Monthly"),
+    OTHER("5", "Other"),
+    DAILY("6", "Daily"),
+    ANNUAL("7", "Annual"),
+    TWO_CALENDAR_MONTHS("8", "Two Calendar Months"),
+    LUMP_SUM_SEPARATION_ALLOWANCE("9", "Lump-Sum Separation Allowance"),
+    QUARTER_TO_DATE("A", "Quarter-to-Date"),
+    YEAR_TO_DATE("B", "Year-to-Date"),
+    SINGLE("C", "Single"),
+    POLICY_PERIOD("D", "Policy Period"),
+    CLAIM_PERIOD("E", "Claim Period"),
+    UNIT_REPORT_IDENTIFIER("F", "Unit Report Identifier"),
+    MONTH_TO_DATE("G", "Month-to-Date"),
+    HOURLY("H", "Hourly"),
+    CURRENT_PERIOD("J", "Current Period"),
+    QUARTERLY("Q", "Quarterly"),
+    SEMIANNUAL("S", "Semiannual"),
+    UNKNOWN("U", "Unknown"),
+    MUTUALLY_DEFINED("Z", "Mutually Defined");
+
+    private final String code;
+    private final String description;
+    private static final EdiEnumLookup<FrequencyCode> LOOKUP;
+
+    static {
+        LOOKUP = new EdiEnumLookup<>(
+                FrequencyCode.class,
+                "Frequency Code",
+                Map.ofEntries(
+                        Map.entry("per week", WEEKLY),
+                        Map.entry("every two weeks", BIWEEKLY),
+                        Map.entry("fortnightly", BIWEEKLY),
+                        Map.entry("twice monthly", SEMIMONTHLY),
+                        Map.entry("per month", MONTHLY),
+                        Map.entry("per day", DAILY),
+                        Map.entry("per year", ANNUAL),
+                        Map.entry("yearly", ANNUAL),
+                        Map.entry("per hour", HOURLY),
+                        Map.entry("ytd", YEAR_TO_DATE),
+                        Map.entry("qtd", QUARTER_TO_DATE),
+                        Map.entry("mtd", MONTH_TO_DATE)
+                )
+        );
+    }
+
+    FrequencyCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    /**
+     * Gets a FrequencyCode instance from any input string.
+     * Matches against codes, names, descriptions, and common variations.
+     *
+     * @param input the string to look up
+     * @return the matching FrequencyCode
+     * @throws IllegalArgumentException if no match is found
+     */
+    public static FrequencyCode fromString(String input) {
+        return LOOKUP.fromString(input);
+    }
+
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
+    @Override
+    public String toString() {
+        return code;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -14,6 +14,7 @@ import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.Income;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication;
 import com.fastChickensHR.edi.x834.loop2000.loop2310.Provider;
 import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits;
@@ -90,6 +91,13 @@ public abstract class BaseMember {
      * {@link MemberCommunication}.
      */
     protected String email;
+    /**
+     * What this member earns (Loop 2100A {@code ICM}). Emitted by {@link X834MemberWriter} after the
+     * member's {@code DMG}, and only when present — the 834 sends income only when the sponsor's
+     * contract with the payer requires it. A member has at most one, the 834 permitting a single
+     * {@code ICM}.
+     */
+    protected Income income;
 
     /**
      * All of this member's postal addresses, keyed by {@link AddressType}. A member may carry a

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -21,9 +21,11 @@ import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
 import com.fastChickensHR.edi.x834.data.DateTimeQualifier;
 import com.fastChickensHR.edi.x834.loop2000.data.BenefitStatusCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberDateQualifier;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.Income;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunicationsNumbers;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberDemographics;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberIncome;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberName;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceCityStateZipCode;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceStreetAddress;
@@ -129,12 +131,13 @@ public class X834MemberWriter {
         addDateSegment(segments, MemberDateQualifier.COVERAGE_END, member.getCoverageEndDate());
 
         // Loop 2100A (member detail): NM1 name, PER communications, N3/N4 residence address,
-        // DMG demographics — in the order required by the 834 spec. Each is emitted only when its
-        // source data is present, so a member carrying only INS-level data renders exactly as before.
+        // DMG demographics, ICM income — in the order required by the 834 spec. Each is emitted only
+        // when its source data is present, so a member carrying only INS-level data renders as before.
         appendMemberName(segments, member);
         appendCommunications(segments, member);
         appendResidenceAddress(segments, member);
         appendDemographics(segments, member);
+        appendIncome(segments, member);
 
         // Loop 2100C (member mailing address), emitted after the 2100A block when the member
         // carries a distinct mailing address.
@@ -421,6 +424,31 @@ public class X834MemberWriter {
                     .setPostalCode(mailing.getZipCode())
                     .build());
         }
+    }
+
+    /**
+     * Loop 2100A ICM (member income), emitted after the DMG when the member carries one. The 834
+     * sends income only when the sponsor's contract with the payer requires it, so absence is the
+     * normal case.
+     * <p>
+     * ICM01 (frequency) and ICM02 (amount) are mandatory, so an income carrying only the later
+     * elements is rejected rather than emitted with empty mandatory slots. This is the case a
+     * carrier hits when it wants just the ICM04 location identifier — BCBS Kansas puts its
+     * department number there — and it is a property of the 834 rather than a rule invented here.
+     */
+    private void appendIncome(List<Segment> segments, BaseMember member) throws ValidationException {
+        Income income = member.getIncome();
+        if (income == null) {
+            return;
+        }
+        segments.add(MemberIncome.builder()
+                .setFrequencyCode(income.getFrequency())
+                .setMonetaryAmount(emptyToNull(income.getAmount()))
+                .setQuantity(emptyToNull(income.getHours()))
+                .setLocationIdentifier(emptyToNull(income.getLocationIdentifier()))
+                .setSalaryGrade(emptyToNull(income.getSalaryGrade()))
+                .setCurrencyCode(emptyToNull(income.getCurrencyCode()))
+                .build());
     }
 
     /** Loop 2100A DMG (member demographics). Emitted when a birth date is present. */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/Income.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/Income.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.data.FrequencyCode;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * What a member earns — the Loop 2100A {@code ICM} of the X12 834 (005010X220A1). A member has at
+ * most one, since the 834 permits a single ICM per member.
+ * <p>
+ * {@link #frequency} and {@link #amount} are the pair that carries the meaning: an amount without
+ * the period it covers says nothing, which is why the 834 makes both mandatory. The rest describes
+ * the job around it — {@link #hours} worked in that period, the {@link #locationIdentifier} the
+ * member works at, their {@link #salaryGrade}, and the {@link #currencyCode} the amount is in.
+ * <p>
+ * <b>The mandatory pair binds the optional elements.</b> BCBS Kansas asks for a department number at
+ * {@code ICM04} and a wage at {@code ICM02}; a sponsor that holds the department but not the pay
+ * cannot emit the department alone, because an ICM without a frequency and an amount is not
+ * conformant. That constraint belongs to the 834, and this library surfaces it as a rejection
+ * rather than emitting a malformed segment.
+ * <p>
+ * Amounts and quantities are carried as strings so the caller's own formatting reaches the wire
+ * unchanged — a decimal rounded on the way through would be a silent restatement of someone's pay.
+ * <p>
+ * This is a pure domain object; translation to 834 segments is the writer's job.
+ */
+@Getter
+@Setter
+public class Income {
+    /** The period {@link #amount} covers (ICM01) — required. */
+    private FrequencyCode frequency;
+    /** What the member earns in that period (ICM02) — required. */
+    private String amount;
+    /** Hours worked in that period (ICM03). */
+    private String hours;
+    /** Where the member works (ICM04); BCBS Kansas carries its department number here. */
+    private String locationIdentifier;
+    /** The member's salary grade (ICM05). */
+    private String salaryGrade;
+    /** The currency {@link #amount} is in (ICM06), e.g. {@code USD}. */
+    private String currencyCode;
+
+    public Income() {
+    }
+
+    /**
+     * @param frequency the period the amount covers (ICM01)
+     * @param amount    what the member earns in that period (ICM02)
+     */
+    public Income(FrequencyCode frequency, String amount) {
+        this.frequency = frequency;
+        this.amount = amount;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberIncome.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberIncome.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.ICMSegment;
+import lombok.Getter;
+
+/**
+ * The ICM (Individual Income) segment in Loop 2100A of the X12 834 (005010X220A1) — what the member
+ * earns.
+ * <p>
+ * Nothing is defaulted. A frequency guessed wrong misstates someone's pay by an order of magnitude,
+ * and a currency assumed is a currency unstated, so both are supplied by the caller or absent.
+ * BCBS Kansas's use renders as {@code ICM*4*4500**DEPT42~} — a monthly wage, with the department
+ * number riding ICM04.
+ */
+@Getter
+public class MemberIncome extends ICMSegment {
+
+    private MemberIncome(Builder builder) throws ValidationException {
+        super(builder);
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link MemberIncome}. */
+    public static class Builder extends ICMSegment.AbstractBuilder<Builder> {
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        @Override
+        public MemberIncome build() throws ValidationException {
+            return new MemberIncome(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/ICMSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/ICMSegment.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.data.FrequencyCode;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import lombok.Getter;
+
+/**
+ * Represents the ICM (Individual Income) segment in the X12 834 (005010X220A1) Benefit Enrollment
+ * and Maintenance transaction.
+ * <p>
+ * The segment carries what the member earns, in Loop 2100A — the input to eligibility, deductibles
+ * and contribution calculations that depend on pay. The 834 transmits it only "when such
+ * transmission is required under the insurance contract between the sponsor and payer".
+ * <p>
+ * Element/position map (data elements per the 834 TR3):
+ * <ul>
+ *     <li>ICM01 = frequency code (594) — <b>mandatory</b>; the period ICM02 covers</li>
+ *     <li>ICM02 = monetary amount (782, R 1/18) — <b>mandatory</b>; the wage itself</li>
+ *     <li>ICM03 = quantity (380, R 1/15) — hours worked in that period</li>
+ *     <li>ICM04 = location identifier (310, AN 1/30) — where the member works</li>
+ *     <li>ICM05 = salary grade (1214, AN 1/5)</li>
+ *     <li>ICM06 = currency code (100, ID 3/3)</li>
+ * </ul>
+ * <p>
+ * <b>ICM01 and ICM02 are mandatory, which has a consequence worth stating plainly:</b> the later
+ * elements cannot be sent on their own. A carrier that wants only the location identifier — BCBS
+ * Kansas places its department number at ICM04 — still has to supply a frequency and an amount,
+ * because an ICM without them is not a conformant segment. That is a property of the 834, not a
+ * choice made here; this class refuses to emit the alternative rather than shipping a segment with
+ * empty mandatory elements.
+ */
+@Getter
+public abstract class ICMSegment extends Segment {
+    public static final String SEGMENT_ID = "ICM";
+
+    /** Element 782 is R 1/18. */
+    public static final int MAX_MONETARY_AMOUNT_LENGTH = 18;
+    /** Element 380 is R 1/15. */
+    public static final int MAX_QUANTITY_LENGTH = 15;
+    /** Element 310 is AN 1/30. */
+    public static final int MAX_LOCATION_IDENTIFIER_LENGTH = 30;
+    /** Element 1214 is AN 1/5. */
+    public static final int MAX_SALARY_GRADE_LENGTH = 5;
+    /** Element 100 is ID 3/3. */
+    public static final int CURRENCY_CODE_LENGTH = 3;
+
+    protected final FrequencyCode icm01;
+    protected final String icm02;
+    protected final String icm03;
+    protected final String icm04;
+    protected final String icm05;
+    protected final String icm06;
+
+    protected ICMSegment(AbstractBuilder<?> builder) throws ValidationException {
+        this.icm01 = builder.icm01;
+        this.icm02 = builder.icm02;
+        this.icm03 = builder.icm03;
+        this.icm04 = builder.icm04;
+        this.icm05 = builder.icm05;
+        this.icm06 = builder.icm06;
+
+        validate();
+    }
+
+    private void validate() throws ValidationException {
+        if (icm01 == null) {
+            throw new ValidationException("Frequency Code (ICM01) is required");
+        }
+        if (icm02 == null || icm02.isEmpty()) {
+            throw new ValidationException("Monetary Amount (ICM02) is required");
+        }
+        maxLength(icm02, MAX_MONETARY_AMOUNT_LENGTH, "Monetary Amount (ICM02)");
+        maxLength(icm03, MAX_QUANTITY_LENGTH, "Quantity (ICM03)");
+        maxLength(icm04, MAX_LOCATION_IDENTIFIER_LENGTH, "Location Identifier (ICM04)");
+        maxLength(icm05, MAX_SALARY_GRADE_LENGTH, "Salary Grade (ICM05)");
+        if (icm06 != null && !icm06.isEmpty() && icm06.length() != CURRENCY_CODE_LENGTH) {
+            throw new ValidationException("Currency Code (ICM06) must be exactly "
+                    + CURRENCY_CODE_LENGTH + " characters; got '" + icm06 + "'");
+        }
+    }
+
+    private static void maxLength(String value, int max, String label) throws ValidationException {
+        if (value != null && value.length() > max) {
+            throw new ValidationException(label + " must be " + max + " characters or less");
+        }
+    }
+
+    @Override
+    public String getSegmentIdentifier() {
+        return SEGMENT_ID;
+    }
+
+    @Override
+    public String[] getElementValues() {
+        return new String[]{icm01.getCode(), icm02, icm03, icm04, icm05, icm06};
+    }
+
+    /** @return ICM01 — the period {@link #getMonetaryAmount()} covers. */
+    public FrequencyCode getFrequencyCode() {
+        return getIcm01();
+    }
+
+    /** @return ICM02 — what the member earns in that period. */
+    public String getMonetaryAmount() {
+        return getIcm02();
+    }
+
+    /** @return ICM03 — hours worked in that period. */
+    public String getQuantity() {
+        return getIcm03();
+    }
+
+    /** @return ICM04 — where the member works. */
+    public String getLocationIdentifier() {
+        return getIcm04();
+    }
+
+    /** @return ICM05 — the member's salary grade. */
+    public String getSalaryGrade() {
+        return getIcm05();
+    }
+
+    /** @return ICM06 — the currency the amount is in. */
+    public String getCurrencyCode() {
+        return getIcm06();
+    }
+
+    /**
+     * Abstract builder for ICM segments.
+     *
+     * @param <T> the concrete builder type, for chaining
+     */
+    public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
+        protected FrequencyCode icm01;
+        protected String icm02;
+        protected String icm03;
+        protected String icm04;
+        protected String icm05;
+        protected String icm06;
+
+        protected abstract T self();
+
+        /** Sets ICM01 (the period the amount covers). */
+        public T setFrequencyCode(FrequencyCode value) {
+            this.icm01 = value;
+            return self();
+        }
+
+        /** Sets ICM02 (what the member earns in that period). */
+        public T setMonetaryAmount(String value) {
+            this.icm02 = value;
+            return self();
+        }
+
+        /** Sets ICM03 (hours worked in that period). */
+        public T setQuantity(String value) {
+            this.icm03 = value;
+            return self();
+        }
+
+        /** Sets ICM04 (where the member works). */
+        public T setLocationIdentifier(String value) {
+            this.icm04 = value;
+            return self();
+        }
+
+        /** Sets ICM05 (the member's salary grade). */
+        public T setSalaryGrade(String value) {
+            this.icm05 = value;
+            return self();
+        }
+
+        /** Sets ICM06 (the currency the amount is in). */
+        public T setCurrencyCode(String value) {
+            this.icm06 = value;
+            return self();
+        }
+
+        /** @return the built segment. */
+        public abstract ICMSegment build() throws ValidationException;
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/data/FrequencyCodeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/data/FrequencyCodeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.data;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FrequencyCodeTest {
+
+    @ParameterizedTest
+    @EnumSource(FrequencyCode.class)
+    void resolvesFromCodeNameAndDescription(FrequencyCode constant) {
+        assertEquals(constant, FrequencyCode.fromString(constant.getCode()));
+        assertEquals(constant, FrequencyCode.fromString(constant.name()));
+        assertEquals(constant, FrequencyCode.fromString(constant.getDescription()));
+    }
+
+    @Test
+    void codesAreUnique() {
+        Map<String, FrequencyCode> byCode = new HashMap<>();
+        for (FrequencyCode constant : FrequencyCode.values()) {
+            FrequencyCode prior = byCode.put(constant.getCode(), constant);
+            assertNull(prior, () -> "duplicate code '" + constant.getCode() + "'");
+        }
+    }
+
+    /** The complete element 594 list — note it skips I, K–P, R and T–Y. */
+    @ParameterizedTest
+    @CsvSource({
+            "0,ANNUALIZED", "1,WEEKLY", "2,BIWEEKLY", "3,SEMIMONTHLY", "4,MONTHLY", "5,OTHER",
+            "6,DAILY", "7,ANNUAL", "8,TWO_CALENDAR_MONTHS", "9,LUMP_SUM_SEPARATION_ALLOWANCE",
+            "A,QUARTER_TO_DATE", "B,YEAR_TO_DATE", "C,SINGLE", "D,POLICY_PERIOD", "E,CLAIM_PERIOD",
+            "F,UNIT_REPORT_IDENTIFIER", "G,MONTH_TO_DATE", "H,HOURLY", "J,CURRENT_PERIOD",
+            "Q,QUARTERLY", "S,SEMIANNUAL", "U,UNKNOWN", "Z,MUTUALLY_DEFINED"})
+    void mapsEachCodeToItsElement594Meaning(String code, FrequencyCode expected) {
+        assertEquals(expected, FrequencyCode.fromString(code));
+    }
+
+    /**
+     * {@code 0} (Annualized; 12-month equivalent) and {@code 7} (Annual) are distinct: the first is
+     * a figure scaled up to a year, the second a figure actually paid over one. Conflating them
+     * would restate a part-year wage as a full-year one.
+     */
+    @Test
+    void annualizedIsNotAnnual()
+    {
+        assertEquals("0", FrequencyCode.ANNUALIZED.getCode());
+        assertEquals("7", FrequencyCode.ANNUAL.getCode());
+    }
+
+    @Test
+    void toStringIsTheRawCode() {
+        assertEquals("4", FrequencyCode.MONTHLY.toString());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "not-a-real-value", "I", "K", "T"})
+    void rejectsNullEmptyAndUnknown(String input) {
+        assertThrows(IllegalArgumentException.class, () -> FrequencyCode.fromString(input));
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
@@ -18,6 +18,8 @@ import com.fastChickensHR.edi.x834.data.PayerResponsibilitySequenceCode;
 import com.fastChickensHR.edi.x834.data.ActionCode;
 import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
+import com.fastChickensHR.edi.x834.data.FrequencyCode;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.Income;
 import com.fastChickensHR.edi.x834.loop2000.loop2310.Provider;
 import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits;
 import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
@@ -466,6 +468,77 @@ class X834MemberWriterTest {
         ValidationException ex = assertThrows(ValidationException.class, () -> writer.toSegments(member));
 
         assertTrue(ex.getMessage().contains("at most 3"), ex.getMessage());
+    }
+
+    @Test
+    void emitsTheIcmAfterTheDmg() throws ValidationException {
+        // 834 Loop 2100A order: NM1, PER, N3, N4, DMG, ICM.
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
+        Income income = new Income(FrequencyCode.MONTHLY, "4500");
+        income.setLocationIdentifier("DEPT42");
+        member.setIncome(income);
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("ICM*4*4500**DEPT42~"),
+                () -> "expected the BCBS Kansas ICM shape; got:\n" + out);
+        assertTrue(out.indexOf("DMG*") < out.indexOf("ICM*"),
+                () -> "the ICM must follow the DMG; got:\n" + out);
+    }
+
+    @Test
+    void emitsTheIcmEvenWhenTheMemberHasNoDemographics() throws ValidationException {
+        // The DMG is emitted only when a birth date is present; the ICM must not depend on it.
+        Member member = baseSubscriber();
+        member.setIncome(new Income(FrequencyCode.HOURLY, "24.50"));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("ICM*H*24.50~"), () -> "expected the ICM; got:\n" + out);
+        assertFalse(out.contains("DMG*"), () -> "no DMG without a birth date; got:\n" + out);
+    }
+
+    @Test
+    void omitsTheIcmWhenTheMemberHasNoIncome() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+
+        String out = render(writer.toSegments(member));
+
+        assertFalse(out.contains("ICM"), () -> "no ICM without an income; got:\n" + out);
+    }
+
+    @Test
+    void rejectsAnIncomeCarryingOnlyTheDepartmentNumber() throws ValidationException {
+        // The Kansas case: a sponsor holding the department number but not the wage cannot emit the
+        // department alone, because ICM01/ICM02 are mandatory.
+        Member member = baseSubscriber();
+        Income income = new Income();
+        income.setLocationIdentifier("DEPT42");
+        member.setIncome(income);
+
+        ValidationException ex = assertThrows(ValidationException.class, () -> writer.toSegments(member));
+
+        assertTrue(ex.getMessage().contains("ICM01"), ex.getMessage());
+    }
+
+    @Test
+    void emitsAnIcmForEachDependentThatCarriesOne() throws ValidationException {
+        Member subscriber = baseSubscriber();
+        subscriber.setIncome(new Income(FrequencyCode.MONTHLY, "4500"));
+        DependentMember dependent = new DependentMember();
+        dependent.setMemberIndicator(MemberIndicator.NOT_INSURED);
+        dependent.setRelationshipCode(IndividualRelationshipCode.SPOUSE);
+        dependent.setMaintenanceTypeCode(MaintenanceTypeCode.ADDITION);
+        dependent.setIncome(new Income(FrequencyCode.WEEKLY, "800"));
+        subscriber.addDependent(dependent);
+
+        String out = render(writer.toSegments(subscriber));
+
+        assertTrue(out.contains("ICM*4*4500~"), () -> "expected the subscriber's ICM; got:\n" + out);
+        assertTrue(out.contains("ICM*1*800~"), () -> "expected the dependent's own ICM; got:\n" + out);
     }
 
     @Test

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberIncomeTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberIncomeTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.data.FrequencyCode;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.ICMSegment;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MemberIncomeTest {
+    private final X834Context context = new X834Context();
+
+    private String render(ICMSegment segment) {
+        segment.setContext(context);
+        return segment.render().trim();
+    }
+
+    @Test
+    void rendersTheBcbsKansasShapeWithTheDepartmentNumberOnIcm04() throws ValidationException {
+        // Kansas places its department number at ICM04 — "Location Identification Code … Department
+        // Number if applicable" — and the wage at ICM02. ICM03 is empty between them, so it renders
+        // as an empty element rather than being trimmed.
+        ICMSegment income = MemberIncome.builder()
+                .setFrequencyCode(FrequencyCode.MONTHLY)
+                .setMonetaryAmount("4500")
+                .setLocationIdentifier("DEPT42")
+                .build();
+
+        assertEquals("ICM*4*4500**DEPT42~", render(income));
+    }
+
+    @Test
+    void rendersTheMandatoryPairAloneWithNoTrailingElements() throws ValidationException {
+        ICMSegment income = MemberIncome.builder()
+                .setFrequencyCode(FrequencyCode.HOURLY)
+                .setMonetaryAmount("24.50")
+                .build();
+
+        assertEquals("ICM*H*24.50~", render(income));
+    }
+
+    @Test
+    void carriesEveryElementWhenAllArePresent() throws ValidationException {
+        ICMSegment income = MemberIncome.builder()
+                .setFrequencyCode(FrequencyCode.WEEKLY)
+                .setMonetaryAmount("1200")
+                .setQuantity("40")
+                .setLocationIdentifier("DEPT42")
+                .setSalaryGrade("G7")
+                .setCurrencyCode("USD")
+                .build();
+
+        assertEquals("ICM*1*1200*40*DEPT42*G7*USD~", render(income));
+        assertEquals("ICM", income.getSegmentIdentifier());
+        assertEquals(FrequencyCode.WEEKLY, income.getFrequencyCode());
+        assertEquals("DEPT42", income.getLocationIdentifier());
+    }
+
+    @Test
+    void preservesTheCallersOwnAmountFormatting() throws ValidationException {
+        // The amount is carried as written. Reformatting or rounding it here would be a silent
+        // restatement of someone's pay.
+        ICMSegment income = MemberIncome.builder()
+                .setFrequencyCode(FrequencyCode.ANNUAL)
+                .setMonetaryAmount("52000.00")
+                .build();
+
+        assertEquals("ICM*7*52000.00~", render(income));
+    }
+
+    @Test
+    void rejectsAnIncomeWithNoFrequency() {
+        // ICM01 is mandatory, and an amount without its period is meaningless — 2000 could be
+        // weekly or annual.
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberIncome.builder().setMonetaryAmount("4500").build());
+
+        assertTrue(ex.getMessage().contains("ICM01"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsALocationIdentifierSentWithoutTheMandatoryPair() {
+        // The case a carrier hits wanting only Kansas's ICM04 department number: the 834 will not
+        // carry it alone, because ICM01/ICM02 are mandatory.
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberIncome.builder().setLocationIdentifier("DEPT42").build());
+
+        assertTrue(ex.getMessage().contains("ICM01"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsAnIncomeWithNoAmount() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberIncome.builder().setFrequencyCode(FrequencyCode.MONTHLY).build());
+
+        assertTrue(ex.getMessage().contains("ICM02"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsALocationIdentifierLongerThanElement310Allows() {
+        String tooLong = "D".repeat(ICMSegment.MAX_LOCATION_IDENTIFIER_LENGTH + 1);
+
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberIncome.builder()
+                        .setFrequencyCode(FrequencyCode.MONTHLY)
+                        .setMonetaryAmount("4500")
+                        .setLocationIdentifier(tooLong)
+                        .build());
+
+        assertTrue(ex.getMessage().contains("30"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsASalaryGradeLongerThanElement1214Allows() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberIncome.builder()
+                        .setFrequencyCode(FrequencyCode.MONTHLY)
+                        .setMonetaryAmount("4500")
+                        .setSalaryGrade("GRADE7")
+                        .build());
+
+        assertTrue(ex.getMessage().contains("5"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsACurrencyCodeThatIsNotThreeCharacters() {
+        // Element 100 is ID 3/3 — "US" is not a currency code.
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberIncome.builder()
+                        .setFrequencyCode(FrequencyCode.MONTHLY)
+                        .setMonetaryAmount("4500")
+                        .setCurrencyCode("US")
+                        .build());
+
+        assertTrue(ex.getMessage().contains("ICM06"), ex.getMessage());
+    }
+}


### PR DESCRIPTION
The fourth follow-on slice of #139, after PER, COB and 2310. Full suite green.

> ⚠️ **Stacked on #194** (2310), which touches the same two files. Merge #194 first — and **retarget this to `master` before you do** (`gh pr edit 195 --base master`), because deleting a base branch auto-closes its child irreversibly. That's how #190 was lost.

## Why

BCBS Kansas places its department number at **`2100A ICM04`** — *"Location Identification Code … Department Number if applicable"* — and a wage amount at **`ICM02`**. `edi` had no ICM segment at all, so both were unemittable. The 0561 profile is explicit that this is an **`edi` gap, not a catalog gap**, of the same class as the missing PER and 2310.

It's also a vindication of #606's placement model: a placement is loop + segment + qualifier, and `2100A ICM04` is a legal position the mechanism absorbed with no change — *"in a different loop and a different segment type"*.

## ⚠️ The finding that matters for seeding

**`ICM01` (frequency) and `ICM02` (monetary amount) are both mandatory.** So `ICM04` **cannot be emitted on its own**.

A sponsor that holds a member's department number but not their wage cannot send the department alone — an ICM without a frequency and an amount is not a conformant segment. `X834_DEPARTMENT_NUMBER` at this placement therefore **drags a frequency and an amount with it**, which is a real constraint on the Kansas catalog work and not something the library can paper over.

This surfaces as a rejection rather than a segment with empty mandatory slots. Two tests pin it, including `rejectsALocationIdentifierSentWithoutTheMandatoryPair` — named for exactly the case a carrier hits.

## What

- **`FrequencyCode`** (element 594) — the complete 23-code list.
- **`ICMSegment`** — all six elements, with each one's published length enforced (782 R 1/18, 380 R 1/15, 310 AN 1/30, 1214 AN 1/5, 100 ID 3/3).
- **`MemberIncome`** — the 2100A ICM.
- **`Income`** — the domain value on `BaseMember`. A **single value, not a list**: the 834 permits one ICM per member (max use 1), unlike the 2310/2320/2700 loops.

### Nothing is defaulted

A frequency guessed wrong misstates someone's pay by an order of magnitude. Element 594 distinguishes `0` "Annualized; 12-month equivalent" from `7` "Annual" — a figure *scaled up* to a year versus one actually *paid* over one — and `annualizedIsNotAnnual` pins that they stay distinct.

Amounts and quantities are carried as **strings**, so the caller's own formatting reaches the wire unchanged. Parsing to a decimal and reformatting would silently restate a wage.

## Emission

The ICM emits after the DMG, per Loop 2100A order (NM1, PER, N3, N4, DMG, EC, ICM), and only when the member carries income — the 834 sends it only "when such transmission is required under the insurance contract between the sponsor and payer", so absence is the normal case.

`emitsTheIcmEvenWhenTheMemberHasNoDemographics` guards a subtle coupling: the DMG is itself conditional on a birth date, and the ICM must not inherit that condition.

Mutation-checked the placement — emitting the ICM before the DMG fails `emitsTheIcmAfterTheDmg`.

## Not included

**EC (Employment Class)**, which sits between DMG and ICM in 2100A. No profiled carrier demands it, and Kansas's related "employment position" concept sits at `2000 REF*P5`, not EC.

## Tests

23 new across two classes, plus 5 writer tests. One correction worth noting: my first expectation for the Kansas shape was `ICM*4*4500***DEPT42~`, and the code was right — a single empty element renders as **two** adjacent asterisks, not three (`ICM*4*4500**DEPT42~`), consistent with the PLA case in #194.

Part of #139 (remaining: 2200 `DSB`, `LUI`, `HLH` — all tail-priority in the 0569 catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)