### PR TITLE
docs: flatfile and x999 quickstarts plus core kernel paragraph in the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Then depend on the module you need:
 
 ## Usage
 
+### Generate an X12 834
+
 Generate an 834 from an enrollment:
 
 ```java
@@ -71,6 +73,101 @@ Generation reports through exactly one channel: `generateDocument()` returns a
 *every* reason it could not be produced. Problems are accumulated, not thrown: build-time
 structure/configuration problems and render-time serialization problems all surface as
 `GenerationError`s in a single pass, so the source can be fixed in one round-trip.
+
+### Round-trip a delimited flat file
+
+Generate a CSV member feed and parse it back:
+
+```java
+FileContent roster = new FileContent(
+        Direction.OUTBOUND,
+        List.of(),
+        List.of(
+                Record.of(List.of(
+                        new Field(new Location(RecordLevel.RECORD, "memberId"), "1001"),
+                        new Field(new Location(RecordLevel.RECORD, "lastName"), "DOE"),
+                        new Field(new Location(RecordLevel.RECORD, "planCode"), "PPO-500"))),
+                Record.of(List.of(
+                        new Field(new Location(RecordLevel.RECORD, "memberId"), "1002"),
+                        new Field(new Location(RecordLevel.RECORD, "lastName"), "ROE"),
+                        new Field(new Location(RecordLevel.RECORD, "planCode"), "HMO-250")))));
+
+String csv = new DelimitedFileGenerator().generate(roster);
+// memberId,lastName,planCode
+// 1001,DOE,PPO-500
+// 1002,ROE,HMO-250
+
+FileContent parsed = new DelimitedFileParser().parse(csv);
+for (Record member : parsed.records()) {
+    for (Field field : member.fields()) {
+        System.out.println(field.location().name() + " = " + field.value());
+    }
+}
+```
+
+Each `Record` is a row and each `Field` a cell under the column named by its `Location`;
+an empty cell parses to no field at all (absence, not a blank value). The no-argument
+constructors speak `DelimitedFormat.csv()` — the one preset guaranteed to survive
+parse-then-generate unchanged. To match a foreign feed instead, pass
+`DelimitedFormat.builder()` with the knobs the target file differs on (delimiter, quote,
+escape, record separator); a headerless format (`.header(false)`) has no column names, so
+the parser addresses cells by 1-based position (`"1"`, `"2"`, …). One level of nesting
+(e.g. dependents under a subscriber) is flattened into linked rows tagged by a reserved
+record-level column, and reconstructed on the way back in.
+
+### Parse a 999 / 997 acknowledgment
+
+Read a functional acknowledgment and check what the carrier said:
+
+```java
+FileContent ack = new X999FileParser().parse(Files.readString(Path.of("carrier.999")));
+
+String groupStatus = field(ack.fileFields(), X999.GROUP_STATUS); // AK901
+if (X999.ACCEPTED.equals(groupStatus)) {
+    System.out.println("functional group accepted");
+}
+for (Record transactionSet : ack.records()) {
+    System.out.println("ST "
+            + field(transactionSet.fields(), X999.TRANSACTION_SET_CONTROL_NUMBER)
+            + ": " + field(transactionSet.fields(), X999.TRANSACTION_SET_STATUS));
+}
+```
+
+where `field` is the one-liner for reading a value by location name:
+
+```java
+static String field(List<Field> fields, String name) {
+    return fields.stream()
+            .filter(field -> name.equals(field.location().name()))
+            .findFirst()
+            .map(Field::value)
+            .orElse(null);
+}
+```
+
+An acknowledgment replies to one functional group, so the file-level fields carry the
+acknowledged group (`X999.FUNCTIONAL_ID_CODE`, `X999.GROUP_CONTROL_NUMBER` — the original
+GS06, your correlation key — and `X999.GROUP_STATUS`), plus the TA1 interchange
+acknowledgment when one is present. Each `Record` is one acknowledged transaction set: its
+control number (the original ST02) and its status. The parser is deliberately dumb — it
+emits the raw X12 codes (`A` accepted, `E` accepted with errors, `P` partially accepted,
+`R` rejected; all named on `X999`) and leaves interpretation and correlation to you.
+Interior error-detail segments (AK3/AK4/IK3/IK4) are skipped in this pass.
+
+### The core kernel
+
+Every module above meets in `core`, the format-neutral file kernel. A `FileContent` is an
+ordered tree — file-level fields (header/trailer, once per file) plus one `Record` per
+subject, each field a resolved value at a `Location` — and it is the pivot between your
+application and any format's dialect: you speak only the tree, and each format module
+interprets the locations into its own tokens (an 834 turns them into loops and segments,
+a delimited file into columns). The seam is a pair of single-method interfaces —
+`FileGenerator` serializes a `FileContent` to text, `FileParser` reads text back into one
+— which is why the flat-file example above round-trips and why an inbound feed and an
+outbound 834 can share one representation. You never depend on `core` alone: consumers
+meet its types through the format modules, as in the examples above. To orient in the
+source, start with `FileContent` and the two seam interfaces; the whole kernel is eight
+small types.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ for (Record transactionSet : ack.records()) {
 }
 ```
 
-where `field` is the one-liner for reading a value by location name:
+where `field` is the small helper for reading a value by location name:
 
 ```java
 static String field(List<Field> fields, String name) {


### PR DESCRIPTION
Executes #246 — the README half of the #212 docs bar (map #202). The root README stays the only prose doc.

## What's added

- **Flat-file quickstart** — a runnable round-trip: build a `FileContent`, generate CSV with `DelimitedFileGenerator`, parse it back with `DelimitedFileParser`. Follow-up prose covers the `DelimitedFormat.csv()` round-trip guarantee, `builder()` for foreign feeds, headerless positional addressing, and linked-row nesting.
- **x999 quickstart** — parse an acknowledgment with `X999FileParser`, read the group status (AK901) and each acknowledged transaction set's control number + status, including the small read-a-field-by-location helper a consumer actually needs. Prose names the correlation keys (GS06 / ST02), the raw-codes stance, and the skipped AK3/AK4/IK3/IK4 pass.
- **Core kernel paragraph** — prose only, no code block: `FileContent` as the ordered tree and pivot, the `FileGenerator`/`FileParser` seam, and that consumers meet core's types through the format modules.

The Install section is untouched — its rewrite is #231's definition of done.

## Verification (the #225 precedent)

Both snippets were compiled **and run** as an outside-package consumer: `mvn -q -DskipTests package`, then `javac`/`java` scratch mains against the packaged `core`/`flatfile`/`x999` jars (plus commons-csv's runtime deps). The CSV comment in the flat-file example and the ack outcomes described are the programs' actual output. Scratch files deleted, nothing committed but README.md.

Closes #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)