### PR TITLE
build: adopt Error Prone 2.50.0, errors-only (#242)

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,4 @@
+# Stamp @lombok.Generated on generated members so Error Prone
+# (-XepDisableWarningsInGeneratedCode:true) skips them.
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lombok.version>1.18.36</lombok.version>
+        <errorprone.version>2.50.0</errorprone.version>
         <junit.version>5.10.2</junit.version>
     </properties>
 
@@ -73,11 +74,23 @@
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
+                        <compilerArgs>
+                            <arg>-XDcompilePolicy=simple</arg>
+                            <arg>--should-stop=ifError=FLOW</arg>
+                            <arg>-Xplugin:ErrorProne</arg>
+                            <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                        </compilerArgs>
                         <annotationProcessorPaths>
+                            <!-- lombok must stay first so Error Prone analyzes post-Lombok trees -->
                             <path>
                                 <groupId>org.projectlombok</groupId>
                                 <artifactId>lombok</artifactId>
                                 <version>${lombok.version}</version>
+                            </path>
+                            <path>
+                                <groupId>com.google.errorprone</groupId>
+                                <artifactId>error_prone_core</artifactId>
+                                <version>${errorprone.version}</version>
                             </path>
                         </annotationProcessorPaths>
                     </configuration>


### PR DESCRIPTION
Closes #242 (execution of the #210 toolchain decision, map #202; last link of the #240→#241→#242 chain).

- `error_prone_core` 2.50.0 in `annotationProcessorPaths`, **lombok kept first** so EP analyzes post-Lombok trees; `-XDcompilePolicy=simple`, `--should-stop=ifError=FLOW`, `-Xplugin:ErrorProne`, `-XDaddTypeAnnotationsToSymbol=true`; JDK `--add-exports`/`--add-opens` set in `.mvn/jvm.config`; `lombok.config` stamps `@lombok.Generated`.
- **Deviation**: `-XepDisableWarningsInGeneratedCode:true` omitted — maven-compiler-plugin 3.13 splits whitespace inside an `<arg>`, so javac rejects the flag standalone. It only suppresses *warnings*, which are non-fatal under the errors-only policy; the `@Generated` stamping stays in place for whenever EP flags are revisited (e.g. `-Werror` post-beta).
- **Triage pass: empty.** Full `mvn -B verify` green locally with zero EP findings (errors *and* warnings) across all modules. Gate proven live with a `DeadException` canary that failed the build, then was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)