### PR TITLE
ci: run mvn -B verify instead of test (#240)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
           cache: maven
 
       - name: Build with Maven and run tests
-        run: mvn -B test
+        run: mvn -B verify
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
Closes #240 (execution of the #210 toolchain decision, map #202).

One-line workflow change: `mvn -B test` → `mvn -B verify`. Filed separately because it is the shared prerequisite for every verify-phase gate — Spotless (#241), JaCoCo (#244), javadoc jar (#245) all bind to `verify` and depend on this named phase move; reverting any one gate leaves the phase move intact.

No new required checks — `Run Unit Tests` and `JUnit Test Report` carry everything bound to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)