### PR TITLE
docs: seed CHANGELOG.md and record the versioning & deprecation policy (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This file is curated by hand — it is not generated from commit messages.
+Conventional commits (with `!` for breaking changes) remain the raw feed at
+commit level; this file is the canonical, human-readable record.
+
+## Conventions
+
+- One section per released version, newest first.
+- Every release section carries a **mandatory Breaking subsection** — written
+  explicitly as "none" when there are no breaking changes. This subsection is
+  the canonical notice that the compatibility promise below refers to.
+- Standard Keep-a-Changelog subsections (Added, Changed, Deprecated, Removed,
+  Fixed, Security) are used as applicable.
+- On each release cut, the version's section is mirrored into the GitHub
+  Release notes.
+
+## Versioning and deprecation policy
+
+Decided in [#205](https://github.com/FastChickensHR/edi/issues/205); recorded
+here so consumers can find it.
+
+### Version scheme
+
+- Versions run `1.0.0-beta.N` → `1.0.0`. There is no 0.x line — the curated
+  public surface *is* the 1.0 candidate, and the version string names that
+  promise. Graduation is a rename (`beta.N` → `1.0.0`), not a renumbering.
+- **Lockstep versioning:** the whole reactor shares one version — the
+  parent's. There are no per-module versions; a major driven by one module
+  re-releases the others unchanged. The empty `fixedwidth` placeholder ships
+  at the reactor version, promise-free.
+- **Graduation rule:** `1.0.0` is a binary-identical re-release of the final
+  beta — nothing but the version string changes. Any other change ships as one
+  more `beta.N` first, which becomes the new candidate.
+
+### Compatibility promise
+
+- **Beta → beta: none-with-notice, measured on the binary axis.** Any
+  binary-incompatible change is allowed between betas, but never silently:
+  every binary break must be enumerated in the release's Breaking subsection
+  (a short, explicit list — possibly "none").
+- **From `1.0.0` on:** binary compatibility holds within a major version, per
+  semver.
+
+### Deprecation policy (post-1.0)
+
+- Removal is **release-based**: a public API is removed only at a major
+  version, and only after being marked
+  `@Deprecated(since = "1.x", forRemoval = true)` — with a `@deprecated`
+  javadoc tag naming the replacement (or stating there is none) — in at least
+  one shipped minor release.
+- During the beta, deprecation is **optional**: betas may break directly under
+  the none-with-notice promise.
+
+## [Unreleased]
+
+### Breaking
+
+- none
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security


### PR DESCRIPTION
Executes #228, transcribing the #205 resolution.

## What

- Seeds `CHANGELOG.md` at the repo root in Keep-a-Changelog format with an `[Unreleased]` section. No fabricated history — the first real entry arrives with the first beta tag (#231).
- Conventions header: one section per released version, **mandatory Breaking subsection** (explicitly "none" when empty), mirrored into the GitHub Release on each cut; curated, not generated.
- Records the versioning & deprecation policy in the CHANGELOG header (the issue's sanctioned location; the README is being reworked concurrently in #246): `1.0.0-beta.N` → `1.0.0` with no 0.x, lockstep reactor version, none-with-notice beta→beta compat on the binary axis, post-1.0 binary compat within a major, release-based deprecation (`@Deprecated(since, forRemoval = true)` + replacement-naming javadoc, ≥1 shipped minor before removal at a major, optional during beta), and the binary-identical graduation rule.

Markdown only — no pom changes (the `1.0.0-beta.1` bump belongs to #231).

Closes #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)