### PR TITLE
feat(x834): disability 2200, member language and health info 2100A (#139)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/DisabilityTypeCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/DisabilityTypeCode.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.data;
+
+import com.fastChickensHR.edi.x834.util.EdiCodeEnum;
+import com.fastChickensHR.edi.x834.util.EdiEnumLookup;
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * Code values for the X12 Disability Type Code (data element 1146), which identifies an
+ * individual's disability status. In the X12 834 (005010X220A1) it appears as DSB01, the mandatory
+ * element opening Loop 2200.
+ *
+ * <p>{@link #NO_DISABILITY} is a stated answer rather than an absence — a sponsor saying "this
+ * member is not disabled" is different from sending no Loop 2200 at all, and only the former
+ * overwrites a disability a carrier already holds.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a value
+ * from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
+ */
+@Getter
+public enum DisabilityTypeCode implements EdiCodeEnum {
+    SHORT_TERM_DISABILITY("1", "Short Term Disability"),
+    LONG_TERM_DISABILITY("2", "Long Term Disability"),
+    PERMANENT_OR_TOTAL_DISABILITY("3", "Permanent or Total Disability"),
+    NO_DISABILITY("4", "No Disability"),
+    PARTIAL_DISABILITY("5", "Partial Disability"),
+    MUTUALLY_DEFINED("Z", "Mutually Defined");
+
+    private final String code;
+    private final String description;
+    private static final EdiEnumLookup<DisabilityTypeCode> LOOKUP;
+
+    static {
+        LOOKUP = new EdiEnumLookup<>(
+                DisabilityTypeCode.class,
+                "Disability Type Code",
+                Map.ofEntries(
+                        Map.entry("std", SHORT_TERM_DISABILITY),
+                        Map.entry("short term", SHORT_TERM_DISABILITY),
+                        Map.entry("ltd", LONG_TERM_DISABILITY),
+                        Map.entry("long term", LONG_TERM_DISABILITY),
+                        Map.entry("permanent", PERMANENT_OR_TOTAL_DISABILITY),
+                        Map.entry("total", PERMANENT_OR_TOTAL_DISABILITY),
+                        Map.entry("none", NO_DISABILITY),
+                        Map.entry("not disabled", NO_DISABILITY),
+                        Map.entry("partial", PARTIAL_DISABILITY)
+                )
+        );
+    }
+
+    DisabilityTypeCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    /**
+     * Gets a DisabilityTypeCode instance from any input string.
+     * Matches against codes, names, descriptions, and common variations.
+     *
+     * @param input the string to look up
+     * @return the matching DisabilityTypeCode
+     * @throws IllegalArgumentException if no match is found
+     */
+    public static DisabilityTypeCode fromString(String input) {
+        return LOOKUP.fromString(input);
+    }
+
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
+    @Override
+    public String toString() {
+        return code;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/HealthRelatedCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/HealthRelatedCode.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.data;
+
+import com.fastChickensHR.edi.x834.util.EdiCodeEnum;
+import com.fastChickensHR.edi.x834.util.EdiEnumLookup;
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * Code values for the X12 Health-Related Code (data element 1212), which states a specific health
+ * situation. In the X12 834 (005010X220A1) it appears as HLH01 in Loop 2100A — in practice the
+ * member's tobacco and substance-use status, a rating input for individual and small-group
+ * products.
+ *
+ * <p>Note that {@link #NONE} and {@link #UNKNOWN} are different answers: {@code N} asserts the
+ * member uses neither, while {@code U} says nobody asked. Collapsing them would turn a missing
+ * answer into a negative one, which for a rated product is a statement about price.
+ *
+ * <p>No default value is defined for this element. {@link #fromString(String)} resolves a value
+ * from its code, enum name, description, or a common synonym, and throws
+ * {@link IllegalArgumentException} when the input matches none.
+ */
+@Getter
+public enum HealthRelatedCode implements EdiCodeEnum {
+    NONE("N", "None"),
+    SUBSTANCE_ABUSE("S", "Substance Abuse"),
+    TOBACCO_USE("T", "Tobacco Use"),
+    UNKNOWN("U", "Unknown"),
+    TOBACCO_USE_AND_SUBSTANCE_ABUSE("X", "Tobacco Use and Substance Abuse");
+
+    private final String code;
+    private final String description;
+    private static final EdiEnumLookup<HealthRelatedCode> LOOKUP;
+
+    static {
+        LOOKUP = new EdiEnumLookup<>(
+                HealthRelatedCode.class,
+                "Health-Related Code",
+                Map.ofEntries(
+                        Map.entry("tobacco", TOBACCO_USE),
+                        Map.entry("smoker", TOBACCO_USE),
+                        Map.entry("non smoker", NONE),
+                        Map.entry("neither", NONE),
+                        Map.entry("both", TOBACCO_USE_AND_SUBSTANCE_ABUSE),
+                        Map.entry("not asked", UNKNOWN)
+                )
+        );
+    }
+
+    HealthRelatedCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    /**
+     * Gets a HealthRelatedCode instance from any input string.
+     * Matches against codes, names, descriptions, and common variations.
+     *
+     * @param input the string to look up
+     * @return the matching HealthRelatedCode
+     * @throws IllegalArgumentException if no match is found
+     */
+    public static HealthRelatedCode fromString(String input) {
+        return LOOKUP.fromString(input);
+    }
+
+    /**
+     * Returns the raw X12 code value for this constant (not the enum name), so the enum
+     * renders directly into an EDI element.
+     */
+    @Override
+    public String toString() {
+        return code;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -14,8 +14,11 @@ import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.HealthInformation;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.Income;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.Language;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication;
+import com.fastChickensHR.edi.x834.loop2000.loop2200.Disability;
 import com.fastChickensHR.edi.x834.loop2000.loop2310.Provider;
 import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits;
 import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
@@ -98,6 +101,12 @@ public abstract class BaseMember {
      * {@code ICM}.
      */
     protected Income income;
+    /**
+     * This member's health-related status (Loop 2100A {@code HLH}) — tobacco and substance use, plus
+     * height and weight. Emitted by {@link X834MemberWriter} after the {@code ICM}, and only when
+     * present. A member has at most one, the 834 permitting a single {@code HLH}.
+     */
+    protected HealthInformation healthInformation;
 
     /**
      * All of this member's postal addresses, keyed by {@link AddressType}. A member may carry a
@@ -216,6 +225,46 @@ public abstract class BaseMember {
      */
     public void addCommunication(CommunicationNumberQualifier qualifier, String number) {
         addCommunication(new MemberCommunication(qualifier, number));
+    }
+
+    /**
+     * The languages this member uses (Loop 2100A {@code LUI}). Emitted by {@link X834MemberWriter}
+     * after the {@code HLH}, one {@code LUI} per entry, in the order added. Empty for a member with
+     * none, in which case nothing is emitted.
+     *
+     * @see #addLanguage(Language)
+     */
+    private final List<Language> languages = new ArrayList<>();
+
+    /**
+     * Adds a language this member uses (Loop 2100A {@code LUI}). Order is preserved.
+     *
+     * @param language the language to emit (ignored if null)
+     */
+    public void addLanguage(Language language) {
+        if (language != null) {
+            languages.add(language);
+        }
+    }
+
+    /**
+     * The disabilities this member has (Loop 2200). Emitted by {@link X834MemberWriter} after the
+     * 2100 loops and before the 2300 coverage segments, one {@code DSB}(/{@code DTP}) block per
+     * entry. Empty for a member with none, in which case nothing is emitted.
+     *
+     * @see #addDisability(Disability)
+     */
+    private final List<Disability> disabilities = new ArrayList<>();
+
+    /**
+     * Adds a disability this member has (Loop 2200). Order is preserved.
+     *
+     * @param disability the disability to emit (ignored if null)
+     */
+    public void addDisability(Disability disability) {
+        if (disability != null) {
+            disabilities.add(disability);
+        }
     }
 
     /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -21,17 +21,23 @@ import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
 import com.fastChickensHR.edi.x834.data.DateTimeQualifier;
 import com.fastChickensHR.edi.x834.loop2000.data.BenefitStatusCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberDateQualifier;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.HealthInformation;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.Income;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.Language;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunicationsNumbers;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberDemographics;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberHealthInformation;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberIncome;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberLanguage;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberName;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceCityStateZipCode;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberResidenceStreetAddress;
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingAddress;
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingCityStateZipCode;
 import com.fastChickensHR.edi.x834.loop2000.loop2100C.MemberMailingStreetAddress;
+import com.fastChickensHR.edi.x834.loop2000.loop2200.Disability;
+import com.fastChickensHR.edi.x834.loop2000.loop2200.MemberDisability;
 import com.fastChickensHR.edi.x834.loop2000.loop2310.Provider;
 import com.fastChickensHR.edi.x834.loop2000.loop2310.ProviderChange;
 import com.fastChickensHR.edi.x834.loop2000.loop2310.ProviderName;
@@ -138,10 +144,15 @@ public class X834MemberWriter {
         appendResidenceAddress(segments, member);
         appendDemographics(segments, member);
         appendIncome(segments, member);
+        appendHealthInformation(segments, member);
+        appendLanguages(segments, member);
 
         // Loop 2100C (member mailing address), emitted after the 2100A block when the member
         // carries a distinct mailing address.
         appendMailingAddress(segments, member);
+
+        // Loop 2200 (disability), emitted after the 2100 loops and before the 2300 block.
+        appendDisabilities(segments, member);
 
         // Loop 2300: this member's own trailing segments (health coverage HD, REF extensions).
         // Emitting them here keeps a member's coverage nested inside its own loop, before any
@@ -290,8 +301,8 @@ public class X834MemberWriter {
                         .setReferenceIdentification(other.getGroupNumber())
                         .build());
             }
-            addCobDateSegment(segments, DateTimeQualifier.COORDINATION_OF_BENEFITS_BEGIN, other.getBeginDate());
-            addCobDateSegment(segments, DateTimeQualifier.COORDINATION_OF_BENEFITS_END, other.getEndDate());
+            addQualifiedDate(segments, DateTimeQualifier.COORDINATION_OF_BENEFITS_BEGIN, other.getBeginDate());
+            addQualifiedDate(segments, DateTimeQualifier.COORDINATION_OF_BENEFITS_END, other.getEndDate());
             if (!isBlank(other.getRelatedEntityName())) {
                 segments.add(CoordinationOfBenefitsRelatedEntityName.builder()
                         .setRelatedEntityName(other.getRelatedEntityName())
@@ -300,8 +311,8 @@ public class X834MemberWriter {
         }
     }
 
-    /** A 2320 coordination date, emitted only when present. */
-    private void addCobDateSegment(List<Segment> segments, DateTimeQualifier qualifier, LocalDateTime date)
+    /** A date under an explicit DTP qualifier, emitted only when present. */
+    private void addQualifiedDate(List<Segment> segments, DateTimeQualifier qualifier, LocalDateTime date)
             throws ValidationException {
         if (date == null) {
             return;
@@ -449,6 +460,65 @@ public class X834MemberWriter {
                 .setSalaryGrade(emptyToNull(income.getSalaryGrade()))
                 .setCurrencyCode(emptyToNull(income.getCurrencyCode()))
                 .build());
+    }
+
+    /**
+     * Loop 2100A HLH (member health information), emitted after the ICM when the member carries it.
+     * BCBSM notes the health-related code "may be required for specific employer groups", so
+     * whether to send it is a config-time answer and absence is the normal case.
+     */
+    private void appendHealthInformation(List<Segment> segments, BaseMember member) throws ValidationException {
+        HealthInformation health = member.getHealthInformation();
+        if (health == null) {
+            return;
+        }
+        segments.add(MemberHealthInformation.builder()
+                .setHealthRelatedCode(health.getHealthRelatedCode())
+                .setHeight(emptyToNull(health.getHeight()))
+                .setCurrentWeight(emptyToNull(health.getCurrentWeight()))
+                .setPreviousWeight(emptyToNull(health.getPreviousWeight()))
+                .setDescription(emptyToNull(health.getDescription()))
+                .build());
+    }
+
+    /**
+     * Loop 2100A LUI (member language), emitted after the HLH — one per language the member uses,
+     * in the order added. Suppressed when the member carries none.
+     */
+    private void appendLanguages(List<Segment> segments, BaseMember member) throws ValidationException {
+        for (Language language : member.getLanguages()) {
+            segments.add(MemberLanguage.builder()
+                    .setLanguage(language.getCodeQualifier(), emptyToNull(language.getCode()))
+                    .setDescription(emptyToNull(language.getDescription()))
+                    .build());
+        }
+    }
+
+    /**
+     * Loop 2200 (disability): per disability, a {@code DSB} followed by its {@code DTP*360}/
+     * {@code DTP*361} period dates. Emitted after the 2100 loops and before the 2300 coverage
+     * segments, and suppressed when the member has none.
+     * <p>
+     * BCBSM asks for the period rather than the detail, but DSB01 is mandatory, so the dates cannot
+     * travel alone — a sponsor sending a disability period must also say what kind of disability it
+     * is. The guide itself is wrong on this point, reading "DTP01 … Start / DTP02 … End" when DTP02
+     * is the date-format qualifier; two dates are two DTP segments, which is what this emits.
+     */
+    private void appendDisabilities(List<Segment> segments, BaseMember member) throws ValidationException {
+        for (Disability disability : member.getDisabilities()) {
+            segments.add(MemberDisability.builder()
+                    .setDisabilityTypeCode(disability.getType())
+                    .setQuantity(emptyToNull(disability.getQuantity()))
+                    .setOccupationCode(emptyToNull(disability.getOccupationCode()))
+                    .setWorkIntensityCode(emptyToNull(disability.getWorkIntensityCode()))
+                    .setProductOptionCode(emptyToNull(disability.getProductOptionCode()))
+                    .setMonetaryAmount(emptyToNull(disability.getMonetaryAmount()))
+                    .build());
+            addQualifiedDate(segments, DateTimeQualifier.INITIAL_DISABILITY_PERIOD_START,
+                    disability.getStartDate());
+            addQualifiedDate(segments, DateTimeQualifier.INITIAL_DISABILITY_PERIOD_END,
+                    disability.getEndDate());
+        }
     }
 
     /** Loop 2100A DMG (member demographics). Emitted when a birth date is present. */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/HealthInformation.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/HealthInformation.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.data.HealthRelatedCode;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * The member's health-related status — the Loop 2100A {@code HLH} of the X12 834 (005010X220A1). A
+ * member has at most one.
+ * <p>
+ * {@link #healthRelatedCode} is what carriers actually ask for: tobacco and substance use, a rating
+ * input for individual and small-group products. BCBSM notes it "may be required for specific
+ * employer groups", so whether to send it is a config-time answer. The height and weight elements
+ * round the segment out.
+ * <p>
+ * Heights and weights are carried as strings so the caller's own precision reaches the wire
+ * unchanged.
+ * <p>
+ * This is a pure domain object; translation to 834 segments is the writer's job.
+ */
+@Getter
+@Setter
+public class HealthInformation {
+    /** The member's tobacco/substance status (HLH01). */
+    private HealthRelatedCode healthRelatedCode;
+    /** The member's height (HLH02). */
+    private String height;
+    /** The member's current weight (HLH03). */
+    private String currentWeight;
+    /** The member's previous weight (HLH04). */
+    private String previousWeight;
+    /** Why the weight changed (HLH05). */
+    private String description;
+
+    public HealthInformation() {
+    }
+
+    /**
+     * @param healthRelatedCode the member's tobacco/substance status (HLH01)
+     */
+    public HealthInformation(HealthRelatedCode healthRelatedCode) {
+        this.healthRelatedCode = healthRelatedCode;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/Language.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/Language.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * A language the member uses — one Loop 2100A {@code LUI} of the X12 834 (005010X220A1). A member
+ * may carry several.
+ * <p>
+ * A language can be given as a {@link #code} under the {@link #codeQualifier} naming its scheme, as
+ * a plain {@link #description}, or both; at least one of the two is required, since an LUI naming
+ * no language is not a statement. BCBSM's BCN Advantage product publishes its own code protocol,
+ * which is why the scheme is supplied rather than assumed.
+ * <p>
+ * This is a pure domain object; translation to 834 segments is the writer's job.
+ */
+@Getter
+@Setter
+public class Language {
+    /** What kind of code {@link #code} is (LUI01); required when a code is given. */
+    private IdentificationCodeQualifier codeQualifier;
+    /** The language code (LUI02); paired with {@link #codeQualifier}. */
+    private String code;
+    /** The language named in words (LUI03). */
+    private String description;
+
+    public Language() {
+    }
+
+    /**
+     * @param codeQualifier what kind of code follows (LUI01)
+     * @param code          the language code (LUI02)
+     */
+    public Language(IdentificationCodeQualifier codeQualifier, String code) {
+        this.codeQualifier = codeQualifier;
+        this.code = code;
+    }
+
+    /**
+     * Names a language in words alone, with no code.
+     *
+     * @param description the language named in words (LUI03)
+     */
+    public Language(String description) {
+        this.description = description;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberHealthInformation.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberHealthInformation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.HLHSegment;
+import lombok.Getter;
+
+/**
+ * The HLH (Health Information) segment in Loop 2100A of the X12 834 (005010X220A1) — the member's
+ * health-related status.
+ * <p>
+ * Nothing is defaulted. BCBSM's tobacco use renders as {@code HLH*T~}; a member stated to use
+ * neither tobacco nor substances as {@code HLH*N~}. Those are different answers from sending no
+ * HLH at all, which says only that nobody asked.
+ */
+@Getter
+public class MemberHealthInformation extends HLHSegment {
+
+    private MemberHealthInformation(Builder builder) throws ValidationException {
+        super(builder);
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link MemberHealthInformation}. */
+    public static class Builder extends HLHSegment.AbstractBuilder<Builder> {
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        @Override
+        public MemberHealthInformation build() throws ValidationException {
+            return new MemberHealthInformation(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberLanguage.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberLanguage.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.LUISegment;
+import lombok.Getter;
+
+/**
+ * The LUI (Language Use) segment in Loop 2100A of the X12 834 (005010X220A1) — a language the
+ * member uses.
+ * <p>
+ * A member may carry several, the 834 permitting more than one LUI. Which coding scheme names the
+ * language is the carrier's to state rather than this library's to assume, so the qualifier is
+ * supplied per language.
+ */
+@Getter
+public class MemberLanguage extends LUISegment {
+
+    private MemberLanguage(Builder builder) throws ValidationException {
+        super(builder);
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link MemberLanguage}. */
+    public static class Builder extends LUISegment.AbstractBuilder<Builder> {
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        @Override
+        public MemberLanguage build() throws ValidationException {
+            return new MemberLanguage(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2200/Disability.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2200/Disability.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2200;
+
+import com.fastChickensHR.edi.x834.data.DisabilityTypeCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * A disability the member has — one occurrence of Loop 2200 in the X12 834 (005010X220A1).
+ * <p>
+ * {@link #type} is the mandatory statement of what kind of disability it is; {@link #startDate} and
+ * {@link #endDate} are the period, which is what BCBSM actually asks for ("Report 360 Initial
+ * Disability Period Start… 361 Initial Disability Period End"). The remaining elements describe the
+ * member's work and the benefit around it.
+ * <p>
+ * Because {@link #type} is mandatory in the segment, <b>the dates cannot travel without it</b>: a
+ * sponsor sending a disability period must also say what kind of disability it is.
+ * <p>
+ * This is a pure domain object; translation to 834 segments is the writer's job.
+ */
+@Getter
+@Setter
+public class Disability {
+    /** What kind of disability this is (DSB01) — required. */
+    private DisabilityTypeCode type;
+    /** The associated quantity (DSB02). */
+    private String quantity;
+    /** The member's occupation (DSB03). */
+    private String occupationCode;
+    /** How intensively the member works (DSB04). */
+    private String workIntensityCode;
+    /** The product option (DSB05). */
+    private String productOptionCode;
+    /** The associated amount (DSB06). */
+    private String monetaryAmount;
+    /** When the disability period began ({@code DTP*360}). */
+    private LocalDateTime startDate;
+    /** When it ended ({@code DTP*361}). */
+    private LocalDateTime endDate;
+
+    public Disability() {
+    }
+
+    /**
+     * @param type what kind of disability this is (DSB01)
+     */
+    public Disability(DisabilityTypeCode type) {
+        this.type = type;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2200/MemberDisability.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2200/MemberDisability.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2200;
+
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.DSBSegment;
+import lombok.Getter;
+
+/**
+ * The DSB segment opening Loop 2200 of the X12 834 (005010X220A1) — the member's disability status.
+ * <p>
+ * Nothing is defaulted: {@code 4} (No Disability) is a stated answer, not the absence of one, and
+ * assuming it would tell a carrier something the sponsor never said.
+ */
+@Getter
+public class MemberDisability extends DSBSegment {
+
+    private MemberDisability(Builder builder) throws ValidationException {
+        super(builder);
+    }
+
+    /** @return a new {@link Builder}. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link MemberDisability}. */
+    public static class Builder extends DSBSegment.AbstractBuilder<Builder> {
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        @Override
+        public MemberDisability build() throws ValidationException {
+            return new MemberDisability(this);
+        }
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/DSBSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/DSBSegment.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.data.DisabilityTypeCode;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import lombok.Getter;
+
+/**
+ * Represents the DSB (Disability Information) segment in the X12 834 (005010X220A1) Benefit
+ * Enrollment and Maintenance transaction.
+ * <p>
+ * The segment opens Loop 2200 and states the member's disability status. BCBSM's interest is the
+ * period rather than the detail — it asks for the initial disability period start and end, which
+ * ride the {@code DTP} segments that follow this one in the same loop.
+ * <p>
+ * Element/position map (data elements per the 834 TR3):
+ * <ul>
+ *     <li>DSB01 = disability type code (1146) — <b>mandatory</b></li>
+ *     <li>DSB02 = quantity (380, R 1/15)</li>
+ *     <li>DSB03 = occupation code (1149, ID 4/6)</li>
+ *     <li>DSB04 = work intensity code (1154, ID 1/1)</li>
+ *     <li>DSB05 = product option code (1161, ID 1/2)</li>
+ *     <li>DSB06 = monetary amount (782, R 1/18)</li>
+ * </ul>
+ * <b>DSB07</b> (product/service ID qualifier) and <b>DSB08</b> (medical code value) are not
+ * modelled. They are a conditional pair at the tail of the segment, no profiled carrier asks for
+ * them, and modelling half of a pair would be worse than modelling neither.
+ * <p>
+ * DSB01 being mandatory means the disability <em>dates</em> cannot travel alone: a sponsor sending
+ * a disability period must also say what kind of disability it is. That is the 834's constraint,
+ * and this class refuses the alternative rather than emitting a segment with an empty mandatory
+ * element.
+ */
+@Getter
+public abstract class DSBSegment extends Segment {
+    public static final String SEGMENT_ID = "DSB";
+
+    /** Element 380 is R 1/15. */
+    public static final int MAX_QUANTITY_LENGTH = 15;
+    /** Element 1149 is ID 4/6. */
+    public static final int MIN_OCCUPATION_CODE_LENGTH = 4;
+    /** Element 1149 is ID 4/6. */
+    public static final int MAX_OCCUPATION_CODE_LENGTH = 6;
+    /** Element 782 is R 1/18. */
+    public static final int MAX_MONETARY_AMOUNT_LENGTH = 18;
+
+    protected final DisabilityTypeCode dsb01;
+    protected final String dsb02;
+    protected final String dsb03;
+    protected final String dsb04;
+    protected final String dsb05;
+    protected final String dsb06;
+
+    protected DSBSegment(AbstractBuilder<?> builder) throws ValidationException {
+        this.dsb01 = builder.dsb01;
+        this.dsb02 = builder.dsb02;
+        this.dsb03 = builder.dsb03;
+        this.dsb04 = builder.dsb04;
+        this.dsb05 = builder.dsb05;
+        this.dsb06 = builder.dsb06;
+
+        validate();
+    }
+
+    private void validate() throws ValidationException {
+        if (dsb01 == null) {
+            throw new ValidationException("Disability Type Code (DSB01) is required");
+        }
+        if (dsb02 != null && dsb02.length() > MAX_QUANTITY_LENGTH) {
+            throw new ValidationException("Quantity (DSB02) must be "
+                    + MAX_QUANTITY_LENGTH + " characters or less");
+        }
+        if (dsb03 != null && !dsb03.isEmpty()
+                && (dsb03.length() < MIN_OCCUPATION_CODE_LENGTH || dsb03.length() > MAX_OCCUPATION_CODE_LENGTH)) {
+            throw new ValidationException("Occupation Code (DSB03) must be between "
+                    + MIN_OCCUPATION_CODE_LENGTH + " and " + MAX_OCCUPATION_CODE_LENGTH
+                    + " characters; got '" + dsb03 + "'");
+        }
+        if (dsb06 != null && dsb06.length() > MAX_MONETARY_AMOUNT_LENGTH) {
+            throw new ValidationException("Monetary Amount (DSB06) must be "
+                    + MAX_MONETARY_AMOUNT_LENGTH + " characters or less");
+        }
+    }
+
+    @Override
+    public String getSegmentIdentifier() {
+        return SEGMENT_ID;
+    }
+
+    @Override
+    public String[] getElementValues() {
+        return new String[]{dsb01.getCode(), dsb02, dsb03, dsb04, dsb05, dsb06};
+    }
+
+    /** @return DSB01 — what kind of disability this is. */
+    public DisabilityTypeCode getDisabilityTypeCode() {
+        return getDsb01();
+    }
+
+    /** @return DSB02 — the associated quantity. */
+    public String getQuantity() {
+        return getDsb02();
+    }
+
+    /** @return DSB03 — the member's occupation. */
+    public String getOccupationCode() {
+        return getDsb03();
+    }
+
+    /** @return DSB04 — how intensively the member works. */
+    public String getWorkIntensityCode() {
+        return getDsb04();
+    }
+
+    /** @return DSB05 — the product option. */
+    public String getProductOptionCode() {
+        return getDsb05();
+    }
+
+    /** @return DSB06 — the associated amount. */
+    public String getMonetaryAmount() {
+        return getDsb06();
+    }
+
+    /**
+     * Abstract builder for DSB segments.
+     *
+     * @param <T> the concrete builder type, for chaining
+     */
+    public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
+        protected DisabilityTypeCode dsb01;
+        protected String dsb02;
+        protected String dsb03;
+        protected String dsb04;
+        protected String dsb05;
+        protected String dsb06;
+
+        protected abstract T self();
+
+        /** Sets DSB01 (what kind of disability this is). */
+        public T setDisabilityTypeCode(DisabilityTypeCode value) {
+            this.dsb01 = value;
+            return self();
+        }
+
+        /** Sets DSB02 (the associated quantity). */
+        public T setQuantity(String value) {
+            this.dsb02 = value;
+            return self();
+        }
+
+        /** Sets DSB03 (the member's occupation). */
+        public T setOccupationCode(String value) {
+            this.dsb03 = value;
+            return self();
+        }
+
+        /** Sets DSB04 (how intensively the member works). */
+        public T setWorkIntensityCode(String value) {
+            this.dsb04 = value;
+            return self();
+        }
+
+        /** Sets DSB05 (the product option). */
+        public T setProductOptionCode(String value) {
+            this.dsb05 = value;
+            return self();
+        }
+
+        /** Sets DSB06 (the associated amount). */
+        public T setMonetaryAmount(String value) {
+            this.dsb06 = value;
+            return self();
+        }
+
+        /** @return the built segment. */
+        public abstract DSBSegment build() throws ValidationException;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/HLHSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/HLHSegment.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.data.HealthRelatedCode;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import lombok.Getter;
+
+/**
+ * Represents the HLH (Health Information) segment in the X12 834 (005010X220A1) Benefit Enrollment
+ * and Maintenance transaction.
+ * <p>
+ * The segment carries the member's health-related status in Loop 2100A — chiefly tobacco and
+ * substance use, a rating input for individual and small-group products. BCBSM notes the code "may
+ * be required for specific employer groups", so requiredness is delegated out-of-band and the
+ * segment is emitted only when a member carries the information.
+ * <p>
+ * Element/position map (data elements per the 834 TR3):
+ * <ul>
+ *     <li>HLH01 = health-related code (1212)</li>
+ *     <li>HLH02 = height (65, R 1/8)</li>
+ *     <li>HLH03 = current weight (81, R 1/10)</li>
+ *     <li>HLH04 = previous weight (81, R 1/10)</li>
+ *     <li>HLH05 = description — the reason for a change in weight (352, AN 1/80)</li>
+ * </ul>
+ * <b>HLH06</b> (current health condition code, element 1213) and <b>HLH07</b> (the reason for the
+ * last doctor visit) are not modelled. Both sit at the tail, so omitting them costs no element
+ * slot, and no profiled carrier asks for either; adding them later disturbs nothing.
+ * <p>
+ * Every element is optional in X12, but a segment carrying none of them says nothing, so an empty
+ * HLH is rejected rather than emitted as a bare {@code HLH~}.
+ */
+@Getter
+public abstract class HLHSegment extends Segment {
+    public static final String SEGMENT_ID = "HLH";
+
+    /** Element 65 is R 1/8. */
+    public static final int MAX_HEIGHT_LENGTH = 8;
+    /** Element 81 is R 1/10. */
+    public static final int MAX_WEIGHT_LENGTH = 10;
+    /** Element 352 is AN 1/80. */
+    public static final int MAX_DESCRIPTION_LENGTH = 80;
+
+    protected final HealthRelatedCode hlh01;
+    protected final String hlh02;
+    protected final String hlh03;
+    protected final String hlh04;
+    protected final String hlh05;
+
+    protected HLHSegment(AbstractBuilder<?> builder) throws ValidationException {
+        this.hlh01 = builder.hlh01;
+        this.hlh02 = builder.hlh02;
+        this.hlh03 = builder.hlh03;
+        this.hlh04 = builder.hlh04;
+        this.hlh05 = builder.hlh05;
+
+        validate();
+    }
+
+    private void validate() throws ValidationException {
+        if (hlh01 == null && isBlank(hlh02) && isBlank(hlh03) && isBlank(hlh04) && isBlank(hlh05)) {
+            throw new ValidationException("HLH carries no health information; at least one element is required");
+        }
+        maxLength(hlh02, MAX_HEIGHT_LENGTH, "Height (HLH02)");
+        maxLength(hlh03, MAX_WEIGHT_LENGTH, "Current Weight (HLH03)");
+        maxLength(hlh04, MAX_WEIGHT_LENGTH, "Previous Weight (HLH04)");
+        maxLength(hlh05, MAX_DESCRIPTION_LENGTH, "Description (HLH05)");
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isEmpty();
+    }
+
+    private static void maxLength(String value, int max, String label) throws ValidationException {
+        if (value != null && value.length() > max) {
+            throw new ValidationException(label + " must be " + max + " characters or less");
+        }
+    }
+
+    @Override
+    public String getSegmentIdentifier() {
+        return SEGMENT_ID;
+    }
+
+    @Override
+    public String[] getElementValues() {
+        return new String[]{hlh01 == null ? null : hlh01.getCode(), hlh02, hlh03, hlh04, hlh05};
+    }
+
+    /** @return HLH01 — the member's health-related status. */
+    public HealthRelatedCode getHealthRelatedCode() {
+        return getHlh01();
+    }
+
+    /** @return HLH02 — the member's height. */
+    public String getHeight() {
+        return getHlh02();
+    }
+
+    /** @return HLH03 — the member's current weight. */
+    public String getCurrentWeight() {
+        return getHlh03();
+    }
+
+    /** @return HLH04 — the member's previous weight. */
+    public String getPreviousWeight() {
+        return getHlh04();
+    }
+
+    /** @return HLH05 — why the weight changed. */
+    public String getDescription() {
+        return getHlh05();
+    }
+
+    /**
+     * Abstract builder for HLH segments.
+     *
+     * @param <T> the concrete builder type, for chaining
+     */
+    public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
+        protected HealthRelatedCode hlh01;
+        protected String hlh02;
+        protected String hlh03;
+        protected String hlh04;
+        protected String hlh05;
+
+        protected abstract T self();
+
+        /** Sets HLH01 (the member's health-related status). */
+        public T setHealthRelatedCode(HealthRelatedCode value) {
+            this.hlh01 = value;
+            return self();
+        }
+
+        /** Sets HLH02 (the member's height). */
+        public T setHeight(String value) {
+            this.hlh02 = value;
+            return self();
+        }
+
+        /** Sets HLH03 (the member's current weight). */
+        public T setCurrentWeight(String value) {
+            this.hlh03 = value;
+            return self();
+        }
+
+        /** Sets HLH04 (the member's previous weight). */
+        public T setPreviousWeight(String value) {
+            this.hlh04 = value;
+            return self();
+        }
+
+        /** Sets HLH05 (why the weight changed). */
+        public T setDescription(String value) {
+            this.hlh05 = value;
+            return self();
+        }
+
+        /** @return the built segment. */
+        public abstract HLHSegment build() throws ValidationException;
+    }
+}

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/LUISegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/LUISegment.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.segments;
+
+import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import lombok.Getter;
+
+/**
+ * Represents the LUI (Language Use) segment in the X12 834 (005010X220A1) Benefit Enrollment and
+ * Maintenance transaction.
+ * <p>
+ * The segment names a language the member uses, in Loop 2100A. BCBSM's BCN Advantage product
+ * publishes a real code protocol for it, and the demand is rising with language-access regulation.
+ * <p>
+ * Element/position map (data elements per the 834 TR3):
+ * <ul>
+ *     <li>LUI01 = identification code qualifier (66) — what kind of language code LUI02 is</li>
+ *     <li>LUI02 = identification code (67, AN 2/80) — the language code itself</li>
+ *     <li>LUI03 = description (352, AN 1/80) — the language named in words</li>
+ * </ul>
+ * <b>LUI04</b> (use of language indicator) and <b>LUI05</b> (language proficiency indicator) are
+ * not modelled: both sit at the tail, neither is demanded by a profiled carrier, and LUI04 carries
+ * a relational condition of its own that would need separate grounding.
+ * <p>
+ * Two published relational conditions are enforced. LUI01 and LUI02 require each other — a code
+ * with no qualifier does not say which scheme it belongs to, and a qualifier alone names nothing.
+ * And a segment must carry at least one of LUI02 or LUI03, since an LUI naming no language at all
+ * is not a statement.
+ */
+@Getter
+public abstract class LUISegment extends Segment {
+    public static final String SEGMENT_ID = "LUI";
+
+    /** Element 67 is AN 2/80. */
+    public static final int MIN_LANGUAGE_CODE_LENGTH = 2;
+    /** Element 67 is AN 2/80. */
+    public static final int MAX_LANGUAGE_CODE_LENGTH = 80;
+    /** Element 352 is AN 1/80. */
+    public static final int MAX_DESCRIPTION_LENGTH = 80;
+
+    protected final IdentificationCodeQualifier lui01;
+    protected final String lui02;
+    protected final String lui03;
+
+    protected LUISegment(AbstractBuilder<?> builder) throws ValidationException {
+        this.lui01 = builder.lui01;
+        this.lui02 = builder.lui02;
+        this.lui03 = builder.lui03;
+
+        validate();
+    }
+
+    private void validate() throws ValidationException {
+        boolean codePresent = lui02 != null && !lui02.isEmpty();
+        if ((lui01 != null) != codePresent) {
+            throw new ValidationException(
+                    "LUI: Identification Code Qualifier (LUI01) and Identification Code (LUI02) must be present together");
+        }
+        boolean descriptionPresent = lui03 != null && !lui03.isEmpty();
+        if (!codePresent && !descriptionPresent) {
+            throw new ValidationException(
+                    "LUI names no language; at least one of Identification Code (LUI02) or Description (LUI03) is required");
+        }
+        if (codePresent && lui02.length() < MIN_LANGUAGE_CODE_LENGTH) {
+            throw new ValidationException("Identification Code (LUI02) must be at least "
+                    + MIN_LANGUAGE_CODE_LENGTH + " characters; got '" + lui02 + "'");
+        }
+        if (codePresent && lui02.length() > MAX_LANGUAGE_CODE_LENGTH) {
+            throw new ValidationException("Identification Code (LUI02) must be "
+                    + MAX_LANGUAGE_CODE_LENGTH + " characters or less");
+        }
+        if (descriptionPresent && lui03.length() > MAX_DESCRIPTION_LENGTH) {
+            throw new ValidationException("Description (LUI03) must be "
+                    + MAX_DESCRIPTION_LENGTH + " characters or less");
+        }
+    }
+
+    @Override
+    public String getSegmentIdentifier() {
+        return SEGMENT_ID;
+    }
+
+    @Override
+    public String[] getElementValues() {
+        return new String[]{lui01 == null ? null : lui01.getCode(), lui02, lui03};
+    }
+
+    /** @return LUI01 — what kind of language code {@link #getLanguageCode()} is. */
+    public IdentificationCodeQualifier getIdentificationCodeQualifier() {
+        return getLui01();
+    }
+
+    /** @return LUI02 — the language code. */
+    public String getLanguageCode() {
+        return getLui02();
+    }
+
+    /** @return LUI03 — the language named in words. */
+    public String getDescription() {
+        return getLui03();
+    }
+
+    /**
+     * Abstract builder for LUI segments.
+     *
+     * @param <T> the concrete builder type, for chaining
+     */
+    public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
+        protected IdentificationCodeQualifier lui01;
+        protected String lui02;
+        protected String lui03;
+
+        protected abstract T self();
+
+        /**
+         * Sets LUI01/LUI02 — the language code and the scheme it belongs to. Both together, since
+         * the 834 requires each if the other is present.
+         *
+         * @param qualifier what kind of code {@code code} is (LUI01)
+         * @param code      the language code (LUI02)
+         */
+        public T setLanguage(IdentificationCodeQualifier qualifier, String code) {
+            this.lui01 = qualifier;
+            this.lui02 = code;
+            return self();
+        }
+
+        /** Sets LUI03 (the language named in words). */
+        public T setDescription(String value) {
+            this.lui03 = value;
+            return self();
+        }
+
+        /** @return the built segment. */
+        public abstract LUISegment build() throws ValidationException;
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
@@ -19,7 +19,12 @@ import com.fastChickensHR.edi.x834.data.ActionCode;
 import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
 import com.fastChickensHR.edi.x834.data.FrequencyCode;
+import com.fastChickensHR.edi.x834.data.DisabilityTypeCode;
+import com.fastChickensHR.edi.x834.data.HealthRelatedCode;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.HealthInformation;
 import com.fastChickensHR.edi.x834.loop2000.loop2100A.Income;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.Language;
+import com.fastChickensHR.edi.x834.loop2000.loop2200.Disability;
 import com.fastChickensHR.edi.x834.loop2000.loop2310.Provider;
 import com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits;
 import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
@@ -539,6 +544,102 @@ class X834MemberWriterTest {
 
         assertTrue(out.contains("ICM*4*4500~"), () -> "expected the subscriber's ICM; got:\n" + out);
         assertTrue(out.contains("ICM*1*800~"), () -> "expected the dependent's own ICM; got:\n" + out);
+    }
+
+    @Test
+    void emitsThe2100ATailInSpecOrderIcmThenHlhThenLui() throws ValidationException {
+        // 834 Loop 2100A order: NM1, PER, N3, N4, DMG, EC, ICM, AMT, HLH, LUI.
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
+        member.setIncome(new Income(FrequencyCode.MONTHLY, "4500"));
+        member.setHealthInformation(new HealthInformation(HealthRelatedCode.TOBACCO_USE));
+        member.addLanguage(new Language("SPANISH"));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("HLH*T~"), () -> "expected the HLH; got:\n" + out);
+        assertTrue(out.contains("LUI***SPANISH~"), () -> "expected the LUI; got:\n" + out);
+        assertTrue(out.indexOf("DMG*") < out.indexOf("ICM*"), () -> "ICM follows DMG; got:\n" + out);
+        assertTrue(out.indexOf("ICM*") < out.indexOf("HLH*"), () -> "HLH follows ICM; got:\n" + out);
+        assertTrue(out.indexOf("HLH*") < out.indexOf("LUI*"), () -> "LUI follows HLH; got:\n" + out);
+    }
+
+    @Test
+    void emitsOneLuiPerLanguageInOrder() throws ValidationException {
+        Member member = baseSubscriber();
+        member.addLanguage(new Language("SPANISH"));
+        member.addLanguage(new Language("VIETNAMESE"));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.indexOf("LUI***SPANISH~") < out.indexOf("LUI***VIETNAMESE~"),
+                () -> "expected both languages, in the order added; got:\n" + out);
+    }
+
+    @Test
+    void emitsTheDisabilityLoopWithItsPeriodDates() throws ValidationException {
+        // BCBSM asks for DTP*360 / DTP*361. The guide reads "DTP01 … Start / DTP02 … End", but
+        // DTP02 is the date-format qualifier, so two dates are two DTP segments.
+        Member member = baseSubscriber();
+        Disability disability = new Disability(DisabilityTypeCode.SHORT_TERM_DISABILITY);
+        disability.setStartDate(LocalDateTime.of(2026, 3, 1, 0, 0));
+        disability.setEndDate(LocalDateTime.of(2026, 6, 30, 0, 0));
+        member.addDisability(disability);
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("DSB*1~"), () -> "expected the DSB; got:\n" + out);
+        assertTrue(out.contains("DTP*360*D8*20260301~"), () -> "expected the period start; got:\n" + out);
+        assertTrue(out.contains("DTP*361*D8*20260630~"), () -> "expected the period end; got:\n" + out);
+        assertTrue(out.indexOf("DSB*1~") < out.indexOf("DTP*360"),
+                () -> "the DSB opens the loop, before its dates; got:\n" + out);
+    }
+
+    @Test
+    void emitsTheDisabilityLoopAfterThe2100LoopsAndBeforeTheCoverageSegments() throws ValidationException {
+        // 834 loop order: 2100A/2100C → 2200 → 2300.
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+        Address mailing = new Address();
+        mailing.setType(AddressType.MAILING);
+        mailing.setLine1("PO BOX 1");
+        member.addAddress(mailing);
+        member.addDisability(new Disability(DisabilityTypeCode.LONG_TERM_DISABILITY));
+        member.addSegment(new RefSegment.Builder()
+                .setReferenceIdentificationQualifier("1L")
+                .setReferenceIdentification("PLAN9")
+                .build());
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.indexOf("NM1*31") < out.indexOf("DSB*2~"),
+                () -> "the 2200 loop must follow the 2100C block; got:\n" + out);
+        assertTrue(out.indexOf("DSB*2~") < out.indexOf("REF*1L*PLAN9"),
+                () -> "the 2200 loop must precede the 2300 segments; got:\n" + out);
+    }
+
+    @Test
+    void omitsHlhLuiAndDsbWhenTheMemberCarriesNone() throws ValidationException {
+        Member member = baseSubscriber();
+        member.setLastName("DOE");
+
+        String out = render(writer.toSegments(member));
+
+        assertFalse(out.contains("HLH"), () -> "no HLH; got:\n" + out);
+        assertFalse(out.contains("LUI"), () -> "no LUI; got:\n" + out);
+        assertFalse(out.contains("DSB"), () -> "no DSB; got:\n" + out);
+    }
+
+    @Test
+    void emitsTheDisabilityDsbEvenWithNoPeriodDates() throws ValidationException {
+        Member member = baseSubscriber();
+        member.addDisability(new Disability(DisabilityTypeCode.PERMANENT_OR_TOTAL_DISABILITY));
+
+        String out = render(writer.toSegments(member));
+
+        assertTrue(out.contains("DSB*3~"), () -> "expected the DSB; got:\n" + out);
+        assertFalse(out.contains("DTP*360"), () -> "no period start without a date; got:\n" + out);
     }
 
     @Test

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberHealthAndLanguageTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberHealthAndLanguageTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;
+
+import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.data.HealthRelatedCode;
+import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.HLHSegment;
+import com.fastChickensHR.edi.x834.segments.LUISegment;
+import com.fastChickensHR.edi.x834.segments.Segment;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MemberHealthAndLanguageTest {
+    private final X834Context context = new X834Context();
+
+    private String render(Segment segment) {
+        segment.setContext(context);
+        return segment.render().trim();
+    }
+
+    // ---- HLH (2100A member health information) ----
+
+    @Test
+    void rendersTobaccoUseAloneAsHlh01() throws ValidationException {
+        HLHSegment health = MemberHealthInformation.builder()
+                .setHealthRelatedCode(HealthRelatedCode.TOBACCO_USE)
+                .build();
+
+        assertEquals("HLH*T~", render(health));
+        assertEquals(HealthRelatedCode.TOBACCO_USE, health.getHealthRelatedCode());
+    }
+
+    @Test
+    void distinguishesStatedNoneFromUnknown() throws ValidationException {
+        // N asserts the member uses neither; U says nobody asked. For a rated product that is a
+        // statement about price, so the two must not collapse.
+        assertEquals("HLH*N~", render(MemberHealthInformation.builder()
+                .setHealthRelatedCode(HealthRelatedCode.NONE).build()));
+        assertEquals("HLH*U~", render(MemberHealthInformation.builder()
+                .setHealthRelatedCode(HealthRelatedCode.UNKNOWN).build()));
+    }
+
+    @Test
+    void carriesHeightAndWeightAlongsideTheCode() throws ValidationException {
+        HLHSegment health = MemberHealthInformation.builder()
+                .setHealthRelatedCode(HealthRelatedCode.NONE)
+                .setHeight("70")
+                .setCurrentWeight("180")
+                .setPreviousWeight("195")
+                .setDescription("DIET")
+                .build();
+
+        assertEquals("HLH*N*70*180*195*DIET~", render(health));
+    }
+
+    @Test
+    void rendersHeightAndWeightWithoutAHealthCode() throws ValidationException {
+        // HLH01 is optional, so an empty first element must still hold its slot.
+        HLHSegment health = MemberHealthInformation.builder()
+                .setHeight("70")
+                .setCurrentWeight("180")
+                .build();
+
+        assertEquals("HLH**70*180~", render(health));
+    }
+
+    @Test
+    void rejectsAnHlhCarryingNothing() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberHealthInformation.builder().build());
+
+        assertTrue(ex.getMessage().contains("no health information"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsAWeightLongerThanElement81Allows() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberHealthInformation.builder()
+                        .setHealthRelatedCode(HealthRelatedCode.NONE)
+                        .setCurrentWeight("1".repeat(HLHSegment.MAX_WEIGHT_LENGTH + 1))
+                        .build());
+
+        assertTrue(ex.getMessage().contains("HLH03"), ex.getMessage());
+    }
+
+    // ---- LUI (2100A member language) ----
+
+    @Test
+    void namesALanguageByCodeUnderItsScheme() throws ValidationException {
+        LUISegment language = MemberLanguage.builder()
+                .setLanguage(IdentificationCodeQualifier.CMS_NPI, "SPA")
+                .build();
+
+        assertEquals("LUI*XX*SPA~", render(language));
+        assertEquals("SPA", language.getLanguageCode());
+    }
+
+    @Test
+    void namesALanguageInWordsAlone() throws ValidationException {
+        LUISegment language = MemberLanguage.builder().setDescription("SPANISH").build();
+
+        assertEquals("LUI***SPANISH~", render(language));
+    }
+
+    @Test
+    void carriesBothCodeAndDescription() throws ValidationException {
+        LUISegment language = MemberLanguage.builder()
+                .setLanguage(IdentificationCodeQualifier.CMS_NPI, "SPA")
+                .setDescription("SPANISH")
+                .build();
+
+        assertEquals("LUI*XX*SPA*SPANISH~", render(language));
+    }
+
+    @Test
+    void rejectsACodeWithoutItsQualifier() {
+        // The 834's own relational condition: LUI01 and LUI02 require each other.
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberLanguage.builder().setLanguage(null, "SPA").build());
+
+        assertTrue(ex.getMessage().contains("LUI01"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsAQualifierWithoutItsCode() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberLanguage.builder()
+                        .setLanguage(IdentificationCodeQualifier.CMS_NPI, null)
+                        .build());
+
+        assertTrue(ex.getMessage().contains("LUI02"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsALuiNamingNoLanguageAtAll() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberLanguage.builder().build());
+
+        assertTrue(ex.getMessage().contains("names no language"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsALanguageCodeShorterThanElement67Allows() {
+        // Element 67 is AN 2/80 — a single character is not a language code.
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberLanguage.builder()
+                        .setLanguage(IdentificationCodeQualifier.CMS_NPI, "S")
+                        .build());
+
+        assertTrue(ex.getMessage().contains("at least 2"), ex.getMessage());
+    }
+}

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2200/MemberDisabilityTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/loop2200/MemberDisabilityTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2200;
+
+import com.fastChickensHR.edi.x834.X834Context;
+import com.fastChickensHR.edi.x834.data.DisabilityTypeCode;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.segments.DSBSegment;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MemberDisabilityTest {
+    private final X834Context context = new X834Context();
+
+    private String render(DSBSegment segment) {
+        segment.setContext(context);
+        return segment.render().trim();
+    }
+
+    @Test
+    void rendersTheDisabilityTypeAlone() throws ValidationException {
+        DSBSegment disability = MemberDisability.builder()
+                .setDisabilityTypeCode(DisabilityTypeCode.SHORT_TERM_DISABILITY)
+                .build();
+
+        assertEquals("DSB*1~", render(disability));
+        assertEquals(DisabilityTypeCode.SHORT_TERM_DISABILITY, disability.getDisabilityTypeCode());
+    }
+
+    @Test
+    void treatsNoDisabilityAsAStatedAnswer() throws ValidationException {
+        // 4 says "this member is not disabled", which is different from sending no Loop 2200 —
+        // only the former overwrites a disability the carrier already holds.
+        assertEquals("DSB*4~", render(MemberDisability.builder()
+                .setDisabilityTypeCode(DisabilityTypeCode.NO_DISABILITY)
+                .build()));
+    }
+
+    @Test
+    void carriesTheWorkAndBenefitElements() throws ValidationException {
+        DSBSegment disability = MemberDisability.builder()
+                .setDisabilityTypeCode(DisabilityTypeCode.LONG_TERM_DISABILITY)
+                .setQuantity("40")
+                .setOccupationCode("1234")
+                .setWorkIntensityCode("F")
+                .setProductOptionCode("A1")
+                .setMonetaryAmount("2500")
+                .build();
+
+        assertEquals("DSB*2*40*1234*F*A1*2500~", render(disability));
+    }
+
+    @Test
+    void rejectsADisabilityWithNoType() {
+        // DSB01 is mandatory, so a disability period cannot travel without saying what kind it is.
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberDisability.builder().setQuantity("40").build());
+
+        assertTrue(ex.getMessage().contains("DSB01"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsAnOccupationCodeOutsideElement1149sRange() {
+        // Element 1149 is ID 4/6.
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberDisability.builder()
+                        .setDisabilityTypeCode(DisabilityTypeCode.SHORT_TERM_DISABILITY)
+                        .setOccupationCode("123")
+                        .build());
+
+        assertTrue(ex.getMessage().contains("DSB03"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsAQuantityLongerThanElement380Allows() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> MemberDisability.builder()
+                        .setDisabilityTypeCode(DisabilityTypeCode.SHORT_TERM_DISABILITY)
+                        .setQuantity("1".repeat(DSBSegment.MAX_QUANTITY_LENGTH + 1))
+                        .build());
+
+        assertTrue(ex.getMessage().contains("DSB02"), ex.getMessage());
+    }
+}


### PR DESCRIPTION
The last three structures in #139's inventory. **With this merged, every member-loop structure the issue catalogued is emittable and #139 closes.** Full suite green.

> ⚠️ **Stacked on #195** (ICM), which is stacked on #194 (2310). Merge order **#194 → #195 → this**, and **retarget each child to `master` before merging its parent** — deleting a base branch auto-closes its child irreversibly. Happy to walk the chain down on request.

## Why these are different from the previous four

Demand here is genuinely thinner, and the PR reflects that rather than overstating it. These are the 0569 catalog's **tail-priority** rows:

| Structure | Demand | Source |
|---|---|---|
| `LUI` 2100A | BCBSM BCN Advantage publishes a code protocol; rising with language-access regulation | 0558 p. 11, 21 |
| `HLH` 2100A | BCBSM: HLH01 *"may be required for specific employer groups"* | 0558 p. 16 |
| `DSB` 2200 | BCBSM wants the **period** (`DTP*360`/`361`); **CareFirst documents it then discards it** — *"Disability information not processed"* | 0558 p. 22, 0569 |

0569 actually **excluded** 2200 on CareFirst's evidence. I've recorded that rather than argued with it: the segment exists now so the position is emittable, which is #139's stated bar ("a question may only exist for a position `edi` can actually emit"), not a claim that anyone is asking for it today.

## Three distinctions the code refuses to collapse

Each is a statement a carrier could be **billed on**, so none is defaulted:

- **`HLH01` `N` (None) vs `U` (Unknown)** — "uses neither tobacco nor substances" versus "nobody asked". For a rated product that difference is a price.
- **`DSB01` `4` (No Disability) is a stated answer**, not an absent one. Only the stated form overwrites a disability the carrier already holds.
- **Sending no segment at all** differs from both.

## Conformance from the published conditions

- **LUI01/LUI02 require each other** (the 834's own relational condition), and an LUI must carry at least one of LUI02/LUI03 — otherwise it names no language.
- **An HLH carrying no element at all** is rejected rather than emitted as a bare `HLH~`.
- **`DSB01` is mandatory**, so — exactly as with ICM's mandatory pair — the disability **dates cannot travel alone**. A sponsor sending a period must also say what kind of disability it is.

### A guide defect, handled

BCBSM's 2200 text reads *"DTP01 - Report 360 Initial Disability Period Start / DTP02 - Report 361 Initial Disability Period End"*. That is wrong on its face — **DTP02 is the date-format qualifier**, not a second date. Two dates are two DTP segments, which is what this emits (`DTP*360*D8*…` then `DTP*361*D8*…`), and a test pins it. 0558 already recorded this as a guide defect.

## Not modelled

All trailing and undemanded, so each can be added later without disturbing an element slot: **HLH06/HLH07** (HLH06 would need element 1213), **LUI04/LUI05** (LUI04 carries its own relational condition needing separate grounding), **DSB07/DSB08** (a conditional *pair* — modelling half would be worse than modelling neither). **EC** (Employment Class, 2100A) also stays absent; no profiled carrier asks, and Kansas's related "employment position" sits at `2000 REF*P5`.

## Tests

19 new segment tests plus 6 writer tests. Placement is pinned across the whole 2100A tail (`DMG → ICM → HLH → LUI`) and the 2200 loop's position between the 2100 loops and 2300. Mutation-checked the 2200 placement — moving it after the 2300 segments fails `emitsTheDisabilityLoopAfterThe2100LoopsAndBeforeTheCoverageSegments`.

One correction worth recording: my first LUI expectation was `LUI**SPANISH~` and the code was right — **two** empty elements render as **three** asterisks (`LUI***SPANISH~`). Same arithmetic as the ICM slice, one level deeper.

## Housekeeping

Renames the COB slice's `addCobDateSegment` helper to `addQualifiedDate`, now that the disability dates share it.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)