### PR TITLE
docs: record the reformat squash SHA in .git-blame-ignore-revs (#241)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# One-shot google-java-format reformat of the whole tree (#241, PR #252).
+# GitHub blame picks this file up automatically; locally, run:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+e0c831ffae75c86591f7ff0398781e84065062dd

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ structure/configuration problems and render-time serialization problems all surf
 
 Java 23 and Maven.
 
+Formatting is enforced by Spotless (google-java-format); `mvn spotless:apply` fixes a failing
+check. The one-shot reformat commit is listed in `.git-blame-ignore-revs` — GitHub blame skips
+it automatically, and locally you can do the same with
+`git config blame.ignoreRevsFile .git-blame-ignore-revs`.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
Closes #241 — the follow-up to #252: records the reformat's squash SHA (`e0c831ff`) in `.git-blame-ignore-revs` and adds the README note about `git config blame.ignoreRevsFile` (GitHub blame picks the file up automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)