### PR TITLE
refactor(x834)!: type gender, drop dead AddressType constants, move MAX_* limits to the domain (#224)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -27,6 +27,7 @@ import com.fastChickensHR.edi.x834.data.FrequencyCode;
 import com.fastChickensHR.edi.x834.data.HealthRelatedCode;
 import com.fastChickensHR.edi.x834.data.IdentificationCodeQualifier;
 import com.fastChickensHR.edi.x834.loop2000.data.EmploymentStatusCode;
+import com.fastChickensHR.edi.x834.loop2000.data.GenderCode;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
@@ -172,7 +173,7 @@ public final class X834FileGenerator implements FileGenerator {
         apply(loc, X834Location.NAME_ID_QUALIFIER, member::setNameIdQualifier);
         apply(loc, X834Location.NAME_ID, member::setNameId);
         apply(loc, X834Location.BIRTH_DATE, v -> member.setBirthDate(parseDateTime(v)));
-        apply(loc, X834Location.GENDER, member::setGender);
+        apply(loc, X834Location.GENDER, v -> member.setGender(GenderCode.fromString(v)));
         apply(loc, X834Location.ADDRESS_LINE_1, member::setAddressLine1);
         apply(loc, X834Location.ADDRESS_LINE_2, member::setAddressLine2);
         apply(loc, X834Location.CITY, member::setCity);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/AddressType.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/AddressType.java
@@ -10,22 +10,16 @@ package com.fastChickensHR.edi.x834.loop2000;
 /**
  * The kind of postal address a member can carry.
  * <p>
- * A member may have more than one address of different kinds. Which kinds the X12 834
- * (005010X220A1) can actually serialize is limited by the transaction's structure:
+ * A member may have more than one address of different kinds. Only the kinds the X12 834
+ * (005010X220A1) member structure can actually serialize are modelled:
  * <ul>
  *   <li>{@link #RESIDENCE} — the member's residence address, emitted as Loop 2100A N3/N4.</li>
  *   <li>{@link #MAILING} — the member's mailing address, emitted as Loop 2100C (NM1*31, N3, N4).</li>
- *   <li>{@link #WORK}, {@link #BILLING} — accepted on the domain model for completeness, but the
- *       834 member structure has no loop for them, so they are not serialized.</li>
  * </ul>
  */
 public enum AddressType {
     /** Residence / home address — Loop 2100A. */
     RESIDENCE,
     /** Mailing address — Loop 2100C. */
-    MAILING,
-    /** Work address — accepted but not serialized (no 834 member loop). */
-    WORK,
-    /** Billing address — accepted but not serialized (no 834 member loop). */
-    BILLING
+    MAILING
 }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -10,6 +10,7 @@ package com.fastChickensHR.edi.x834.loop2000;
 import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.loop2000.data.EmploymentStatusCode;
+import com.fastChickensHR.edi.x834.loop2000.data.GenderCode;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceReasonCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
@@ -60,7 +61,8 @@ public abstract class BaseMember {
      */
     protected String nameId;
     protected LocalDateTime birthDate;
-    protected String gender;
+    /** DMG03 — the member's gender, drawn from the element-1068 code list. */
+    protected GenderCode gender;
     protected MemberIndicator memberIndicator;
     protected MaintenanceTypeCode maintenanceTypeCode;
     /**
@@ -208,7 +210,7 @@ public abstract class BaseMember {
      * becomes PER03/04, then PER05/06, then PER07/08. An explicit communication takes precedence
      * over the {@link #phoneNumber}/{@link #email} conveniences when both name the same
      * qualifier. The 834 permits at most
-     * {@value com.fastChickensHR.edi.x834.segments.PERSegment#MAX_COMMUNICATION_PAIRS} per
+     * {@value com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication#MAX_PER_MEMBER} per
      * member; a member carrying more is rejected when written, not silently truncated.
      *
      * @param communication the communication number to emit (ignored if null)
@@ -306,7 +308,7 @@ public abstract class BaseMember {
      * <p>
      * Order is preserved, and the {@code LX} assigned number is counted over the emitted
      * occurrences. The 834 permits at most
-     * {@value com.fastChickensHR.edi.x834.loop2000.X834MemberWriter#MAX_PROVIDERS} per member; a
+     * {@value com.fastChickensHR.edi.x834.loop2000.loop2310.Provider#MAX_PER_MEMBER} per member; a
      * member carrying more is rejected when written, not silently truncated.
      *
      * @param provider the provider to emit (ignored if null)
@@ -331,7 +333,7 @@ public abstract class BaseMember {
      * Adds another plan this member holds (Loop 2320).
      * <p>
      * Order is preserved. The 834 permits at most
-     * {@value com.fastChickensHR.edi.x834.loop2000.X834MemberWriter#MAX_COORDINATION_OF_BENEFITS}
+     * {@value com.fastChickensHR.edi.x834.loop2000.loop2320.CoordinationOfBenefits#MAX_PER_MEMBER}
      * occurrences per member; a member carrying more is rejected when written, not silently
      * truncated.
      *

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriter.java
@@ -208,12 +208,6 @@ public class X834MemberWriter {
     /** LS01/LE01 loop identifier for the Member Reporting Categories loop (2700). */
     private static final String REPORTING_CATEGORY_LOOP_ID = "2700";
 
-    /** The most Loop 2320 occurrences the 834 permits per member. */
-    public static final int MAX_COORDINATION_OF_BENEFITS = 5;
-
-    /** The most Loop 2310 occurrences the 834 permits per member. */
-    public static final int MAX_PROVIDERS = 30;
-
     /**
      * Loop 2310 (provider): per provider the member is assigned to, an {@code LX} assigned number,
      * the {@code NM1} naming them, and — when the assignment is being changed rather than merely
@@ -232,8 +226,8 @@ public class X834MemberWriter {
         if (providers.isEmpty()) {
             return;
         }
-        if (providers.size() > MAX_PROVIDERS) {
-            throw new ValidationException("A member carries at most " + MAX_PROVIDERS
+        if (providers.size() > Provider.MAX_PER_MEMBER) {
+            throw new ValidationException("A member carries at most " + Provider.MAX_PER_MEMBER
                     + " provider loops (2310); got " + providers.size());
         }
         int assignedNumber = 1;
@@ -287,8 +281,8 @@ public class X834MemberWriter {
         if (others.isEmpty()) {
             return;
         }
-        if (others.size() > MAX_COORDINATION_OF_BENEFITS) {
-            throw new ValidationException("A member carries at most " + MAX_COORDINATION_OF_BENEFITS
+        if (others.size() > CoordinationOfBenefits.MAX_PER_MEMBER) {
+            throw new ValidationException("A member carries at most " + CoordinationOfBenefits.MAX_PER_MEMBER
                     + " coordination-of-benefits loops (2320); got " + others.size());
         }
         for (CoordinationOfBenefits other : others) {
@@ -549,7 +543,7 @@ public class X834MemberWriter {
         segments.add(new MemberDemographics.Builder()
                 .setDateTimePeriodFormatQualifier(DateFormat.D8.getFormat())
                 .setBirthDate(DateFormatter.formatDate(DateFormat.D8, member.getBirthDate()))
-                .setGenderCode(emptyToNull(member.getGender()))
+                .setGenderCode(member.getGender() == null ? null : member.getGender().getCode())
                 .build());
     }
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberCommunication.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberCommunication.java
@@ -18,8 +18,7 @@ import lombok.Setter;
  * The {@link #qualifier} states what kind of number this is (home phone, email, cellular, …) and
  * {@link #number} is the number itself. A member may carry several; the writer emits them as the
  * PER03/04, PER05/06 and PER07/08 pairs of a single {@code PER} segment, which is why the 834
- * permits at most {@value com.fastChickensHR.edi.x834.segments.PERSegment#MAX_COMMUNICATION_PAIRS}
- * per member.
+ * permits at most {@value #MAX_PER_MEMBER} per member.
  * <p>
  * Which channels a carrier wants is a per-carrier choice rather than a fixed list — BCBSM
  * MembersEdge asks for email, home and work; its Medicare Advantage product for alternate,
@@ -30,6 +29,13 @@ import lombok.Setter;
 @Getter
 @Setter
 public class MemberCommunication {
+
+    /**
+     * The most communications the 834 permits per member — fixed by the single Loop 2100A
+     * {@code PER}'s three qualifier/number element pairs (PER03/04, PER05/06, PER07/08).
+     */
+    public static final int MAX_PER_MEMBER = 3;
+
     /** What kind of number this is (PER03/05/07) — required. */
     private CommunicationNumberQualifier qualifier;
     /** The number itself (PER04/06/08) — required. */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/Provider.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/Provider.java
@@ -35,6 +35,10 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 public class Provider {
+
+    /** The most Loop 2310 occurrences the 834 permits per member. */
+    public static final int MAX_PER_MEMBER = 30;
+
     /** The provider's last or organization name (NM103) — required. */
     private String lastName;
     /** The provider's first name (NM104). */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/CoordinationOfBenefits.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/CoordinationOfBenefits.java
@@ -36,6 +36,9 @@ import java.time.LocalDateTime;
 @Setter
 public class CoordinationOfBenefits {
 
+    /** The most Loop 2320 occurrences the 834 permits per member. */
+    public static final int MAX_PER_MEMBER = 5;
+
     /** REF01 qualifier {@code 6P} — Group Number; the default for the 2320 group-number REF. */
     public static final String DEFAULT_GROUP_NUMBER_QUALIFIER = "6P";
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/PERSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/PERSegment.java
@@ -9,6 +9,7 @@ package com.fastChickensHR.edi.x834.segments;
 
 import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberCommunication;
 import lombok.Getter;
 
 /**
@@ -44,9 +45,6 @@ public abstract class PERSegment extends Segment {
 
     /** Element 364 is AN 1/256 — a longer communication number cannot be represented. */
     public static final int MAX_COMMUNICATION_NUMBER_LENGTH = 256;
-
-    /** The most qualifier/number pairs one PER can carry (PER03/04, PER05/06, PER07/08). */
-    public static final int MAX_COMMUNICATION_PAIRS = 3;
 
     protected final String per01;
     protected final String per02;
@@ -160,12 +158,13 @@ public abstract class PERSegment extends Segment {
          * <p>
          * Callers state <em>which</em> channels a member has, not which element positions they
          * occupy, so the pairs fill in call order. A PER carries at most
-         * {@link #MAX_COMMUNICATION_PAIRS}; a fourth is rejected rather than dropped, because
-         * silently discarding a communication number is the data loss this segment exists to end.
+         * {@link MemberCommunication#MAX_PER_MEMBER} pairs; a fourth is rejected rather than
+         * dropped, because silently discarding a communication number is the data loss this
+         * segment exists to end.
          *
          * @param qualifier the communication number qualifier (PER03/05/07)
          * @param number    the communication number it qualifies (PER04/06/08)
-         * @throws ValidationException if the segment already carries {@link #MAX_COMMUNICATION_PAIRS}
+         * @throws ValidationException if the segment already carries {@link MemberCommunication#MAX_PER_MEMBER} pairs
          */
         public T addCommunicationNumber(CommunicationNumberQualifier qualifier, String number)
                 throws ValidationException {
@@ -180,7 +179,7 @@ public abstract class PERSegment extends Segment {
                 per08 = number;
             } else {
                 throw new ValidationException("A PER segment carries at most "
-                        + MAX_COMMUNICATION_PAIRS + " communication numbers");
+                        + MemberCommunication.MAX_PER_MEMBER + " communication numbers");
             }
             return self();
         }

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/X834DocumentTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/X834DocumentTest.java
@@ -8,11 +8,14 @@
 package com.fastChickensHR.edi.x834;
 
 import com.fastChickensHR.edi.x834.GenerationError.Phase;
+import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.header.Header;
 import com.fastChickensHR.edi.x834.loop2000.Member;
+import com.fastChickensHR.edi.x834.loop2000.data.GenderCode;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
+import com.fastChickensHR.edi.x834.loop2000.loop2100A.MemberDemographics;
 import com.fastChickensHR.edi.x834.spec.CharacterClass;
 import com.fastChickensHR.edi.x834.testsupport.TestFixtures;
 import com.fastChickensHR.edi.x834.trailer.Trailer;
@@ -241,13 +244,16 @@ class X834DocumentTest {
     }
 
     @Test
-    void rejectsACodeTheElementDoesNotPermit() {
-        // DMG03 takes a raw string all the way to the wire: before the spec ring, nothing anywhere
-        // checked that a gender was an element-1068 code.
+    void rejectsACodeTheElementDoesNotPermit() throws ValidationException {
+        // The domain model's typed gender cannot carry a bad code, but a custom segment still
+        // takes raw strings to the wire; the spec ring is what checks element-1068 codes there.
         Member member = buildMinimalMember();
         member.setLastName("DOE");
-        member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
-        member.setGender("Q");
+        member.addSegment(new MemberDemographics.Builder()
+                .setDateTimePeriodFormatQualifier("D8")
+                .setBirthDate("19800115")
+                .setGenderCode("Q")
+                .build());
         X834Document doc = new X834Document.Builder(context)
                 .withHeader(buildHeader())
                 .withTrailer(new Trailer.Builder(context))
@@ -264,7 +270,7 @@ class X834DocumentTest {
         Member member = buildMinimalMember();
         member.setLastName("DOE");
         member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
-        member.setGender("F");
+        member.setGender(GenderCode.FEMALE);
         X834Document doc = new X834Document.Builder(context)
                 .withHeader(buildHeader())
                 .withTrailer(new Trailer.Builder(context))
@@ -275,13 +281,17 @@ class X834DocumentTest {
     }
 
     @Test
-    void aggregatesSpecViolationsWithEachOtherAndWithDelimiterViolations() {
+    void aggregatesSpecViolationsWithEachOtherAndWithDelimiterViolations() throws ValidationException {
         // One channel, one pass: a caller fixing its data should see every problem at once rather
         // than one failed generation at a time.
         Member member = buildMinimalMember();
         member.setLastName("D".repeat(61));
         member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
-        member.setGender("Q");
+        member.addSegment(new MemberDemographics.Builder()
+                .setDateTimePeriodFormatQualifier("D8")
+                .setBirthDate("19800115")
+                .setGenderCode("Q")
+                .build());
         X834Document doc = new X834Document.Builder(context)
                 .withHeader(buildHeaderWithSponsor("ACME*CORP"))
                 .withTrailer(new Trailer.Builder(context))

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/loop2000/X834MemberWriterTest.java
@@ -10,6 +10,7 @@ package com.fastChickensHR.edi.x834.loop2000;
 import com.fastChickensHR.edi.x834.X834Context;
 import com.fastChickensHR.edi.x834.data.CommunicationNumberQualifier;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
+import com.fastChickensHR.edi.x834.loop2000.data.GenderCode;
 import com.fastChickensHR.edi.x834.loop2000.data.IndividualRelationshipCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MaintenanceTypeCode;
 import com.fastChickensHR.edi.x834.loop2000.data.MemberIndicator;
@@ -141,7 +142,7 @@ class X834MemberWriterTest {
         Member member = baseSubscriber();
         member.setLastName("DOE");
         member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
-        member.setGender("M");
+        member.setGender(GenderCode.MALE);
 
         String out = render(writer.toSegments(member));
 
@@ -176,7 +177,7 @@ class X834MemberWriterTest {
         member.setState("IL");
         member.setZipCode("62704");
         member.setBirthDate(LocalDateTime.of(1980, 1, 15, 0, 0));
-        member.setGender("F");
+        member.setGender(GenderCode.FEMALE);
 
         String out = render(writer.toSegments(member));
 
@@ -265,20 +266,6 @@ class X834MemberWriterTest {
         String out = render(writer.toSegments(member));
 
         assertFalse(out.contains("NM1*31"), () -> "no 2100C without a mailing address; got:\n" + out);
-    }
-
-    @Test
-    void workAddressIsAcceptedButNotSerialized() throws ValidationException {
-        Member member = baseSubscriber();
-        member.setLastName("DOE");
-        member.addAddress(Address.builder()
-                .type(AddressType.WORK)
-                .line1("500 OFFICE PKWY").city("SPRINGFIELD").state("IL").zipCode("62704")
-                .build());
-
-        String out = render(writer.toSegments(member));
-
-        assertFalse(out.contains("500 OFFICE PKWY"), () -> "WORK address must not be serialized; got:\n" + out);
     }
 
     @Test
@@ -835,7 +822,7 @@ class X834MemberWriterTest {
     @Test
     void rejectsMoreProvidersThanThe834Permits() throws ValidationException {
         Member member = baseSubscriber();
-        for (int i = 0; i < X834MemberWriter.MAX_PROVIDERS + 1; i++) {
+        for (int i = 0; i < Provider.MAX_PER_MEMBER + 1; i++) {
             member.addProvider(new Provider("DOC" + i));
         }
 
@@ -971,7 +958,7 @@ class X834MemberWriterTest {
     @Test
     void rejectsMoreOtherPlansThanThe834Permits() throws ValidationException {
         Member member = baseSubscriber();
-        for (int i = 0; i < X834MemberWriter.MAX_COORDINATION_OF_BENEFITS + 1; i++) {
+        for (int i = 0; i < CoordinationOfBenefits.MAX_PER_MEMBER + 1; i++) {
             member.addCoordinationOfBenefits(new CoordinationOfBenefits(
                     PayerResponsibilitySequenceCode.PRIMARY,
                     CoordinationOfBenefitsCode.COORDINATION_OF_BENEFITS));


### PR DESCRIPTION
Executes ticket #224 of build map #229 (curation ruling on #216).

- **`BaseMember.gender` is now `GenderCode`** (was `String`). The writer renders `getCode()`; the `X834FileGenerator` string seam maps input via `GenderCode.fromString`, matching every other coded field on that seam.
- **`AddressType.WORK`/`BILLING` removed** — the 834 member structure has no loop for them, so they were accepted-but-never-serialized. They return if a loop ever serializes them.
- **Per-member occurrence limits move to the domain types** so the writer can hide in the #220 sweep: `Provider.MAX_PER_MEMBER` (30), `CoordinationOfBenefits.MAX_PER_MEMBER` (5), `MemberCommunication.MAX_PER_MEMBER` (3, formerly `PERSegment.MAX_COMMUNICATION_PAIRS`). `PERSegment`'s builder guard now references the domain constant (precedent: `PLASegment` already imports from `loop2000.data`).

The two spec-ring tests that pushed an invalid DMG03 `"Q"` through the String gender field now push it through a hand-built `MemberDemographics` via `addSegment` — the typed domain path can no longer carry a bad code, but custom segments still take raw strings to the wire, which is exactly the path the ring guards. The test pinning WORK-address non-serialization is deleted with the constant.

mono is unaffected: no references to `setGender`, the MAX constants, or `AddressType` in mono's tree.

Full reactor green: 3,931 x834 tests + core/x999/flatfile, golden fixtures byte-identical.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)