### PR TITLE
docs: CONTRIBUTING.md — posture, gate stack, style and quality bars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing
+
+## Posture
+
+Issues and bug reports are very welcome — that is what a beta is for. For code
+contributions, please **open an issue first** before writing a PR: the API is
+deliberately in flux ahead of 1.0, and a change that looks reasonable in
+isolation may collide with an API move already in progress. Discussing first
+saves everyone a rewritten PR.
+
+## Dev setup
+
+- **Java 23** (the build sets `--source`/`--target` 23)
+- **Maven** (any recent 3.9+)
+
+Before opening a PR, run the full gate stack locally:
+
+```bash
+mvn -B verify
+```
+
+That single command runs everything CI runs: compilation with Error Prone,
+the unit test suite, the Spotless format check, and the JaCoCo coverage
+floors. If `mvn -B verify` passes locally, CI will pass.
+
+## Style
+
+**Spotless + google-java-format is the law.** The build enforces
+google-java-format 1.35.0 (Google style: 2-space indent, 100-column lines)
+via the Spotless Maven plugin, along with unused-import removal, annotation
+formatting, and the license header (a byte-for-byte match against
+`license-header.txt`). Never hand-format; to fix any style failure, run:
+
+```bash
+mvn spotless:apply
+```
+
+**Error Prone runs errors-only.** Error Prone 2.50.0 is wired into
+compilation; its default ERROR-severity patterns fail the build. Warnings are
+printed but non-fatal — do not add suppressions to silence warnings, and do
+not suppress an error without a comment explaining why.
+
+**Frozen quirks** — these look wrong but are settled; do not "fix" them:
+
+- Package names stay `com.fastChickensHR.*` (capital C and HR). The namespace
+  is frozen; renaming it breaks every consumer.
+- The license header year is a static "2025" — the check is a byte match, not
+  a currency claim.
+
+## Quality bar
+
+**Coverage floors are hand-ratcheted, never lowered.** Each module declares
+per-module JaCoCo regression floors (`jacoco.line.floor` /
+`jacoco.branch.floor` properties in its own `pom.xml`), set just under the
+measured coverage at the time they were set. They exist to stop backsliding:
+they are ratcheted *upward* by hand as real coverage improves, and are
+**never lowered to admit a PR**. The root pom defaults both floors to 1.00,
+so a new module fails `verify` until it declares its own floors. Current
+floors (line / branch): core 0.99 / 0.90 · x834 0.95 / 0.75 ·
+x999 0.95 / 0.80 · flatfile 0.94 / 0.82.
+
+**The golden corpus is the conformance suite.** The fixtures in
+`x834/src/test/resources/golden/` are the named conformance suite for emitted
+834 output. Any PR that adds or alters emitted surface — a new segment, loop,
+ordinal, or format behavior — must extend or update a golden fixture **in the
+same PR**.
+
+**Generate + parse ⇒ round-trip.** A module that both generates and parses a
+format must round-trip test it (generate, parse the output, assert
+equivalence). This codifies flatfile's existing practice and binds any future
+parser.
+
+**Test structure:** flat test classes with behavior-sentence method names
+(e.g. `unknownCodeThrowsIllegalArgument`). `@DisplayName` is disallowed — it
+duplicates the method name. `@Nested` stays unused — a test class that wants
+grouping should split into two classes.
+
+**Documentation conventions:**
+
+- README examples must stay fresh: every code example in the README compiles
+  against the current API. A PR that changes public API used by a README
+  example updates the example in the same PR.
+- Every package containing promised public types carries a `package-info.java`
+  with one orienting paragraph (plumbing-only packages are exempt). Doclint
+  cannot flag a missing package-info, so this is a convention checked at
+  tag time, not a CI gate.
+
+## Changelog
+
+User-visible changes update `CHANGELOG.md` in the same PR, in
+[Keep a Changelog](https://keepachangelog.com/) format (see
+[#228](https://github.com/FastChickensHR/edi/issues/228), which seeds the
+file and the versioning policy). Add your entry under the *Unreleased*
+heading.
+
+## Idioms
+
+The code idiom guide (builders, Lombok charter, nullness, `X834*` naming,
+records vs beans) is being settled in
+[#243](https://github.com/FastChickensHR/edi/issues/243); its resolution will
+produce the guide that replaces this line.
+
+## Licensing
+
+By submitting a pull request you agree that your contribution is licensed
+under the [MIT License](LICENSE) (inbound = outbound). There is no DCO and no
+CLA.


### PR DESCRIPTION
Closes #248.

Writes the repo-root `CONTRIBUTING.md` with the seven sections the #213 hygiene ruling specified, describing the `verify` gate stack as it actually exists on master today (all four blockers #240/#241/#242/#244 merged):

1. **Posture** — issues/bug reports welcome; PRs discuss-first (API in flux pre-1.0).
2. **Dev setup** — Java 23, Maven, `mvn -B verify` runs the whole gate stack locally.
3. **Style** (#210) — Spotless + google-java-format 1.35.0 is the law, `mvn spotless:apply` to fix; license-header byte match; Error Prone 2.50.0 errors-only; frozen quirks (`com.fastChickensHR` packages, static "2025" header year).
4. **Quality bar** (#211) — per-module `jacoco.line.floor`/`jacoco.branch.floor` regression floors, hand-ratcheted, never lowered to admit a PR; root default 1.00 fails new modules until they declare floors; golden-corpus same-PR growth rule; generate+parse ⇒ round-trip rule; flat test classes, behavior-sentence names, no `@DisplayName`/`@Nested`. Also carries #212's two routed conventions: README example freshness and package-info-on-promised-packages at tag time.
5. **Changelog** — user-visible changes update `CHANGELOG.md` same-PR, Keep-a-Changelog, pointing at #228 (whose PR seeds the file).
6. **Idioms** — one placeholder line linking #243; the guide replaces it when settled.
7. **Licensing** — MIT inbound=outbound, no DCO, no CLA.

Deliberately absent per the issue: roadmap, architecture tour, release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)