### PR TITLE
chore: OSS hygiene sweep — SECURITY.md, code of conduct, templates, pom developer contact (#247)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report a defect in the edi library
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!CAUTION]
+        > **Synthetic data only.** 834 files carry real people's names, SSNs, dates of birth,
+        > and other protected information. Never paste production EDI content, real member
+        > data, or anything derived from it into this public issue. Rebuild your reproducer
+        > with made-up values before filing.
+  - type: input
+    id: version
+    attributes:
+      label: edi version or commit SHA
+      description: The release you depend on, or the commit SHA if you build from source.
+      placeholder: "1.0.0-beta.1"
+    validations:
+      required: true
+  - type: dropdown
+    id: module
+    attributes:
+      label: Module
+      options:
+        - core
+        - x834
+        - x999
+        - flatfile
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: The smallest code snippet (with synthetic input, if any) that shows the problem.
+      render: java
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happens instead — output, exception, stack trace.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!-- The API is still moving pre-1.0. Please open an issue first so the change
+     can be discussed before you invest in a PR. -->
+
+Closes #
+
+## Checklist
+
+- [ ] Linked to a discussed issue
+- [ ] `mvn -B verify` passes locally
+- [ ] `mvn spotless:apply` has been run
+- [ ] `CHANGELOG.md` updated if the change is user-visible
+- [ ] Conformance corpus grown if this adds a new segment or loop

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+contact@fastchickenshr.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report suspected vulnerabilities privately via
+[GitHub private vulnerability reporting](https://github.com/FastChickensHR/edi/security/advisories/new).
+
+**Do not file a public issue for a security problem.** Public issues are visible
+immediately, before a fix exists.
+
+Reports are triaged and answered in the advisory thread, and fixes are
+coordinated and disclosed there.
+
+## Supported versions
+
+Only the **latest release** receives security fixes. During the beta series each
+new `1.0.0-beta.N` supersedes the previous one; older betas are not patched.

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,15 @@
     <name>FastChickensHR EDI</name>
     <description>Open-source toolkit for generating X12 EDI benefit enrollment documents</description>
 
+    <developers>
+        <developer>
+            <name>Mark Beebe</name>
+            <email>contact@fastchickenshr.com</email>
+            <organization>FastChickensHR</organization>
+            <organizationUrl>https://fastchickenshr.com</organizationUrl>
+        </developer>
+    </developers>
+
     <modules>
         <module>core</module>
         <module>x834</module>


### PR DESCRIPTION
Executes the file half of #247 (hygiene checklist decided in #213, map #202):

- **SECURITY.md** — GitHub private vulnerability reporting as the only channel; no public issues for vulns; supported versions = latest release only.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 verbatim; enforcement contact `contact@fastchickenshr.com` (the address the project already publishes in every license header), now also declared as the pom's developer email so it's stated once.
- **Bug-report issue form** — version/SHA, module dropdown, minimal reproducer, expected vs actual, with a prominent **synthetic-data-only** caution (834s carry names/SSNs/DOBs). No feature-request form; `config.yml` keeps blank issues enabled as the question channel.
- **PR template** — checklist mirroring the contribution bar: linked issue, `mvn -B verify`, `spotless:apply`, CHANGELOG, conformance corpus.
- **pom** — minimal `<developers>` block backing the CoC contact; the rest of the Central-grade metadata stays with #231.

The settings half (repo description, topics, private-vulnerability-reporting toggle) is applied directly via the API and recorded on #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)