### PR TITLE
build: JaCoCo check with per-module regression floors (#244)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,6 +23,12 @@
     <name>FastChickensHR EDI Core</name>
     <description>Format-neutral file kernel (FileContent / Record / Field / Location) and the generate/parse seam</description>
 
+    <properties>
+        <!-- Coverage regression floors (#244) - hand-ratchet only, never lower to admit a PR -->
+        <jacoco.line.floor>0.99</jacoco.line.floor>
+        <jacoco.branch.floor>0.90</jacoco.branch.floor>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/flatfile/pom.xml
+++ b/flatfile/pom.xml
@@ -23,6 +23,12 @@
     <name>FastChickensHR EDI Flat File</name>
     <description>Flat-file support (delimited today, fixed-width reserved) — parses into and generates from the core file kernel</description>
 
+    <properties>
+        <!-- Coverage regression floors (#244) - hand-ratchet only, never lower to admit a PR -->
+        <jacoco.line.floor>0.94</jacoco.line.floor>
+        <jacoco.branch.floor>0.82</jacoco.branch.floor>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fastchickenshr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lombok.version>1.18.36</lombok.version>
         <errorprone.version>2.50.0</errorprone.version>
+        <jacoco.version>0.8.13</jacoco.version>
+        <!--
+            Coverage regression floors (#244): each module declares its own
+            jacoco.line.floor / jacoco.branch.floor, set just under its measured
+            coverage. Hand-ratchet them upward when numbers durably improve;
+            never lower one to admit a PR. The 1.00 defaults here deliberately
+            fail any new module until it declares its floors.
+        -->
+        <jacoco.line.floor>1.00</jacoco.line.floor>
+        <jacoco.branch.floor>1.00</jacoco.branch.floor>
         <junit.version>5.10.2</junit.version>
     </properties>
 
@@ -125,6 +135,44 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>check-floors</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${jacoco.line.floor}</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${jacoco.branch.floor}</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/x834/pom.xml
+++ b/x834/pom.xml
@@ -23,6 +23,12 @@
     <name>FastChickensHR EDI 834</name>
     <description>X12 834 benefit enrollment EDI document generation toolkit</description>
 
+    <properties>
+        <!-- Coverage regression floors (#244) - hand-ratchet only, never lower to admit a PR -->
+        <jacoco.line.floor>0.95</jacoco.line.floor>
+        <jacoco.branch.floor>0.75</jacoco.branch.floor>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fastchickenshr</groupId>

--- a/x999/pom.xml
+++ b/x999/pom.xml
@@ -23,6 +23,12 @@
     <name>FastChickensHR EDI 999</name>
     <description>X12 999 / 997 acknowledgment support — parses into the core file kernel</description>
 
+    <properties>
+        <!-- Coverage regression floors (#244) - hand-ratchet only, never lower to admit a PR -->
+        <jacoco.line.floor>0.95</jacoco.line.floor>
+        <jacoco.branch.floor>0.80</jacoco.branch.floor>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fastchickenshr</groupId>


### PR DESCRIPTION
Closes #244 (execution of the #211 quality bar, map #202).

- jacoco-maven-plugin **0.8.13** in the root build: `prepare-agent` + a `BUNDLE`-element `check` bound at `verify`, limits on `LINE` and `BRANCH` `COVEREDRATIO`.
- Floors are property-driven: each module pom declares `jacoco.line.floor`/`jacoco.branch.floor` per the #211 table (core 0.99/0.90, x834 0.95/0.75, x999 0.95/0.80, flatfile 0.94/0.82). The **root default is 1.00**, so a future module fails loudly until it declares its own floors.
- Whole-module counters, no exclusion lists; the pom comments carry the hand-ratchet rule (never lower to admit a PR).
- Proof: full `mvn -B verify` green — all four module checks report "All coverage checks have been met" — and a canary override (`-Djacoco.line.floor=0.999` on x834) fails with "lines covered ratio is 0.966", confirming the gate bites and the measured numbers still match the `1923b50` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)