### PR TITLE
docs(x834): document the failure-channel contract (#222)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/GenerationResult.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/GenerationResult.java
@@ -17,6 +17,11 @@ import java.util.List;
  * problem, generation accumulates every problem it can (all build-time checks, every member's
  * assembly, every delimiter-unsafe value) into one {@link Failure}, so the source can be fixed in a
  * single round-trip instead of one failed generation at a time.
+ *
+ * <p>Its counterpart is the construction phase: an individual component builder that cannot produce
+ * its component at all fails earlier, at its own {@code build()}, with a checked
+ * {@link com.fastChickensHR.edi.x834.exception.ValidationException} — see that type for why the
+ * split exists. Everything after construction reports here.
  */
 public sealed interface GenerationResult {
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/RefSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/RefSegment.java
@@ -107,7 +107,8 @@ public abstract class RefSegment extends Segment {
          * Builds and validates the REF segment.
          *
          * @return a new {@link RefSegment} instance
-         * @throws ValidationException if validation fails
+         * @throws ValidationException if the segment is mis-constructed — the construction-phase
+         * side of the failure contract; see {@link ValidationException}
          */
         public abstract RefSegment build() throws ValidationException;
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/X834Document.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/X834Document.java
@@ -30,7 +30,9 @@ import java.util.Optional;
  * {@link GenerationResult.Failure} carrying <em>every</em> reason it could not be produced. There is
  * no separate {@code isValid()}/{@code getErrors()} accessor and no thrown exception: build-time
  * (structure/configuration) and render-time (serialization) problems all surface as
- * {@link GenerationError}s in the {@code Failure}.
+ * {@link GenerationError}s in the {@code Failure}. The only checked failure in the contract sits
+ * upstream of this boundary — a component builder that cannot construct its component throws
+ * {@link ValidationException} at its own {@code build()}; from the document inward, nothing throws.
  */
 public class X834Document {
     private final Header header;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/exception/ValidationException.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/exception/ValidationException.java
@@ -8,9 +8,17 @@
 package com.fastChickensHR.edi.x834.exception;
 
 /**
- * Exception thrown when EDI document validation fails.
- * This exception is used to signal issues with segment content,
- * required fields, or cross-segment validation failures.
+ * The construction-phase half of the failure contract: thrown — checked, at the call site — by a
+ * component's {@code build()} or {@code validate()} when that one component is mis-constructed
+ * (a missing required element, an over-length value, a broken cross-element rule).
+ *
+ * <p>The split is deliberate. A construction failure is local to the component being built and is
+ * the caller's own coding or data error, so it surfaces immediately, as a checked exception, at the
+ * call that caused it. Document-level generation, by contrast, never throws for content problems:
+ * once components reach {@link com.fastChickensHR.edi.x834.X834Document}, every problem — build-time
+ * and render-time alike — accumulates into a
+ * {@link com.fastChickensHR.edi.x834.GenerationResult.Failure} so one
+ * {@code generateDocument()} call reports them all.
  */
 public class ValidationException extends Exception {
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -71,6 +71,15 @@ import java.util.stream.Collectors;
  * Record (dependents attached as child members), then — after all members, in Record order — each
  * Record's custom REF extensions followed by its HD coverage segment, then the trailer. Control
  * numbers, segment counts and SE/GE/IEA are generated internally by the library.
+ *
+ * <p><strong>Failure channel — this seam flattens.</strong> {@link FileGenerator#generate} returns a
+ * {@code String}, so there is nowhere to hand back a structured result: a
+ * {@link GenerationResult.Failure} becomes an unchecked {@link IllegalStateException} whose message
+ * concatenates every {@link GenerationError}, and a construction-phase {@link ValidationException}
+ * is wrapped into the same exception type. Every reason still arrives — but as prose in one message,
+ * with the errors' phase and location structure lost. A caller that wants the errors as data (to
+ * route, count, or display them individually) should drive {@link X834Document} directly and switch
+ * on its {@link GenerationResult}.
  */
 public final class X834FileGenerator implements FileGenerator {
 

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/Trailer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/Trailer.java
@@ -204,7 +204,8 @@ public class Trailer {
          * Builds the final Trailer object
          *
          * @return The configured Trailer
-         * @throws ValidationException If validation fails
+         * @throws ValidationException if the trailer is mis-constructed — the construction-phase
+         * side of the failure contract; see {@link ValidationException}
          */
         public Trailer build() throws ValidationException {
             return new Trailer(this);


### PR DESCRIPTION
Closes #222 (map #229; ruling on #216).

Docs-only — no behavior change. Six javadoc edits stating the failure-channel contract:

- **`ValidationException`** now carries the canonical statement of the construction-phase half: checked, thrown at a component's own `build()`/`validate()`, deliberately split from document-level reporting.
- **`GenerationResult`** gains the counterpart sentence: builders fail earlier with the checked exception; everything after construction reports here.
- **`X834Document`** class javadoc names the split explicitly: the only checked failure sits upstream of the document boundary; from the document inward, nothing throws.
- **`X834FileGenerator`** class javadoc states the String-seam flattening: a `Failure` becomes one `IllegalStateException` message carrying every reason as prose, losing the errors' phase/location structure — and points at `X834Document` for the structured path.
- **`Trailer.Builder.build()`** / **`RefSegment.AbstractBuilder.build()`** `@throws` clauses now frame the checked exception as the construction-phase side and link to `ValidationException`.

`mvn verify` green. `javadoc:javadoc` still fails on 21 pre-existing missing-`@param` warnings (identical count on clean master, not a CI gate); my edits add no new javadoc complaints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)