### PR TITLE
feat(x834): per-partner interchange ID qualifiers + ActionCode RX (mono#658)

### DIFF
--- a/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
@@ -42,6 +42,18 @@ public class X834Context {
     private String senderID;
     private String receiverID;
     /**
+     * ISA05 — Interchange Sender ID Qualifier. Null or blank falls back to the header's default
+     * ({@code "30"}, U.S. Federal Tax Identification Number). Trading partners routinely mandate
+     * {@code "ZZ"} (Mutually Defined) instead (mono#658/#640), so this is a per-partner value,
+     * not a constant.
+     */
+    private String senderIdQualifier;
+    /**
+     * ISA07 — Interchange Receiver ID Qualifier. Null or blank falls back to the header's default
+     * ({@code "ZZ"}, Mutually Defined).
+     */
+    private String receiverIdQualifier;
+    /**
      * GS02 — Application Sender's Code, the functional-group sender identifier. Distinct from
      * {@link #senderID} (ISA06): a trading partner may assign a sender code that differs from the
      * interchange mailbox ID. Null or blank falls back to {@link #senderID}, which is the common

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/ActionCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/ActionCode.java
@@ -123,7 +123,8 @@ public enum ActionCode implements EdiCodeEnum {
     SEND_RECORD_SPRING("95", "Send Record at End of the Spring Term"),
     SEND_RECORD_SUMMER("96", "Send Record at End of the Summer Term"),
     CERTIFIED_TOTAL("A1", "Certified in total"),
-    SEND_RECORD_INTERSESSION("97", "Send Record at End of the Intersession Term");
+    SEND_RECORD_INTERSESSION("97", "Send Record at End of the Intersession Term"),
+    REPLACE("RX", "Replace");
 
     private final String code;
     private final String description;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -126,6 +126,8 @@ public final class X834FileGenerator implements FileGenerator {
         X834Context context = new X834Context();
         apply(file, X834Location.SENDER_ID, context::setSenderID);
         apply(file, X834Location.RECEIVER_ID, context::setReceiverID);
+        apply(file, X834Location.SENDER_ID_QUALIFIER, context::setSenderIdQualifier);
+        apply(file, X834Location.RECEIVER_ID_QUALIFIER, context::setReceiverIdQualifier);
         apply(file, X834Location.APPLICATION_SENDER_CODE, context::setApplicationSenderCode);
         apply(file, X834Location.APPLICATION_RECEIVER_CODE, context::setApplicationReceiverCode);
         apply(file, X834Location.INTERCHANGE_CONTROL_NUMBER, context::setInterchangeControlNumber);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
@@ -24,6 +24,10 @@ public final class X834Location {
     // ---- File level: envelope + control numbers (X834Context) ----
     public static final String SENDER_ID = "senderId";       // ISA06
     public static final String RECEIVER_ID = "receiverId";   // ISA08
+    /** ISA05 — interchange sender ID qualifier; absent keeps the header default ("30"). */
+    public static final String SENDER_ID_QUALIFIER = "senderIdQualifier";
+    /** ISA07 — interchange receiver ID qualifier; absent keeps the header default ("ZZ"). */
+    public static final String RECEIVER_ID_QUALIFIER = "receiverIdQualifier";
     /** GS02 — application sender's code; falls back to {@link #SENDER_ID} when absent. */
     public static final String APPLICATION_SENDER_CODE = "applicationSenderCode";
     /** GS03 — application receiver's code; falls back to {@link #RECEIVER_ID} when absent. */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/InterchangeControlHeader.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/InterchangeControlHeader.java
@@ -67,9 +67,15 @@ class InterchangeControlHeader extends ISASegment {
             this.isa02 = DEFAULT_AUTHORIZATION_INFO;
             this.isa03 = DEFAULT_SECURITY_INFO_QUALIFIER;
             this.isa04 = DEFAULT_SECURITY_INFO;
-            this.isa05 = DEFAULT_INTERCHANGE_SENDER_QUALIFIER;
+            // Per-partner interchange qualifiers (mono#658/#640): a trading partner may mandate
+            // e.g. ISA05=ZZ; a null/blank context value keeps the historical defaults.
+            this.isa05 = context.getSenderIdQualifier() == null || context.getSenderIdQualifier().isBlank()
+                    ? DEFAULT_INTERCHANGE_SENDER_QUALIFIER
+                    : InterchangeIdQualifier.fromString(context.getSenderIdQualifier());
             this.setIsa06(context.getSenderID());
-            this.isa07 = DEFAULT_INTERCHANGE_RECEIVER_QUALIFIER;
+            this.isa07 = context.getReceiverIdQualifier() == null || context.getReceiverIdQualifier().isBlank()
+                    ? DEFAULT_INTERCHANGE_RECEIVER_QUALIFIER
+                    : InterchangeIdQualifier.fromString(context.getReceiverIdQualifier());
             this.setIsa08(context.getReceiverID());
             // ISA09 is the fixed 6-digit YYMMDD interchange date, independent of the
             // document's D8 (CCYYMMDD) format used by GS04/BGN03/DTP.

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/header/InterchangeControlHeaderTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/header/InterchangeControlHeaderTest.java
@@ -72,6 +72,27 @@ class InterchangeControlHeaderTest {
      * that GS04/BGN03/DTP carry — the fixed-width layout the getter assertions never render.
      */
     @Test
+    void contextQualifiersOverrideTheIsaDefaults() throws ValidationException {
+        // mono#658/#640: Florida Blue mandates ISA05=ZZ; the context now carries the per-partner
+        // qualifier pair, and null/blank keeps the historical defaults (the test above).
+        X834Context context = new X834Context();
+        context.setSenderID("SENDER123");
+        context.setReceiverID("RECEIVER456");
+        context.setSenderIdQualifier("ZZ");
+        context.setReceiverIdQualifier("30");
+        context.setDocumentDate(LocalDateTime.of(2023, 6, 30, 0, 0));
+
+        InterchangeControlHeader header = new InterchangeControlHeader.Builder(context)
+                .setInterchangeControlNumber("000000001")
+                .build();
+        SegmentTestSupport.setContext(header, context);
+
+        assertEquals(
+                "ISA*00*          *00*          *ZZ*SENDER123      *30*RECEIVER456    *230630*0000*^*00501*000000001*0*T*:~\n",
+                header.render());
+    }
+
+    @Test
     void rendersIsaSegmentFromContextDefaults() throws ValidationException {
         X834Context context = new X834Context();
         context.setSenderID("SENDER123");

--- a/x834/src/test/resources/golden/x834-location-keys.txt
+++ b/x834/src/test/resources/golden/x834-location-keys.txt
@@ -89,10 +89,12 @@ provider.idQualifier
 provider.lastName
 provider.middleName
 receiverId
+receiverIdQualifier
 ref.
 referenceIdentification
 relationshipCode
 senderId
+senderIdQualifier
 state
 subscriberNumber
 transactionSetControlNumber


### PR DESCRIPTION
The two seams mono#658's held tail needs:

1. **ISA05/ISA07 are per-partner values, not constants**: `X834Context` gains `senderIdQualifier`/`receiverIdQualifier`, the header honours them (null/blank keeps the historical `30`/`ZZ` defaults — pinned by the existing defaults test and a new override test), and `X834FileGenerator` maps two new `X834Location` tokens. Golden regenerated per its own instruction.
2. **`ActionCode` gains `REPLACE("RX")`** — Anthem CA's BGN08 third value; flows into `x834.spec` automatically via `ActionCode.class`, unblocking mono's seed-time vet for the `{2,4,RX}` constraint.

Full suite green locally (5802 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)