### PR TITLE
refactor(x834): drop the 11 Header/Trailer sub-builder escape hatches and hide their types (#219)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/BeginningSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/BeginningSegment.java
@@ -18,7 +18,7 @@ import lombok.Getter;
  * of the 834 and provides transaction set purpose and control information.
  */
 @Getter
-public class BeginningSegment extends BGNSegment {
+class BeginningSegment extends BGNSegment {
     /** Default BGN01 transaction set purpose code {@code "00"} (Original). */
     public static final String DEFAULT_TRANSACTION_SET_PURPOSE_CODE = "00";
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/FileEffectiveDate.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/FileEffectiveDate.java
@@ -18,7 +18,7 @@ import lombok.experimental.Accessors;
  * Produces the DTP segment carrying the master effective date for the file. Extends the
  * generic {@link DTPSegment}.
  */
-public class FileEffectiveDate extends DTPSegment {
+class FileEffectiveDate extends DTPSegment {
     /** Default DTP01 date/time qualifier {@code "007"} (Effective). */
     public static final String DEFAULT_DATE_TIME_QUALIFIER = "007";
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/FunctionalGroupHeader.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/FunctionalGroupHeader.java
@@ -22,7 +22,7 @@ import lombok.Getter;
  * with X834-specific defaults.
  */
 @Getter
-public class FunctionalGroupHeader extends GSSegment {
+class FunctionalGroupHeader extends GSSegment {
     /** Default GS01 functional identifier code {@code "BE"} (Benefit Enrollment and Maintenance, 834). */
     private static final FunctionalIdentifierCode DEFAULT_FUNCTIONAL_ID_CODE = FunctionalIdentifierCode.fromString("BE");
     /** Default GS07 responsible agency code (ASC X12). */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/Header.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/Header.java
@@ -10,8 +10,6 @@ package com.fastChickensHR.edi.x834.header;
 import com.fastChickensHR.edi.x834.segments.Segment;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.X834Context;
-import com.fastChickensHR.edi.x834.loop1000A.SponsorName;
-import com.fastChickensHR.edi.x834.loop1000B.Payer;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -38,16 +36,6 @@ public class Header {
     private String payerName;
     private String payerIdentification;
 
-    // Custom builders to allow advanced customization
-    private InterchangeControlHeader.Builder customInterchangeBuilder;
-    private FunctionalGroupHeader.Builder customFunctionalBuilder;
-    private TransactionSetHeader.Builder customTransactionSetBuilder;
-    private BeginningSegment.Builder customBeginningSegmentBuilder;
-    private FileEffectiveDate.Builder customFileEffectiveDateBuilder;
-    private TransactionSetPolicyNumber.Builder customPolicyNumberBuilder;
-    private SponsorName.Builder customSponsorBuilder;
-    private Payer.Builder customPayerBuilder;
-
     /**
      * Creates a new Header instance with the specified context
      *
@@ -63,7 +51,7 @@ public class Header {
      * @throws ValidationException If validation fails
      */
     public void validate() throws ValidationException {
-        if (customTransactionSetBuilder == null && (transactionSetIdentifierCode == null || transactionSetIdentifierCode.isEmpty())) {
+        if (transactionSetIdentifierCode == null || transactionSetIdentifierCode.isEmpty()) {
             throw new ValidationException("Transaction Set Identifier Code is required");
         }
     }
@@ -77,49 +65,20 @@ public class Header {
         validate();
 
         List<Segment> segments = new ArrayList<>();
-
-        // Create or use builders as appropriate
-        InterchangeControlHeader.Builder interchangeBuilder = customInterchangeBuilder != null ?
-                customInterchangeBuilder :
-                new InterchangeControlHeader.Builder(context);
-
-        FunctionalGroupHeader.Builder functionalBuilder = customFunctionalBuilder != null ?
-                customFunctionalBuilder :
-                new FunctionalGroupHeader.Builder(context);
-
-        TransactionSetHeader.Builder transactionSetBuilder = customTransactionSetBuilder != null ?
-                customTransactionSetBuilder :
-                new TransactionSetHeader.Builder(context)
-                        .setTransactionSetIdentifierCode(transactionSetIdentifierCode);
-
-        BeginningSegment.Builder beginningSegmentBuilder = customBeginningSegmentBuilder != null ?
-                customBeginningSegmentBuilder :
-                new BeginningSegment.Builder(context).setReferenceIdentification(referenceIdentification);
-
-        FileEffectiveDate.Builder fileEffectiveDateBuilder = customFileEffectiveDateBuilder != null ?
-                customFileEffectiveDateBuilder :
-                new FileEffectiveDate.Builder(context);
-
-        TransactionSetPolicyNumber.Builder policyNumberBuilder = customPolicyNumberBuilder != null ?
-                customPolicyNumberBuilder :
-                new TransactionSetPolicyNumber.Builder().setMasterPolicyNumber(masterPolicyNumber);
-
-        SponsorName.Builder sponsorBuilder = customSponsorBuilder != null ?
-                customSponsorBuilder :
-                new SponsorName.Builder().setPlanSponsorName(planSponsorName);
-
-        Payer.Builder payerBuilder = customPayerBuilder != null ?
-                customPayerBuilder :
-                createDefaultPayerBuilder();
-
-        segments.add(interchangeBuilder.build());
-        segments.add(functionalBuilder.build());
-        segments.add(transactionSetBuilder.build());
-        segments.add(beginningSegmentBuilder.build());
-        segments.add(fileEffectiveDateBuilder.build());
-        segments.add(policyNumberBuilder.build());
-        segments.add(sponsorBuilder.build());
-        segments.add(payerBuilder.build());
+        segments.add(new InterchangeControlHeader.Builder(context).build());
+        segments.add(new FunctionalGroupHeader.Builder(context).build());
+        segments.add(new TransactionSetHeader.Builder(context)
+                .setTransactionSetIdentifierCode(transactionSetIdentifierCode)
+                .build());
+        segments.add(new BeginningSegment.Builder(context)
+                .setReferenceIdentification(referenceIdentification)
+                .build());
+        segments.add(new FileEffectiveDate.Builder(context).build());
+        segments.add(new TransactionSetPolicyNumber.Builder()
+                .setMasterPolicyNumber(masterPolicyNumber)
+                .build());
+        segments.add(new SponsorName.Builder().setPlanSponsorName(planSponsorName).build());
+        segments.add(createDefaultPayerBuilder().build());
 
         return segments;
     }
@@ -152,16 +111,6 @@ public class Header {
         private String planSponsorName;
         private String payerName;
         private String payerIdentification;
-
-        // Custom builders
-        private InterchangeControlHeader.Builder customInterchangeBuilder;
-        private FunctionalGroupHeader.Builder customFunctionalBuilder;
-        private TransactionSetHeader.Builder customTransactionSetBuilder;
-        private BeginningSegment.Builder customBeginningSegmentBuilder;
-        private FileEffectiveDate.Builder customFileEffectiveDateBuilder;
-        private TransactionSetPolicyNumber.Builder customPolicyNumberBuilder;
-        private SponsorName.Builder customSponsorBuilder;
-        private Payer.Builder customPayerBuilder;
 
         /**
          * Creates a new Builder with the required context
@@ -239,95 +188,6 @@ public class Header {
             return this;
         }
 
-        // Custom builder setters
-        /**
-         * Supplies a custom Interchange Control Header (ISA) builder, overriding the default.
-         *
-         * @param builder the custom ISA builder
-         * @return this builder instance
-         */
-        public Builder setInterchangeControlHeaderBuilder(InterchangeControlHeader.Builder builder) {
-            this.customInterchangeBuilder = builder;
-            return this;
-        }
-
-        /**
-         * Supplies a custom Functional Group Header (GS) builder, overriding the default.
-         *
-         * @param builder the custom GS builder
-         * @return this builder instance
-         */
-        public Builder setFunctionalGroupHeaderBuilder(FunctionalGroupHeader.Builder builder) {
-            this.customFunctionalBuilder = builder;
-            return this;
-        }
-
-        /**
-         * Supplies a custom Transaction Set Header (ST) builder, overriding the default.
-         *
-         * @param builder the custom ST builder
-         * @return this builder instance
-         */
-        public Builder setTransactionSetHeaderBuilder(TransactionSetHeader.Builder builder) {
-            this.customTransactionSetBuilder = builder;
-            return this;
-        }
-
-        /**
-         * Supplies a custom Beginning Segment (BGN) builder, overriding the default.
-         *
-         * @param builder the custom BGN builder
-         * @return this builder instance
-         */
-        public Builder setBeginningSegmentBuilder(BeginningSegment.Builder builder) {
-            this.customBeginningSegmentBuilder = builder;
-            return this;
-        }
-
-        /**
-         * Supplies a custom File Effective Date (DTP*007) builder, overriding the default.
-         *
-         * @param builder the custom DTP builder
-         * @return this builder instance
-         */
-        public Builder setFileEffectiveDateBuilder(FileEffectiveDate.Builder builder) {
-            this.customFileEffectiveDateBuilder = builder;
-            return this;
-        }
-
-        /**
-         * Supplies a custom Transaction Set Policy Number (REF*38) builder, overriding the default.
-         *
-         * @param builder the custom REF builder
-         * @return this builder instance
-         */
-        public Builder setTransactionSetPolicyNumberBuilder(TransactionSetPolicyNumber.Builder builder) {
-            this.customPolicyNumberBuilder = builder;
-            return this;
-        }
-
-        /**
-         * Supplies a custom Sponsor Name (Loop 1000A, N1*P5) builder, overriding the default.
-         *
-         * @param builder the custom sponsor builder
-         * @return this builder instance
-         */
-        public Builder setSponsorNameBuilder(SponsorName.Builder builder) {
-            this.customSponsorBuilder = builder;
-            return this;
-        }
-
-        /**
-         * Supplies a custom Payer (Loop 1000B, N1*IN) builder, overriding the default.
-         *
-         * @param builder the custom payer builder
-         * @return this builder instance
-         */
-        public Builder setPayerBuilder(Payer.Builder builder) {
-            this.customPayerBuilder = builder;
-            return this;
-        }
-
         /**
          * Builds a new Header instance
          *
@@ -342,15 +202,6 @@ public class Header {
             header.planSponsorName = this.planSponsorName;
             header.payerName = this.payerName;
             header.payerIdentification = this.payerIdentification;
-
-            header.customInterchangeBuilder = this.customInterchangeBuilder;
-            header.customFunctionalBuilder = this.customFunctionalBuilder;
-            header.customTransactionSetBuilder = this.customTransactionSetBuilder;
-            header.customBeginningSegmentBuilder = this.customBeginningSegmentBuilder;
-            header.customFileEffectiveDateBuilder = this.customFileEffectiveDateBuilder;
-            header.customPolicyNumberBuilder = this.customPolicyNumberBuilder;
-            header.customSponsorBuilder = this.customSponsorBuilder;
-            header.customPayerBuilder = this.customPayerBuilder;
 
             return header;
         }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/InterchangeControlHeader.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/InterchangeControlHeader.java
@@ -22,7 +22,7 @@ import lombok.Getter;
  * paired with the closing IEA. Extends the generic ISA segment with X834-specific defaults.
  */
 @Getter
-public class InterchangeControlHeader extends ISASegment {
+class InterchangeControlHeader extends ISASegment {
     private final X834Context context;
     /** Default ISA01 authorization information qualifier {@code "00"} (No authorization information present). */
     public static final AuthorizationInformationQualifier DEFAULT_AUTHORIZATION_INFO_QUALIFIER = AuthorizationInformationQualifier.fromString("00");

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/Payer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/Payer.java
@@ -5,7 +5,7 @@
  *
  * For license information see the LICENSE file in the root of this project.
  */
-package com.fastChickensHR.edi.x834.loop1000B;
+package com.fastChickensHR.edi.x834.header;
 
 import com.fastChickensHR.edi.x834.segments.N1Segment;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
@@ -17,7 +17,7 @@ import lombok.experimental.Accessors;
  * Produces the N1 segment that identifies the payer (insurer) in the header portion
  * of the 834, following the plan sponsor (Loop 1000A). Extends the generic {@link N1Segment}.
  */
-public class Payer extends N1Segment {
+class Payer extends N1Segment {
     /** Default N101 entity identifier code {@code "IN"} (Insurer). */
     public static final String DEFAULT_ENTITY_IDENTIFIER_CODE = "IN";
     /** Default N103 identification code qualifier {@code "FI"} (Federal Taxpayer's Identification Number). */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/SponsorName.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/SponsorName.java
@@ -5,7 +5,7 @@
  *
  * For license information see the LICENSE file in the root of this project.
  */
-package com.fastChickensHR.edi.x834.loop1000A;
+package com.fastChickensHR.edi.x834.header;
 
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.segments.N1Segment;
@@ -18,7 +18,7 @@ import lombok.experimental.Accessors;
  * in the header portion of the 834, after the transaction set header/BGN and before
  * the payer (Loop 1000B). Extends the generic {@link N1Segment}.
  */
-public class SponsorName extends N1Segment {
+class SponsorName extends N1Segment {
     /** Default N101 entity identifier code {@code "P5"} (Plan Sponsor). */
     public static final String DEFAULT_ENTITY_IDENTIFIER_CODE = "P5";
     /** Default N103 identification code qualifier {@code "FI"} (Federal Taxpayer's Identification Number). */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/TransactionSetHeader.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/TransactionSetHeader.java
@@ -19,7 +19,7 @@ import lombok.Getter;
  * and implementation convention reference (ST03). Extends the generic ST segment.
  */
 @Getter
-public class TransactionSetHeader extends STSegment {
+class TransactionSetHeader extends STSegment {
     /** Default ST01 transaction set identifier code {@code "834"} (Benefit Enrollment and Maintenance). */
     private final static String DEFAULT_TRANSACTION_SET_ID = "834";
     /** Default ST02 transaction set control number {@code "0001"}. */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/TransactionSetPolicyNumber.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/TransactionSetPolicyNumber.java
@@ -16,7 +16,7 @@ import lombok.Getter;
  * This segment uses the REF segment format with the {@code "38"} qualifier for the master policy number.
  */
 @Getter
-public class TransactionSetPolicyNumber extends RefSegment {
+class TransactionSetPolicyNumber extends RefSegment {
     /** Default REF01 reference identification qualifier {@code "38"} (Master Policy Number). */
     private final static String DEFAULT_REFERENCE_IDENTIFICATION_QUALIFIER = "38";
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/segments/STSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/segments/STSegment.java
@@ -9,7 +9,6 @@ package com.fastChickensHR.edi.x834.segments;
 
 import com.fastChickensHR.edi.x834.data.TransactionSetIdentifierCode;
 import com.fastChickensHR.edi.x834.exception.ValidationException;
-import com.fastChickensHR.edi.x834.header.TransactionSetHeader;
 import lombok.Getter;
 
 /**

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/FunctionalGroupTrailer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/FunctionalGroupTrailer.java
@@ -18,7 +18,7 @@ import lombok.experimental.Accessors;
  * This class extends the GESegment (GE - Functional Group Trailer segment).
  */
 @Getter
-public class FunctionalGroupTrailer extends GESegment {
+class FunctionalGroupTrailer extends GESegment {
 
     private FunctionalGroupTrailer(Builder builder) throws ValidationException {
         super(builder);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/InterchangeControlTrailer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/InterchangeControlTrailer.java
@@ -20,7 +20,7 @@ import lombok.experimental.Accessors;
  * the number of functional groups included and the interchange control number.
  */
 @Getter
-public class InterchangeControlTrailer extends IEASegment {
+class InterchangeControlTrailer extends IEASegment {
     /** Default IEA01 — number of functional groups in the interchange; always {@code "1"} for an 834. */
     public static final String DEFAULT_NUMBER_OF_INCLUDED_GROUPS = "1";
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/Trailer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/Trailer.java
@@ -37,32 +37,20 @@ public class Trailer {
     private Trailer(Builder builder) throws ValidationException {
         this.context = builder.context;
 
-        // Build the Transaction Set Trailer
-        TransactionSetTrailer.Builder tsBuilder = builder.customTransactionSetBuilder;
-        if (tsBuilder == null) {
-            tsBuilder = TransactionSetTrailer.builder()
-                    .setSetControlNumber(builder.transactionSetControlNumber)
-                    .setTransactionSegmentCount(builder.numberOfIncludedSegments);
-        }
-        this.transactionSetTrailer = tsBuilder.build();
+        this.transactionSetTrailer = TransactionSetTrailer.builder()
+                .setSetControlNumber(builder.transactionSetControlNumber)
+                .setTransactionSegmentCount(builder.numberOfIncludedSegments)
+                .build();
 
-        // Build the Functional Group Trailer
-        FunctionalGroupTrailer.Builder fgBuilder = builder.customFunctionalGroupBuilder;
-        if (fgBuilder == null) {
-            fgBuilder = FunctionalGroupTrailer.builder()
-                    .setNumberOfTransactionSets(builder.numberOfTransactionSetsIncluded)
-                    .setGroupControlNumber(builder.groupControlNumber);
-        }
-        this.functionalGroupTrailer = fgBuilder.build();
+        this.functionalGroupTrailer = FunctionalGroupTrailer.builder()
+                .setNumberOfTransactionSets(builder.numberOfTransactionSetsIncluded)
+                .setGroupControlNumber(builder.groupControlNumber)
+                .build();
 
-        // Build the Interchange Control Trailer
-        InterchangeControlTrailer.Builder icBuilder = builder.customInterchangeControlBuilder;
-        if (icBuilder == null) {
-            icBuilder = InterchangeControlTrailer.builder()
-                    .setNumberOfIncludedGroups(builder.numberOfIncludedFunctionalGroups)
-                    .setInterchangeControlNumber(builder.interchangeControlNumber);
-        }
-        this.interchangeControlTrailer = icBuilder.build();
+        this.interchangeControlTrailer = InterchangeControlTrailer.builder()
+                .setNumberOfIncludedGroups(builder.numberOfIncludedFunctionalGroups)
+                .setInterchangeControlNumber(builder.interchangeControlNumber)
+                .build();
     }
 
     /**
@@ -122,11 +110,6 @@ public class Trailer {
         private String groupControlNumber;
         private String numberOfIncludedFunctionalGroups = InterchangeControlTrailer.DEFAULT_NUMBER_OF_INCLUDED_GROUPS;
         private String interchangeControlNumber;
-
-        // Custom builders for advanced configuration
-        private TransactionSetTrailer.Builder customTransactionSetBuilder;
-        private FunctionalGroupTrailer.Builder customFunctionalGroupBuilder;
-        private InterchangeControlTrailer.Builder customInterchangeControlBuilder;
 
         /**
          * Creates a new Builder with the specified context. Control numbers (SE02, GE02, IEA02)
@@ -214,39 +197,6 @@ public class Trailer {
          */
         public Builder setInterchangeControlNumber(String interchangeControlNumber) {
             this.interchangeControlNumber = interchangeControlNumber;
-            return this;
-        }
-
-        /**
-         * Sets a custom TransactionSetTrailer builder for advanced configuration.
-         *
-         * @param builder A custom transaction set trailer builder
-         * @return This builder instance
-         */
-        public Builder withTransactionSetTrailer(TransactionSetTrailer.Builder builder) {
-            this.customTransactionSetBuilder = builder;
-            return this;
-        }
-
-        /**
-         * Sets a custom FunctionalGroupTrailer builder for advanced configuration.
-         *
-         * @param builder A custom functional group trailer builder
-         * @return This builder instance
-         */
-        public Builder withFunctionalGroupTrailer(FunctionalGroupTrailer.Builder builder) {
-            this.customFunctionalGroupBuilder = builder;
-            return this;
-        }
-
-        /**
-         * Sets a custom InterchangeControlTrailer builder for advanced configuration.
-         *
-         * @param builder A custom interchange control trailer builder
-         * @return This builder instance
-         */
-        public Builder withInterchangeControlTrailer(InterchangeControlTrailer.Builder builder) {
-            this.customInterchangeControlBuilder = builder;
             return this;
         }
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/TransactionSetTrailer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/TransactionSetTrailer.java
@@ -18,7 +18,7 @@ import lombok.experimental.Accessors;
  * This class extends the SESegment (SE - Transaction Set Trailer segment).
  */
 @Getter
-public class TransactionSetTrailer extends SESegment {
+class TransactionSetTrailer extends SESegment {
 
     private TransactionSetTrailer(Builder builder) throws ValidationException {
         super(builder);

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/header/HeaderTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/header/HeaderTest.java
@@ -125,21 +125,6 @@ class HeaderTest {
     }
 
     @Test
-    void testBuilderWithCustomBuilders() throws ValidationException {
-        InterchangeControlHeader.Builder interchangeBuilder = new InterchangeControlHeader.Builder(context);
-        FunctionalGroupHeader.Builder functionalBuilder = new FunctionalGroupHeader.Builder(context);
-
-        Header.Builder builder = new Header.Builder(context)
-                .setInterchangeControlHeaderBuilder(interchangeBuilder)
-                .setFunctionalGroupHeaderBuilder(functionalBuilder);
-
-        Header header = builder.build();
-
-        assertEquals(interchangeBuilder, header.getCustomInterchangeBuilder());
-        assertEquals(functionalBuilder, header.getCustomFunctionalBuilder());
-    }
-
-    @Test
     void testBuilderDefaultValues() throws ValidationException {
         Header header = new Header.Builder(context).build();
 

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/header/PayerTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/header/PayerTest.java
@@ -5,7 +5,7 @@
  *
  * For license information see the LICENSE file in the root of this project.
  */
-package com.fastChickensHR.edi.x834.loop1000B;
+package com.fastChickensHR.edi.x834.header;
 
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.X834Context;

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/header/SponsorNameTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/header/SponsorNameTest.java
@@ -5,7 +5,7 @@
  *
  * For license information see the LICENSE file in the root of this project.
  */
-package com.fastChickensHR.edi.x834.loop1000A;
+package com.fastChickensHR.edi.x834.header;
 
 import com.fastChickensHR.edi.x834.exception.ValidationException;
 import com.fastChickensHR.edi.x834.X834Context;

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/trailer/TrailerTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/trailer/TrailerTest.java
@@ -125,30 +125,6 @@ class TrailerTest {
     }
 
     @Test
-    void testCustomBuilders() throws ValidationException {
-        // Test using custom builders for the component trailers
-        TransactionSetTrailer.Builder transBuilder = new TransactionSetTrailer.Builder();
-        transBuilder.setSetControlNumber("9999");
-
-        FunctionalGroupTrailer.Builder functionalBuilder = new FunctionalGroupTrailer.Builder();
-        functionalBuilder.setGroupControlNumber("8888");
-
-        InterchangeControlTrailer.Builder interchangeBuilder = new InterchangeControlTrailer.Builder();
-        interchangeBuilder.setNumberOfIncludedGroups("1");
-        interchangeBuilder.setInterchangeControlNumber("7777777");
-
-        Trailer trailer = new Trailer.Builder(context)
-                .withTransactionSetTrailer(transBuilder)
-                .withFunctionalGroupTrailer(functionalBuilder)
-                .withInterchangeControlTrailer(interchangeBuilder)
-                .build();
-
-        assertEquals("9999", trailer.getTransactionSetTrailer().getSetControlNumber());
-        assertEquals("8888", trailer.getFunctionalGroupTrailer().getGroupControlNumber());
-        assertEquals("7777777", trailer.getInterchangeControlTrailer().getInterchangeControlNumber());
-    }
-
-    @Test
     void testDefaultValues() throws ValidationException {
         // Test default values
         Trailer trailer = new Trailer.Builder(context).build();


### PR DESCRIPTION
Execution of the curation ruling on #216 (map #202, build map #229) — closes #219.

- **11 escape-hatch setters removed**: `Header.Builder`'s 8 `set*Builder(...)` and `Trailer.Builder`'s 3 `with*Trailer(...)`, plus the custom-builder fields and branching they fed. The default construction path — the only one anything exercised — is unchanged; golden fixture tests pass untouched.
- **11 types hidden**: the 6 header segment classes, `SponsorName`, `Payer`, and the 3 trailer segment classes are now package-private. `SponsorName`/`Payer` relocate into the `header` package (the co-location pattern from #221/#230) so they can hide; the emptied `loop1000A`/`loop1000B` packages are gone.
- `STSegment` drops an unused import of the now-hidden `TransactionSetHeader`.
- Tests: the two cases that exercised the hatches (`HeaderTest.testBuilderWithCustomBuilders`, `TrailerTest.testCustomBuilders`) are deleted; `SponsorNameTest`/`PayerTest` move with their classes. Full reactor: 3,857 tests green.

mono is unaffected — it imports only `Header` and `Trailer`, and never called the removed setters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)