### PR TITLE
docs: javadoc completeness gate — doclint-clean javadoc jar at verify (#245)

### DIFF
--- a/core/src/main/java/com/fastChickensHR/edi/core/Direction.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/Direction.java
@@ -12,6 +12,8 @@ package com.fastChickensHR.edi.core;
  * partner (emitted).
  */
 public enum Direction {
+  /** Parsed from a trading partner's file into the consuming application. */
   INBOUND,
+  /** Emitted by the consuming application toward a trading partner. */
   OUTBOUND
 }

--- a/core/src/main/java/com/fastChickensHR/edi/core/Field.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/Field.java
@@ -12,19 +12,32 @@ import java.util.Optional;
 /**
  * One resolved value at a {@link Location}. A {@code null} value means <b>OMIT</b> — the location
  * is described, but nothing is generated for this subject (e.g. a situational REF with no value).
+ *
+ * @param location the address this value belongs to
+ * @param value the resolved value, or {@code null} to OMIT
  */
 public record Field(Location location, String value) {
+  /** Rejects a null location; a null value stays null and means OMIT. */
   public Field {
     if (location == null) {
       throw new IllegalArgumentException("location is required");
     }
   }
 
-  /** {@code true} when this field generates nothing (OMIT). */
+  /**
+   * States whether this field is the OMIT case.
+   *
+   * @return {@code true} when this field generates nothing (OMIT)
+   */
   public boolean isOmitted() {
     return value == null;
   }
 
+  /**
+   * The value with the OMIT case made explicit.
+   *
+   * @return the resolved value, or empty when this field is omitted
+   */
   public Optional<String> valueIfPresent() {
     return Optional.ofNullable(value);
   }

--- a/core/src/main/java/com/fastChickensHR/edi/core/FileContent.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/FileContent.java
@@ -15,8 +15,13 @@ import java.util.List;
  * file) plus one {@link Record} per subject. This is the pivot between the consuming application
  * and a format's dialect — the caller speaks only this, and each format interprets the {@link
  * Location}s.
+ *
+ * @param direction whether this content was parsed from a partner file or is being emitted to one
+ * @param fileFields the file-level (header/trailer) fields, appearing once per file
+ * @param records one {@link Record} per subject, in file order
  */
 public record FileContent(Direction direction, List<Field> fileFields, List<Record> records) {
+  /** Rejects a null direction and normalizes null lists to empty immutable copies. */
   public FileContent {
     if (direction == null) {
       throw new IllegalArgumentException("direction is required");

--- a/core/src/main/java/com/fastChickensHR/edi/core/FileGenerator.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/FileGenerator.java
@@ -16,5 +16,11 @@ package com.fastChickensHR.edi.core;
  * implement it.
  */
 public interface FileGenerator {
+  /**
+   * Serializes the fully-resolved content into this format's text.
+   *
+   * @param file the format-neutral content to serialize
+   * @return the file's complete text in this format's dialect
+   */
   String generate(FileContent file);
 }

--- a/core/src/main/java/com/fastChickensHR/edi/core/FileParser.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/FileParser.java
@@ -12,5 +12,11 @@ package com.fastChickensHR.edi.core;
  * format's dialect into a format-neutral {@link FileContent}, keeping the kernel bidirectional.
  */
 public interface FileParser {
+  /**
+   * Reads this format's text into the format-neutral tree.
+   *
+   * @param raw the file's complete text in this format's dialect
+   * @return the parsed content, direction {@link Direction#INBOUND}
+   */
   FileContent parse(String raw);
 }

--- a/core/src/main/java/com/fastChickensHR/edi/core/Location.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/Location.java
@@ -12,8 +12,12 @@ package com.fastChickensHR.edi.core;
  * (segment identifier, delimiters) and they are never overridable; {@code name} carries only the
  * <b>configurable</b> token(s) — an 834 REF qualifier, a CSV column — interpreted by the format's
  * own dialect below the kernel. {@code level} is the tree depth the address sits at.
+ *
+ * @param level the tree depth this address sits at
+ * @param name the configurable token(s) the format's dialect interprets at that depth
  */
 public record Location(RecordLevel level, String name) {
+  /** Rejects a null level and a null or blank name. */
   public Location {
     if (level == null) {
       throw new IllegalArgumentException("level is required");

--- a/core/src/main/java/com/fastChickensHR/edi/core/Record.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/Record.java
@@ -14,14 +14,23 @@ import java.util.List;
  * (its {@code RECORD}-level fields plus coverage); {@code children} are the nested child records
  * ({@code SUBRECORD}-level groups, e.g. dependents). In a flat file a record collapses to a single
  * line; in a grouped file it spans many.
+ *
+ * @param fields the subject's own values ({@code RECORD}-level fields plus coverage)
+ * @param children the nested child records ({@code SUBRECORD}-level groups, e.g. dependents)
  */
 public record Record(List<Field> fields, List<Record> children) {
+  /** Normalizes null lists to empty immutable copies. */
   public Record {
     fields = fields == null ? List.of() : List.copyOf(fields);
     children = children == null ? List.of() : List.copyOf(children);
   }
 
-  /** A leaf Record with no nested dependents. */
+  /**
+   * A leaf Record with no nested dependents.
+   *
+   * @param fields the subject's own values
+   * @return a Record carrying {@code fields} and no children
+   */
   public static Record of(List<Field> fields) {
     return new Record(fields, List.of());
   }

--- a/core/src/main/java/com/fastChickensHR/edi/core/RecordLevel.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/RecordLevel.java
@@ -17,7 +17,10 @@ package com.fastChickensHR.edi.core;
  * </ul>
  */
 public enum RecordLevel {
+  /** Header/trailer fields, once per file. */
   FILE,
+  /** A subject record's own fields (and its coverage). */
   RECORD,
+  /** A child record's fields, nested within a record. */
   SUBRECORD
 }

--- a/core/src/main/java/com/fastChickensHR/edi/core/package-info.java
+++ b/core/src/main/java/com/fastChickensHR/edi/core/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * The format-neutral file kernel: {@link com.fastChickensHR.edi.core.FileContent} is the pivot
+ * every format speaks — an ordered tree of {@link com.fastChickensHR.edi.core.Record}s and {@link
+ * com.fastChickensHR.edi.core.Field}s addressed by {@link com.fastChickensHR.edi.core.Location}.
+ * Format modules implement {@link com.fastChickensHR.edi.core.FileGenerator} and {@link
+ * com.fastChickensHR.edi.core.FileParser} to serialize and read it; start at {@link
+ * com.fastChickensHR.edi.core.FileContent}.
+ */
+package com.fastChickensHR.edi.core;

--- a/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFileGenerator.java
+++ b/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFileGenerator.java
@@ -42,7 +42,11 @@ public final class DelimitedFileGenerator implements FileGenerator {
     this(DelimitedFormat.csv());
   }
 
-  /** Writes a delimited flat file in the given {@code format} (e.g. to match a foreign feed). */
+  /**
+   * Writes a delimited flat file in the given {@code format} (e.g. to match a foreign feed).
+   *
+   * @param format the delimiter/quote/header convention to write
+   */
   public DelimitedFileGenerator(DelimitedFormat format) {
     this.format = format;
   }

--- a/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFileParser.java
+++ b/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFileParser.java
@@ -49,7 +49,11 @@ public final class DelimitedFileParser implements FileParser {
     this(DelimitedFormat.csv());
   }
 
-  /** Reads a delimited flat file in the given {@code format} (e.g. to match a foreign feed). */
+  /**
+   * Reads a delimited flat file in the given {@code format} (e.g. to match a foreign feed).
+   *
+   * @param format the delimiter/quote/header convention to expect
+   */
   public DelimitedFileParser(DelimitedFormat format) {
     this.format = format;
   }

--- a/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFormat.java
+++ b/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/DelimitedFormat.java
@@ -44,6 +44,8 @@ public final class DelimitedFormat {
    * character), minimal quoting, LF ({@code \n}) record separator, and a leading header row. This
    * is the format the module's round-trip tests verify; it is the one preset guaranteed to survive
    * parse-then-generate unchanged.
+   *
+   * @return the pinned CSV preset
    */
   public static DelimitedFormat csv() {
     return builder()
@@ -56,6 +58,11 @@ public final class DelimitedFormat {
         .build();
   }
 
+  /**
+   * Starts a custom format; defaults mirror {@link #csv()}.
+   *
+   * @return a builder seeded with the CSV defaults
+   */
   public static Builder builder() {
     return new Builder();
   }
@@ -103,12 +110,23 @@ public final class DelimitedFormat {
 
     private Builder() {}
 
+    /**
+     * The field delimiter, {@code ','} by default.
+     *
+     * @param delimiter the character separating fields within a record
+     * @return this builder
+     */
     public Builder delimiter(char delimiter) {
       this.delimiter = delimiter;
       return this;
     }
 
-    /** The quote character, or {@code null} for an unquoted format. */
+    /**
+     * The quote character, or {@code null} for an unquoted format.
+     *
+     * @param quote the character wrapping quoted fields, or {@code null} to never quote
+     * @return this builder
+     */
     public Builder quote(Character quote) {
       this.quote = quote;
       return this;
@@ -117,17 +135,32 @@ public final class DelimitedFormat {
     /**
      * The escape character, or {@code null} to escape an embedded quote by doubling it (the CSV
      * convention).
+     *
+     * @param escape the escape character, or {@code null} for quote-doubling
+     * @return this builder
      */
     public Builder escape(Character escape) {
       this.escape = escape;
       return this;
     }
 
+    /**
+     * When fields get quoted, {@link QuoteMode#MINIMAL} by default.
+     *
+     * @param quoteMode the Commons CSV quoting policy
+     * @return this builder
+     */
     public Builder quoteMode(QuoteMode quoteMode) {
       this.quoteMode = quoteMode;
       return this;
     }
 
+    /**
+     * The record separator, LF ({@code "\n"}) by default.
+     *
+     * @param recordSeparator the string terminating each record
+     * @return this builder
+     */
     public Builder recordSeparator(String recordSeparator) {
       this.recordSeparator = recordSeparator;
       return this;
@@ -137,12 +170,20 @@ public final class DelimitedFormat {
      * Whether files in this format carry a leading header row (the default). With {@code false} the
      * generator omits it and the parser, having no column names to read, addresses cells by their
      * 1-based position instead — see {@link DelimitedFileParser}.
+     *
+     * @param header {@code true} to read and write a leading header row
+     * @return this builder
      */
     public Builder header(boolean header) {
       this.header = header;
       return this;
     }
 
+    /**
+     * Finishes the format.
+     *
+     * @return the immutable assembled format
+     */
     public DelimitedFormat build() {
       return new DelimitedFormat(this);
     }

--- a/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/package-info.java
+++ b/flatfile/src/main/java/com/fastChickensHR/edi/flatfile/delimited/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * Delimited flat files (CSV and its variants) over the core kernel. {@link
+ * com.fastChickensHR.edi.flatfile.delimited.DelimitedFormat} pins the dialect (delimiter, quoting,
+ * header row); {@link com.fastChickensHR.edi.flatfile.delimited.DelimitedFileGenerator} writes it
+ * and {@link com.fastChickensHR.edi.flatfile.delimited.DelimitedFileParser} reads it back. Start at
+ * {@link com.fastChickensHR.edi.flatfile.delimited.DelimitedFormat#csv()}.
+ */
+package com.fastChickensHR.edi.flatfile.delimited;

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,26 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.12.0</version>
+                <configuration>
+                    <additionalOptions>
+                        <additionalOption>-Xdoclint:all</additionalOption>
+                    </additionalOptions>
+                    <failOnWarnings>true</failOnWarnings>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/GenerationError.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/GenerationError.java
@@ -17,9 +17,15 @@ import java.util.Objects;
  * like {@code "Header"} or {@code "Member[3]"}, or a segment identifier like {@code "HD"}), and a
  * human-readable {@code message}. Consumers enumerate these off a {@link GenerationResult.Failure}
  * rather than parsing a flattened exception string.
+ *
+ * @param phase the generation stage the failure arose in
+ * @param location a free-form label naming where it arose, e.g. {@code "Header"} or {@code
+ *     "Member[3]"}
+ * @param message the human-readable reason
  */
 public record GenerationError(Phase phase, String location, String message) {
 
+  /** Rejects a null phase, location, or message. */
   public GenerationError {
     Objects.requireNonNull(phase, "phase");
     Objects.requireNonNull(location, "location");
@@ -36,6 +42,8 @@ public record GenerationError(Phase phase, String location, String message) {
 
   /**
    * A single-line rendering — {@code PHASE | location | message} — for log and exception surfaces.
+   *
+   * @return the error as one pipe-delimited line
    */
   public String formatted() {
     return phase + " | " + location + " | " + message;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/GenerationResult.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/GenerationResult.java
@@ -25,11 +25,21 @@ import java.util.List;
  */
 public sealed interface GenerationResult {
 
-  /** Generation succeeded; {@link #document()} is the complete X12 834 string. */
+  /**
+   * Generation succeeded; {@link #document()} is the complete X12 834 string.
+   *
+   * @param document the finished X12 834 document text
+   */
   record Success(String document) implements GenerationResult {}
 
-  /** Generation failed; {@link #errors()} lists every reason, accumulated in one pass. */
+  /**
+   * Generation failed; {@link #errors()} lists every reason, accumulated in one pass.
+   *
+   * @param errors every reason generation failed, in the order encountered
+   */
   record Failure(List<GenerationError> errors) implements GenerationResult {
+
+    /** Defensively copies the error list. */
     public Failure {
       errors = List.copyOf(errors);
     }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/RefSegment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/RefSegment.java
@@ -31,6 +31,8 @@ import lombok.Getter;
  */
 @Getter
 public abstract class RefSegment extends Segment {
+
+  /** The X12 segment identifier for this segment: {@code REF}. */
   public static final String SEGMENT_ID = "REF";
 
   /** Maximum length of REF02 (Reference Identification, X12 element 127: AN 1/50 in 005010). */
@@ -48,6 +50,13 @@ public abstract class RefSegment extends Segment {
   /** REF03 — reference description (element 352, max 80 characters). */
   protected final String ref03;
 
+  /**
+   * Creates a REF segment from a builder's captured element values.
+   *
+   * @param builder the builder carrying REF01–REF03
+   * @throws ValidationException if both REF02 and REF03 are absent, or either exceeds its maximum
+   *     length
+   */
   protected RefSegment(RefSegment.AbstractBuilder<?> builder) throws ValidationException {
     this.ref01 = builder.ref01;
     this.ref02 = builder.ref02;
@@ -82,6 +91,8 @@ public abstract class RefSegment extends Segment {
   }
 
   /**
+   * Returns the kind of reference this segment carries.
+   *
    * @return REF01 — reference identification qualifier.
    */
   public ReferenceIdentificationQualifier getReferenceIdentificationQualifier() {
@@ -89,6 +100,8 @@ public abstract class RefSegment extends Segment {
   }
 
   /**
+   * Returns the reference value itself.
+   *
    * @return REF02 — reference identification value.
    */
   public String getReferenceIdentification() {
@@ -96,6 +109,8 @@ public abstract class RefSegment extends Segment {
   }
 
   /**
+   * Returns the free-form description accompanying the reference.
+   *
    * @return REF03 — reference description.
    */
   public String getReferenceDescription() {
@@ -108,11 +123,22 @@ public abstract class RefSegment extends Segment {
    * @param <T> the concrete builder type for method chaining
    */
   public abstract static class AbstractBuilder<T extends RefSegment.AbstractBuilder<T>> {
+
+    /** Creates a builder with no element values set; used by concrete builder subclasses. */
+    protected AbstractBuilder() {}
+
+    /** REF01 — reference identification qualifier to build with. */
     protected ReferenceIdentificationQualifier ref01;
+
+    /** REF02 — reference identification value to build with. */
     protected String ref02;
+
+    /** REF03 — reference description to build with. */
     protected String ref03;
 
     /**
+     * Self-typing hook for method chaining.
+     *
      * @return this builder cast to the concrete type.
      */
     protected abstract T self();
@@ -126,35 +152,66 @@ public abstract class RefSegment extends Segment {
      */
     public abstract RefSegment build() throws ValidationException;
 
-    /** Sets REF01 (reference identification qualifier) from its string code. */
+    /**
+     * Sets REF01 (reference identification qualifier) from its string code.
+     *
+     * @param value the qualifier code, resolved via {@link
+     *     ReferenceIdentificationQualifier#fromString(String)}
+     * @return this builder
+     */
     public T setReferenceIdentificationQualifier(String value) {
       this.ref01 = ReferenceIdentificationQualifier.fromString(value);
       return self();
     }
 
-    /** Sets REF02 (reference identification value). */
+    /**
+     * Sets REF02 (reference identification value).
+     *
+     * @param value the reference identification (element 127, max 50 characters)
+     * @return this builder
+     */
     public T setReferenceIdentification(String value) {
       this.ref02 = value;
       return self();
     }
 
-    /** Sets REF03 (reference description). */
+    /**
+     * Sets REF03 (reference description).
+     *
+     * @param value the reference description (element 352, max 80 characters)
+     * @return this builder
+     */
     public T setReferenceDescription(String value) {
       this.ref03 = value;
       return self();
     }
 
-    /** Element alias for {@link #setReferenceIdentificationQualifier(String)}. */
+    /**
+     * Element alias for {@link #setReferenceIdentificationQualifier(String)}.
+     *
+     * @param value the qualifier code for REF01
+     * @return this builder
+     */
     public T setRef01(String value) {
       return setReferenceIdentificationQualifier(value);
     }
 
-    /** Element alias for {@link #setReferenceIdentification(String)}. */
+    /**
+     * Element alias for {@link #setReferenceIdentification(String)}.
+     *
+     * @param value the reference identification for REF02
+     * @return this builder
+     */
     public T setRef02(String value) {
       return setReferenceIdentification(value);
     }
 
-    /** Element alias for {@link #setReferenceDescription(String)}. */
+    /**
+     * Element alias for {@link #setReferenceDescription(String)}.
+     *
+     * @param value the reference description for REF03
+     * @return this builder
+     */
     public T setRef03(String value) {
       return setReferenceDescription(value);
     }
@@ -162,6 +219,10 @@ public abstract class RefSegment extends Segment {
 
   /** Concrete builder implementation for {@link RefSegment}. */
   public static class Builder extends AbstractBuilder<Builder> {
+
+    /** Creates a builder with no element values set. */
+    public Builder() {}
+
     @Override
     protected RefSegment.Builder self() {
       return this;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/Segment.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/Segment.java
@@ -21,9 +21,16 @@ package com.fastChickensHR.edi.x834;
  * X834Context} is injected by the document's render loop before {@link #render()} is called.
  */
 public abstract class Segment {
+
+  /** Creates a segment with no context; the document's render loop injects one before render. */
+  protected Segment() {}
+
+  /** The rendering context, injected by the document's render loop before {@link #render()}. */
   protected X834Context context;
 
   /**
+   * The rendering context this segment was given.
+   *
    * @return The X834Context for this segment
    */
   protected X834Context getContext() {
@@ -41,11 +48,15 @@ public abstract class Segment {
   }
 
   /**
+   * The two- or three-character identifier this segment renders under.
+   *
    * @return The segment identifier (e.g., "ST", "GS")
    */
   public abstract String getSegmentIdentifier();
 
   /**
+   * The segment's element values in wire order; a null entry renders as an empty slot.
+   *
    * @return Array of element values for this segment
    */
   public abstract String[] getElementValues();

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/X834Context.java
@@ -134,6 +134,8 @@ public class X834Context {
   }
 
   /**
+   * The separator written between a segment's elements.
+   *
    * @return the element separator character (the character value, not the enum)
    */
   public char getElementSeparator() {
@@ -141,6 +143,8 @@ public class X834Context {
   }
 
   /**
+   * The separator written between the components of a composite element.
+   *
    * @return the sub-element (component) separator character
    */
   public char getSubElementSeparator() {
@@ -148,6 +152,8 @@ public class X834Context {
   }
 
   /**
+   * The terminator written at the end of each segment.
+   *
    * @return the segment terminator character
    */
   public char getSegmentTerminator() {
@@ -155,6 +161,8 @@ public class X834Context {
   }
 
   /**
+   * The line terminator written after each segment, for human-readable output.
+   *
    * @return the line terminator string appended after each rendered segment
    */
   public String getLineTerminator() {
@@ -162,6 +170,8 @@ public class X834Context {
   }
 
   /**
+   * The interchange control version this library writes.
+   *
    * @return the interchange control version number {@value #EDI_VERSION} (ISA12)
    */
   public String getEdiVersion() {
@@ -169,6 +179,8 @@ public class X834Context {
   }
 
   /**
+   * The transaction set identifier for benefit enrollment and maintenance.
+   *
    * @return the transaction set identifier {@value #TRANSACTION_SET_ID}
    */
   public String getTransactionSetId() {
@@ -176,6 +188,8 @@ public class X834Context {
   }
 
   /**
+   * The implementation convention this library writes to (ST03 / GS08).
+   *
    * @return the implementation convention reference {@value #IMPLEMENTATION_CONVENTION_REFERENCE}
    */
   public String getImplementationConventionReference() {
@@ -183,19 +197,22 @@ public class X834Context {
   }
 
   /**
-   * @return the document date formatted with the current {@link #getDateFormat() date format}.
-   *     Rendered into ISA09 (interchange date), GS04 (group date), BGN03 and the file effective
-   *     DTP. Always derived from {@link #getDocumentDate()} on read, so it can never go stale.
+   * The document date as it goes on the wire.
+   *
+   * @return the document date formatted with the current {@code dateFormat}. Rendered into ISA09
+   *     (interchange date), GS04 (group date), BGN03 and the file effective DTP. Always derived
+   *     from {@code documentDate} on read, so it can never go stale.
    */
   public String getFormattedDocumentDate() {
     return formatDate(documentDate);
   }
 
   /**
-   * @return the document time formatted with the current {@link #getTimeFormat() time format}.
-   *     Rendered into ISA10 (interchange time) and GS05 (group time). Always derived from {@link
-   *     #getDocumentDate()} on read, so it follows {@link #setDocumentDate} consistently with the
-   *     formatted date.
+   * The document time as it goes on the wire.
+   *
+   * @return the document time formatted with the current {@code timeFormat}. Rendered into ISA10
+   *     (interchange time) and GS05 (group time). Always derived from {@code documentDate} on read,
+   *     so it follows {@code setDocumentDate} consistently with the formatted date.
    */
   public String getFormattedDocumentTime() {
     return formatTime(documentDate);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/constants/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/constants/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * Interchange delimiter and terminator conventions (element, sub-element, segment, line) an {@link
+ * com.fastChickensHR.edi.x834.X834Context} is configured with.
+ */
+package com.fastChickensHR.edi.x834.constants;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/AcknowledgmentRequested.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/AcknowledgmentRequested.java
@@ -23,7 +23,9 @@ import lombok.Getter;
  */
 @Getter
 public enum AcknowledgmentRequested implements EdiCodeEnum {
+  /** No Interchange Acknowledgment Requested — X12 code "0". */
   NO_ACKNOWLEDGMENT("0", "No Interchange Acknowledgment Requested"),
+  /** Interchange Acknowledgment Requested (TA1) — X12 code "1". */
   ACKNOWLEDGMENT_REQUESTED("1", "Interchange Acknowledgment Requested (TA1)");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/ActionCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/ActionCode.java
@@ -23,106 +23,207 @@ import lombok.Getter;
  */
 @Getter
 public enum ActionCode implements EdiCodeEnum {
+  /** Authorize — X12 code "0". */
   AUTHORIZE("0", "Authorize"),
+  /** Authorize and Settle Combination — X12 code "00". */
   AUTHORIZE_AND_SETTLE("00", "Authorize and Settle Combination"),
+  /** Add — X12 code "1". */
   ADD("1", "Add"),
+  /** Change (Update) — X12 code "2". */
   CHANGE("2", "Change (Update)"),
+  /** Delete — X12 code "3". */
   DELETE("3", "Delete"),
+  /** Verify — X12 code "4". */
   VERIFY("4", "Verify"),
+  /** Send — X12 code "5". */
   SEND("5", "Send"),
+  /** Receive — X12 code "6". */
   RECEIVE("6", "Receive"),
+  /** Request — X12 code "7". */
   REQUEST("7", "Request"),
+  /** In Production Send — X12 code "8". */
   IN_PRODUCTION_SEND("8", "In Production Send"),
+  /** Not Capable of Taking Action — X12 code "9". */
   NOT_CAPABLE("9", "Not Capable of Taking Action"),
+  /** Adjourn — X12 code "10". */
   ADJOURN("10", "Adjourn"),
+  /** Approve — X12 code "11". */
   APPROVE("11", "Approve"),
+  /** Auction — X12 code "12". */
   AUCTION("12", "Auction"),
+  /** Cleared — X12 code "13". */
   CLEARED("13", "Cleared"),
+  /** Compose — X12 code "14". */
   COMPOSE("14", "Compose"),
+  /** Correct and Resubmit Claim — X12 code "15". */
   CORRECT_RESUBMIT_CLAIM("15", "Correct and Resubmit Claim"),
+  /** Consider — X12 code "16". */
   CONSIDER("16", "Consider"),
+  /** Create — X12 code "17". */
   CREATE("17", "Create"),
+  /** Decide — X12 code "18". */
   DECIDE("18", "Decide"),
+  /** Declare — X12 code "19". */
   DECLARE("19", "Declare"),
+  /** Decree Recall — X12 code "20". */
   DECREE_RECALL("20", "Decree Recall"),
+  /** Disapprove — X12 code "21". */
   DISAPPROVE("21", "Disapprove"),
+  /** Dissolve — X12 code "22". */
   DISSOLVE("22", "Dissolve"),
+  /** Escalation — X12 code "23". */
   ESCALATION("23", "Escalation"),
+  /** On-Hold — X12 code "24". */
   ON_HOLD("24", "On-Hold"),
+  /** Dropped — X12 code "25". */
   DROPPED("25", "Dropped"),
+  /** Bankruptcy Filed - Review Account — X12 code "26". */
   BANKRUPTCY_FILED("26", "Bankruptcy Filed - Review Account"),
+  /** Moved - Follow Up — X12 code "27". */
   MOVED_FOLLOW_UP("27", "Moved - Follow Up"),
+  /** Change Phone Number — X12 code "28". */
   CHANGE_PHONE_NUMBER("28", "Change Phone Number"),
+  /** Payment Received - Follow Up — X12 code "29". */
   PAYMENT_RECEIVED("29", "Payment Received - Follow Up"),
+  /** Account Active - Pursue — X12 code "30". */
   ACCOUNT_ACTIVE("30", "Account Active - Pursue"),
+  /** Return per Client Request — X12 code "31". */
   RETURN_PER_CLIENT("31", "Return per Client Request"),
+  /** Pursue Legal Action — X12 code "32". */
   PURSUE_LEGAL_ACTION("32", "Pursue Legal Action"),
+  /** Active — X12 code "33". */
   ACTIVE("33", "Active"),
+  /** Pursue Garnishment — X12 code "34". */
   PURSUE_GARNISHMENT("34", "Pursue Garnishment"),
+  /** New Assignment - Proceed — X12 code "35". */
   NEW_ASSIGNMENT("35", "New Assignment - Proceed"),
+  /** Repossess Merchandise — X12 code "36". */
   REPOSSESS_MERCHANDISE("36", "Repossess Merchandise"),
+  /** Adjust Payment — X12 code "37". */
   ADJUST_PAYMENT("37", "Adjust Payment"),
+  /** Change Address — X12 code "38". */
   CHANGE_ADDRESS("38", "Change Address"),
+  /** Skiptrace Account — X12 code "39". */
   SKIPTRACE_ACCOUNT("39", "Skiptrace Account"),
+  /** Close Account - Deceased — X12 code "40". */
   CLOSE_ACCOUNT_DECEASED("40", "Close Account - Deceased"),
+  /** Update to Inactive — X12 code "41". */
   UPDATE_TO_INACTIVE("41", "Update to Inactive"),
+  /** Account Paid in Full - Close Account — X12 code "42". */
   ACCOUNT_PAID_CLOSE("42", "Account Paid in Full - Close Account"),
+  /** Refused to Pay - Review Account — X12 code "43". */
   REFUSED_TO_PAY("43", "Refused to Pay - Review Account"),
+  /** Account Disputed - Review — X12 code "44". */
   ACCOUNT_DISPUTED("44", "Account Disputed - Review"),
+  /** Do Not Contact - Fair Debt Collection Practices Act (FDCPA) — X12 code "45". */
   DO_NOT_CONTACT("45", "Do Not Contact - Fair Debt Collection Practices Act (FDCPA)"),
+  /** Forward Account — X12 code "46". */
   FORWARD_ACCOUNT("46", "Forward Account"),
+  /** Enforce — X12 code "47". */
   ENFORCE("47", "Enforce"),
+  /** Extinguish — X12 code "48". */
   EXTINGUISH("48", "Extinguish"),
+  /** Judgment for Defendant — X12 code "49". */
   JUDGMENT_DEFENDANT("49", "Judgment for Defendant"),
+  /** Judgment for Plaintiff — X12 code "50". */
   JUDGMENT_PLAINTIFF("50", "Judgment for Plaintiff"),
+  /** Complete — X12 code "51". */
   COMPLETE("51", "Complete"),
+  /** Justified — X12 code "52". */
   JUSTIFIED("52", "Justified"),
+  /** Legal Moratorium on Debts Incurred to Date — X12 code "53". */
   LEGAL_MORATORIUM("53", "Legal Moratorium on Debts Incurred to Date"),
+  /** Meeting Held — X12 code "54". */
   MEETING_HELD("54", "Meeting Held"),
+  /** Meeting Held and Opened — X12 code "55". */
   MEETING_HELD_OPENED("55", "Meeting Held and Opened"),
+  /** Moratorium — X12 code "56". */
   MORATORIUM("56", "Moratorium"),
+  /** Not Filed — X12 code "57". */
   NOT_FILED("57", "Not Filed"),
+  /** Not Justified — X12 code "58". */
   NOT_JUSTIFIED("58", "Not Justified"),
+  /** Partial Release — X12 code "59". */
   PARTIAL_RELEASE("59", "Partial Release"),
+  /** Provisional Moratorium — X12 code "60". */
   PROVISIONAL_MORATORIUM("60", "Provisional Moratorium"),
+  /** Readjudicate — X12 code "61". */
   READJUDICATE("61", "Readjudicate"),
+  /** Resolve — X12 code "62". */
   RESOLVE("62", "Resolve"),
+  /** Resulted in a Suit — X12 code "63". */
   RESULTED_IN_SUIT("63", "Resulted in a Suit"),
+  /** Resulted in No Liquidation — X12 code "64". */
   RESULTED_NO_LIQUIDATION("64", "Resulted in No Liquidation"),
+  /** Set Aside — X12 code "65". */
   SET_ASIDE("65", "Set Aside"),
+  /** Settled out of Court — X12 code "66". */
   SETTLED_OUT_OF_COURT("66", "Settled out of Court"),
+  /** Sold — X12 code "67". */
   SOLD("67", "Sold"),
+  /** Stayed — X12 code "68". */
   STAYED("68", "Stayed"),
+  /** Subordination — X12 code "69". */
   SUBORDINATION("69", "Subordination"),
+  /** Surrender — X12 code "70". */
   SURRENDER("70", "Surrender"),
+  /** Term Expired — X12 code "71". */
   TERM_EXPIRED("71", "Term Expired"),
+  /** Unsatisfied — X12 code "72". */
   UNSATISFIED("72", "Unsatisfied"),
+  /** Void — X12 code "73". */
   VOID("73", "Void"),
+  /** Suspended, 24 Hours — X12 code "74". */
   SUSPENDED("74", "Suspended, 24 Hours"),
+  /** Dispute — X12 code "75". */
   DISPUTE("75", "Dispute"),
+  /** Assign — X12 code "76". */
   ASSIGN("76", "Assign"),
+  /** Agent Change — X12 code "77". */
   AGENT_CHANGE("77", "Agent Change"),
+  /** Agent Hierarchy Change — X12 code "78". */
   AGENT_HIERARCHY_CHANGE("78", "Agent Hierarchy Change"),
+  /** Reactivate — X12 code "79". */
   REACTIVATE("79", "Reactivate"),
+  /** Reconcile — X12 code "80". */
   RECONCILE("80", "Reconcile"),
+  /** Renew — X12 code "81". */
   RENEW("81", "Renew"),
+  /** Follow Up — X12 code "82". */
   FOLLOW_UP("82", "Follow Up"),
+  /** Future — X12 code "83". */
   FUTURE("83", "Future"),
+  /** Letter of Authority Sent — X12 code "84". */
   LETTER_OF_AUTHORITY("84", "Letter of Authority Sent"),
+  /** New Premium Only — X12 code "85". */
   NEW_PREMIUM_ONLY("85", "New Premium Only"),
+  /** Pended for Follow Up — X12 code "86". */
   PENDED_FOR_FOLLOW_UP("86", "Pended for Follow Up"),
+  /** Countersue — X12 code "87". */
   COUNTERSUE("87", "Countersue"),
+  /** Contact via Telephone Call — X12 code "88". */
   CONTACT_VIA_TELEPHONE("88", "Contact via Telephone Call"),
+  /** Contact via Fax — X12 code "89". */
   CONTACT_VIA_FAX("89", "Contact via Fax"),
+  /** Mark — X12 code "90". */
   MARK("90", "Mark"),
+  /** In Progress — X12 code "91". */
   IN_PROGRESS("91", "In Progress"),
+  /** Reconfirm — X12 code "92". */
   RECONFIRM("92", "Reconfirm"),
+  /** Send Record at End of the Fall Term — X12 code "93". */
   SEND_RECORD_FALL("93", "Send Record at End of the Fall Term"),
+  /** Send Record at End of the Winter Term — X12 code "94". */
   SEND_RECORD_WINTER("94", "Send Record at End of the Winter Term"),
+  /** Send Record at End of the Spring Term — X12 code "95". */
   SEND_RECORD_SPRING("95", "Send Record at End of the Spring Term"),
+  /** Send Record at End of the Summer Term — X12 code "96". */
   SEND_RECORD_SUMMER("96", "Send Record at End of the Summer Term"),
+  /** Certified in total — X12 code "A1". */
   CERTIFIED_TOTAL("A1", "Certified in total"),
+  /** Send Record at End of the Intersession Term — X12 code "97". */
   SEND_RECORD_INTERSESSION("97", "Send Record at End of the Intersession Term"),
+  /** Replace — X12 code "RX". */
   REPLACE("RX", "Replace");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/AuthorizationInformationQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/AuthorizationInformationQualifier.java
@@ -23,12 +23,19 @@ import lombok.Getter;
  */
 @Getter
 public enum AuthorizationInformationQualifier implements EdiCodeEnum {
+  /** No Authorization — X12 code "00". */
   NO_AUTHORIZATION_INFORMATION("00", "No Authorization"),
+  /** UCS Communications ID — X12 code "01". */
   UCS_COMMUNICATIONS_ID("01", "UCS Communications ID"),
+  /** EDX Communications ID — X12 code "02". */
   EDX_COMMUNICATIONS_ID("02", "EDX Communications ID"),
+  /** Additional Data Identification — X12 code "03". */
   ADDITIONAL_DATA_ID("03", "Additional Data Identification"),
+  /** Rail Communications ID — X12 code "04". */
   RAIL_COMMUNICATIONS_ID("04", "Rail Communications ID"),
+  /** Department of Defense (DoD) Communication Identifier — X12 code "05". */
   DOD_COMMUNICATION_ID("05", "Department of Defense (DoD) Communication Identifier"),
+  /** United States Federal Government Communication Identifier — X12 code "06". */
   US_FEDERAL_GOVT_COMM_ID("06", "United States Federal Government Communication Identifier");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/CommunicationNumberQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/CommunicationNumberQualifier.java
@@ -29,13 +29,21 @@ import lombok.Getter;
  */
 @Getter
 public enum CommunicationNumberQualifier implements EdiCodeEnum {
+  /** Alternate Telephone — X12 code "AP". */
   ALTERNATE_TELEPHONE("AP", "Alternate Telephone"),
+  /** Cellular Phone — X12 code "CP". */
   CELLULAR_PHONE("CP", "Cellular Phone"),
+  /** Electronic Mail — X12 code "EM". */
   ELECTRONIC_MAIL("EM", "Electronic Mail"),
+  /** Telephone Extension — X12 code "EX". */
   TELEPHONE_EXTENSION("EX", "Telephone Extension"),
+  /** Facsimile — X12 code "FX". */
   FACSIMILE("FX", "Facsimile"),
+  /** Home Phone Number — X12 code "HP". */
   HOME_PHONE("HP", "Home Phone Number"),
+  /** Telephone — X12 code "TE". */
   TELEPHONE("TE", "Telephone"),
+  /** Work Phone Number — X12 code "WP". */
   WORK_PHONE("WP", "Work Phone Number");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/CoordinationOfBenefitsCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/CoordinationOfBenefitsCode.java
@@ -30,17 +30,26 @@ import lombok.Getter;
  */
 @Getter
 public enum CoordinationOfBenefitsCode implements EdiCodeEnum {
+  /** Coordination of Benefits — X12 code "1". */
   COORDINATION_OF_BENEFITS("1", "Coordination of Benefits"),
+  /** Coordination of Benefits applies to Spouse Only — X12 code "2". */
   COORDINATION_OF_BENEFITS_SPOUSE_ONLY("2", "Coordination of Benefits applies to Spouse Only"),
+  /** Coordination of Benefits applies to Spouse and Dependents — X12 code "3". */
   COORDINATION_OF_BENEFITS_SPOUSE_AND_DEPENDENTS(
       "3", "Coordination of Benefits applies to Spouse and Dependents"),
+  /** Coordination of Benefits applies to Dependents Only — X12 code "4". */
   COORDINATION_OF_BENEFITS_DEPENDENTS_ONLY(
       "4", "Coordination of Benefits applies to Dependents Only"),
+  /** Unknown — X12 code "5". */
   UNKNOWN("5", "Unknown"),
+  /** No Coordination of Benefits — X12 code "6". */
   NO_COORDINATION_OF_BENEFITS("6", "No Coordination of Benefits"),
+  /** Coordination of Benefits Applies to Subscriber Only — X12 code "7". */
   COORDINATION_OF_BENEFITS_SUBSCRIBER_ONLY(
       "7", "Coordination of Benefits Applies to Subscriber Only"),
+  /** Conflict in Coordination of Benefit — X12 code "8". */
   CONFLICT_IN_COORDINATION_OF_BENEFIT("8", "Conflict in Coordination of Benefit"),
+  /** Coordination of Benefits Applies to Whole Family — X12 code "9". */
   COORDINATION_OF_BENEFITS_WHOLE_FAMILY("9", "Coordination of Benefits Applies to Whole Family");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/DateTimeQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/DateTimeQualifier.java
@@ -23,409 +23,811 @@ import lombok.Getter;
  */
 @Getter
 public enum DateTimeQualifier implements EdiCodeEnum {
+  /** Cancel After — X12 code "001". */
   CANCEL_AFTER("001", "Cancel After"),
+  /** Delivery Requested — X12 code "002". */
   DELIVERY_REQUESTED("002", "Delivery Requested"),
+  /** Invoice — X12 code "003". */
   INVOICE("003", "Invoice"),
+  /** Purchase Order — X12 code "004". */
   PURCHASE_ORDER("004", "Purchase Order"),
+  /** Sailing — X12 code "005". */
   SAILING("005", "Sailing"),
+  /** Sold — X12 code "006". */
   SOLD("006", "Sold"),
+  /** Effective — X12 code "007". */
   EFFECTIVE("007", "Effective"),
+  /** Purchase Order Received — X12 code "008". */
   PURCHASE_ORDER_RECEIVED("008", "Purchase Order Received"),
+  /** Process — X12 code "009". */
   PROCESS("009", "Process"),
+  /** Requested Ship — X12 code "010". */
   REQUESTED_SHIP("010", "Requested Ship"),
+  /** Shipped — X12 code "011". */
   SHIPPED("011", "Shipped"),
+  /** Terms Discount Due — X12 code "012". */
   TERMS_DISCOUNT_DUE("012", "Terms Discount Due"),
+  /** Terms Net Due — X12 code "013". */
   TERMS_NET_DUE("013", "Terms Net Due"),
+  /** Deferred Payment — X12 code "014". */
   DEFERRED_PAYMENT("014", "Deferred Payment"),
+  /** Promotion Start — X12 code "015". */
   PROMOTION_START("015", "Promotion Start"),
+  /** Promotion End — X12 code "016". */
   PROMOTION_END("016", "Promotion End"),
+  /** Estimated Delivery — X12 code "017". */
   ESTIMATED_DELIVERY("017", "Estimated Delivery"),
+  /** Available — X12 code "018". */
   AVAILABLE("018", "Available"),
+  /** Unloaded — X12 code "019". */
   UNLOADED("019", "Unloaded"),
+  /** Check — X12 code "020". */
   CHECK("020", "Check"),
+  /** Charge Back — X12 code "021". */
   CHARGE_BACK("021", "Charge Back"),
+  /** Freight Bill — X12 code "022". */
   FREIGHT_BILL("022", "Freight Bill"),
+  /** Promotion Order - Start — X12 code "023". */
   PROMOTION_ORDER_START("023", "Promotion Order - Start"),
+  /** Promotion Order - End — X12 code "024". */
   PROMOTION_ORDER_END("024", "Promotion Order - End"),
+  /** Promotion Ship - Start — X12 code "025". */
   PROMOTION_SHIP_START("025", "Promotion Ship - Start"),
+  /** Promotion Ship - End — X12 code "026". */
   PROMOTION_SHIP_END("026", "Promotion Ship - End"),
+  /** Promotion Requested Delivery - Start — X12 code "027". */
   PROMOTION_REQUESTED_DELIVERY_START("027", "Promotion Requested Delivery - Start"),
+  /** Promotion Requested Delivery - End — X12 code "028". */
   PROMOTION_REQUESTED_DELIVERY_END("028", "Promotion Requested Delivery - End"),
+  /** Promotion Performance - Start — X12 code "029". */
   PROMOTION_PERFORMANCE_START("029", "Promotion Performance - Start"),
+  /** Promotion Performance - End — X12 code "030". */
   PROMOTION_PERFORMANCE_END("030", "Promotion Performance - End"),
+  /** Promotion Invoice Performance - Start — X12 code "031". */
   PROMOTION_INVOICE_PERFORMANCE_START("031", "Promotion Invoice Performance - Start"),
+  /** Promotion Invoice Performance - End — X12 code "032". */
   PROMOTION_INVOICE_PERFORMANCE_END("032", "Promotion Invoice Performance - End"),
+  /** Promotion Floor Stock Protect - Start — X12 code "033". */
   PROMOTION_FLOOR_STOCK_PROTECT_START("033", "Promotion Floor Stock Protect - Start"),
+  /** Promotion Floor Stock Protect - End — X12 code "034". */
   PROMOTION_FLOOR_STOCK_PROTECT_END("034", "Promotion Floor Stock Protect - End"),
+  /** Delivered — X12 code "035". */
   DELIVERED("035", "Delivered"),
+  /** Expiration Date coverage expires — X12 code "036". */
   EXPIRATION_DATE("036", "Expiration Date coverage expires"),
+  /** Ship Not Before — X12 code "037". */
   SHIP_NOT_BEFORE("037", "Ship Not Before"),
+  /** Ship No Later — X12 code "038". */
   SHIP_NO_LATER("038", "Ship No Later"),
+  /** Ship Week of — X12 code "039". */
   SHIP_WEEK_OF("039", "Ship Week of"),
+  /** Status (After and Including) — X12 code "040". */
   STATUS_AFTER_AND_INCLUDING("040", "Status (After and Including)"),
+  /** Status (Prior and Including) — X12 code "041". */
   STATUS_PRIOR_AND_INCLUDING("041", "Status (Prior and Including)"),
+  /** Superseded — X12 code "042". */
   SUPERSEDED("042", "Superseded"),
+  /** Publication — X12 code "043". */
   PUBLICATION("043", "Publication"),
+  /** Settlement Date as Specified by the Originator — X12 code "044". */
   SETTLEMENT_DATE_BY_ORIGINATOR("044", "Settlement Date as Specified by the Originator"),
+  /** Endorsement Date — X12 code "045". */
   ENDORSEMENT_DATE("045", "Endorsement Date"),
+  /** Field Failure — X12 code "046". */
   FIELD_FAILURE("046", "Field Failure"),
+  /** Functional Test — X12 code "047". */
   FUNCTIONAL_TEST("047", "Functional Test"),
+  /** System Test — X12 code "048". */
   SYSTEM_TEST("048", "System Test"),
+  /** Prototype Test — X12 code "049". */
   PROTOTYPE_TEST("049", "Prototype Test"),
+  /** Received — X12 code "050". */
   RECEIVED("050", "Received"),
+  /** Cumulative Quantity Start — X12 code "051". */
   CUMULATIVE_QUANTITY_START("051", "Cumulative Quantity Start"),
+  /** Cumulative Quantity End — X12 code "052". */
   CUMULATIVE_QUANTITY_END("052", "Cumulative Quantity End"),
+  /** Buyers Local — X12 code "053". */
   BUYERS_LOCAL("053", "Buyers Local"),
+  /** Sellers Local — X12 code "054". */
   SELLERS_LOCAL("054", "Sellers Local"),
+  /** Confirmed — X12 code "055". */
   CONFIRMED("055", "Confirmed"),
+  /** Estimated Port of Entry — X12 code "056". */
   ESTIMATED_PORT_OF_ENTRY("056", "Estimated Port of Entry"),
+  /** Actual Port of Entry — X12 code "057". */
   ACTUAL_PORT_OF_ENTRY("057", "Actual Port of Entry"),
+  /** Customs Clearance — X12 code "058". */
   CUSTOMS_CLEARANCE("058", "Customs Clearance"),
+  /** Inland Ship — X12 code "059". */
   INLAND_SHIP("059", "Inland Ship"),
+  /** Engineering Change Level — X12 code "060". */
   ENGINEERING_CHANGE_LEVEL("060", "Engineering Change Level"),
+  /** Cancel if Not Delivered by — X12 code "061". */
   CANCEL_IF_NOT_DELIVERED_BY("061", "Cancel if Not Delivered by"),
+  /** Blueprint — X12 code "062". */
   BLUEPRINT("062", "Blueprint"),
+  /** Do Not Deliver After — X12 code "063". */
   DO_NOT_DELIVER_AFTER("063", "Do Not Deliver After"),
+  /** Do Not Deliver Before — X12 code "064". */
   DO_NOT_DELIVER_BEFORE("064", "Do Not Deliver Before"),
+  /** 1st Schedule Delivery — X12 code "065". */
   FIRST_SCHEDULE_DELIVERY("065", "1st Schedule Delivery"),
+  /** 1st Schedule Ship — X12 code "066". */
   FIRST_SCHEDULE_SHIP("066", "1st Schedule Ship"),
+  /** Current Schedule Delivery — X12 code "067". */
   CURRENT_SCHEDULE_DELIVERY("067", "Current Schedule Delivery"),
+  /** Current Schedule Ship — X12 code "068". */
   CURRENT_SCHEDULE_SHIP("068", "Current Schedule Ship"),
+  /** Promised for Delivery — X12 code "069". */
   PROMISED_FOR_DELIVERY("069", "Promised for Delivery"),
+  /** Scheduled for Delivery (After and Including) — X12 code "070". */
   SCHEDULED_FOR_DELIVERY_AFTER("070", "Scheduled for Delivery (After and Including)"),
+  /** Requested for Delivery (After and Including) — X12 code "071". */
   REQUESTED_FOR_DELIVERY_AFTER("071", "Requested for Delivery (After and Including)"),
+  /** Promised for Delivery (After and Including) — X12 code "072". */
   PROMISED_FOR_DELIVERY_AFTER("072", "Promised for Delivery (After and Including)"),
+  /** Scheduled for Delivery (Prior to and Including) — X12 code "073". */
   SCHEDULED_FOR_DELIVERY_PRIOR("073", "Scheduled for Delivery (Prior to and Including)"),
+  /** Requested for Delivery (Prior to and Including) — X12 code "074". */
   REQUESTED_FOR_DELIVERY_PRIOR("074", "Requested for Delivery (Prior to and Including)"),
+  /** Promised for Delivery (Prior to and Including) — X12 code "075". */
   PROMISED_FOR_DELIVERY_PRIOR("075", "Promised for Delivery (Prior to and Including)"),
+  /** Scheduled for Delivery (Week of) — X12 code "076". */
   SCHEDULED_FOR_DELIVERY_WEEK("076", "Scheduled for Delivery (Week of)"),
+  /** Requested for Delivery (Week of) — X12 code "077". */
   REQUESTED_FOR_DELIVERY_WEEK("077", "Requested for Delivery (Week of)"),
+  /** Promised for Delivery (Week of) — X12 code "078". */
   PROMISED_FOR_DELIVERY_WEEK("078", "Promised for Delivery (Week of)"),
+  /** Promised for Shipment — X12 code "079". */
   PROMISED_FOR_SHIPMENT("079", "Promised for Shipment"),
+  /** Scheduled for Shipment (After and Including) — X12 code "080". */
   SCHEDULED_FOR_SHIPMENT_AFTER("080", "Scheduled for Shipment (After and Including)"),
+  /** Requested for Shipment (After and Including) — X12 code "081". */
   REQUESTED_FOR_SHIPMENT_AFTER("081", "Requested for Shipment (After and Including)"),
+  /** Promised for Shipment (After and Including) — X12 code "082". */
   PROMISED_FOR_SHIPMENT_AFTER("082", "Promised for Shipment (After and Including)"),
+  /** Scheduled for Shipment (Prior to and Including) — X12 code "083". */
   SCHEDULED_FOR_SHIPMENT_PRIOR("083", "Scheduled for Shipment (Prior to and Including)"),
+  /** Requested for Shipment (Prior to and Including) — X12 code "084". */
   REQUESTED_FOR_SHIPMENT_PRIOR("084", "Requested for Shipment (Prior to and Including)"),
+  /** Promised for Shipment (Prior to and Including) — X12 code "085". */
   PROMISED_FOR_SHIPMENT_PRIOR("085", "Promised for Shipment (Prior to and Including)"),
+  /** Scheduled for Shipment (Week of) — X12 code "086". */
   SCHEDULED_FOR_SHIPMENT_WEEK("086", "Scheduled for Shipment (Week of)"),
+  /** Requested for Shipment (Week of) — X12 code "087". */
   REQUESTED_FOR_SHIPMENT_WEEK("087", "Requested for Shipment (Week of)"),
+  /** Promised for Shipment (Week of) — X12 code "088". */
   PROMISED_FOR_SHIPMENT_WEEK("088", "Promised for Shipment (Week of)"),
+  /** Inquiry — X12 code "089". */
   INQUIRY("089", "Inquiry"),
+  /** Report Start — X12 code "090". */
   REPORT_START("090", "Report Start"),
+  /** Report End — X12 code "091". */
   REPORT_END("091", "Report End"),
+  /** Contract Effective — X12 code "092". */
   CONTRACT_EFFECTIVE("092", "Contract Effective"),
+  /** Contract Expiration — X12 code "093". */
   CONTRACT_EXPIRATION("093", "Contract Expiration"),
+  /** Manufacture — X12 code "094". */
   MANUFACTURE("094", "Manufacture"),
+  /** Bill of Lading — X12 code "095". */
   BILL_OF_LADING("095", "Bill of Lading"),
+  /** Discharge — X12 code "096". */
   DISCHARGE("096", "Discharge"),
+  /** Transaction Creation — X12 code "097". */
   TRANSACTION_CREATION("097", "Transaction Creation"),
+  /** Bid (Effective) — X12 code "098". */
   BID_EFFECTIVE("098", "Bid (Effective)"),
+  /** Bid Open (Date Bids Will Be Opened) — X12 code "099". */
   BID_OPEN("099", "Bid Open (Date Bids Will Be Opened)"),
+  /** No Shipping Schedule Established as of — X12 code "100". */
   NO_SHIPPING_SCHEDULE("100", "No Shipping Schedule Established as of"),
+  /** No Production Schedule Established as of — X12 code "101". */
   NO_PRODUCTION_SCHEDULE("101", "No Production Schedule Established as of"),
+  /** Issue — X12 code "102". */
   ISSUE("102", "Issue"),
+  /** Award — X12 code "103". */
   AWARD("103", "Award"),
+  /** System Survey — X12 code "104". */
   SYSTEM_SURVEY("104", "System Survey"),
+  /** Quality Rating — X12 code "105". */
   QUALITY_RATING("105", "Quality Rating"),
+  /** Required By — X12 code "106". */
   REQUIRED_BY("106", "Required By"),
+  /** Deposit — X12 code "107". */
   DEPOSIT("107", "Deposit"),
+  /** Postmark — X12 code "108". */
   POSTMARK("108", "Postmark"),
+  /** Received at Lockbox — X12 code "109". */
   RECEIVED_AT_LOCKBOX("109", "Received at Lockbox"),
+  /** Originally Scheduled Ship — X12 code "110". */
   ORIGINALLY_SCHEDULED_SHIP("110", "Originally Scheduled Ship"),
+  /** Manifest/Ship Notice — X12 code "111". */
   MANIFEST_SHIP_NOTICE("111", "Manifest/Ship Notice"),
+  /** Buyers Dock — X12 code "112". */
   BUYERS_DOCK("112", "Buyers Dock"),
+  /** Sample Required — X12 code "113". */
   SAMPLE_REQUIRED("113", "Sample Required"),
+  /** Tooling Required — X12 code "114". */
   TOOLING_REQUIRED("114", "Tooling Required"),
+  /** Sample Available — X12 code "115". */
   SAMPLE_AVAILABLE("115", "Sample Available"),
+  /** Scheduled Interchange Delivery — X12 code "116". */
   SCHEDULED_INTERCHANGE_DELIVERY("116", "Scheduled Interchange Delivery"),
+  /** Requested Pickup — X12 code "118". */
   REQUESTED_PICKUP("118", "Requested Pickup"),
+  /** Test Performed — X12 code "119". */
   TEST_PERFORMED("119", "Test Performed"),
+  /** Control Plan — X12 code "120". */
   CONTROL_PLAN("120", "Control Plan"),
+  /** Feasibility Sign Off — X12 code "121". */
   FEASIBILITY_SIGN_OFF("121", "Feasibility Sign Off"),
+  /** Failure Mode Effective — X12 code "122". */
   FAILURE_MODE_EFFECTIVE("122", "Failure Mode Effective"),
+  /** Group Contract Effective — X12 code "124". */
   GROUP_CONTRACT_EFFECTIVE("124", "Group Contract Effective"),
+  /** Group Contract Expiration — X12 code "125". */
   GROUP_CONTRACT_EXPIRATION("125", "Group Contract Expiration"),
+  /** Wholesale Contract Effective — X12 code "126". */
   WHOLESALE_CONTRACT_EFFECTIVE("126", "Wholesale Contract Effective"),
+  /** Wholesale Contract Expiration — X12 code "127". */
   WHOLESALE_CONTRACT_EXPIRATION("127", "Wholesale Contract Expiration"),
+  /** Replacement Effective — X12 code "128". */
   REPLACEMENT_EFFECTIVE("128", "Replacement Effective"),
+  /** Customer Contract Effective — X12 code "129". */
   CUSTOMER_CONTRACT_EFFECTIVE("129", "Customer Contract Effective"),
+  /** Customer Contract Expiration — X12 code "130". */
   CUSTOMER_CONTRACT_EXPIRATION("130", "Customer Contract Expiration"),
+  /** Item Contract Effective — X12 code "131". */
   ITEM_CONTRACT_EFFECTIVE("131", "Item Contract Effective"),
+  /** Item Contract Expiration — X12 code "132". */
   ITEM_CONTRACT_EXPIRATION("132", "Item Contract Expiration"),
+  /** Accounts Receivable - Statement Date — X12 code "133". */
   ACCOUNTS_RECEIVABLE_STATEMENT_DATE("133", "Accounts Receivable - Statement Date"),
+  /** Ready for Inspection — X12 code "134". */
   READY_FOR_INSPECTION("134", "Ready for Inspection"),
+  /** Booking — X12 code "135". */
   BOOKING("135", "Booking"),
+  /** Technical Rating — X12 code "136". */
   TECHNICAL_RATING("136", "Technical Rating"),
+  /** Delivery Rating — X12 code "137". */
   DELIVERY_RATING("137", "Delivery Rating"),
+  /** Commercial Rating — X12 code "138". */
   COMMERCIAL_RATING("138", "Commercial Rating"),
+  /** Estimated — X12 code "139". */
   ESTIMATED("139", "Estimated"),
+  /** Actual — X12 code "140". */
   ACTUAL("140", "Actual"),
+  /** Assigned — X12 code "141". */
   ASSIGNED("141", "Assigned"),
+  /** Loss — X12 code "142". */
   LOSS("142", "Loss"),
+  /** Due Date of First Payment to Principal and Interest — X12 code "143". */
   DUE_DATE_FIRST_PAYMENT("143", "Due Date of First Payment to Principal and Interest"),
+  /** Estimated Acceptance — X12 code "144". */
   ESTIMATED_ACCEPTANCE("144", "Estimated Acceptance"),
+  /** Opening Date — X12 code "145". */
   OPENING_DATE("145", "Opening Date"),
+  /** Closing Date — X12 code "146". */
   CLOSING_DATE("146", "Closing Date"),
+  /** Due Date Last Complete Installment Paid — X12 code "147". */
   DUE_DATE_LAST_COMPLETE_INSTALLMENT("147", "Due Date Last Complete Installment Paid"),
+  /**
+   * Date of Local Office Approval of Conveyance of Damaged Real Estate Property — X12 code "148".
+   */
   DATE_LOCAL_OFFICE_APPROVAL(
       "148", "Date of Local Office Approval of Conveyance of Damaged Real Estate Property"),
+  /** Date Deed Filed for Record — X12 code "149". */
   DATE_DEED_FILED("149", "Date Deed Filed for Record"),
+  /** Service Period Start — X12 code "150". */
   SERVICE_PERIOD_START("150", "Service Period Start"),
+  /** Service Period End — X12 code "151". */
   SERVICE_PERIOD_END("151", "Service Period End"),
+  /** Effective Date of Change — X12 code "152". */
   EFFECTIVE_DATE_OF_CHANGE("152", "Effective Date of Change"),
+  /** Service Interruption — X12 code "153". */
   SERVICE_INTERRUPTION("153", "Service Interruption"),
+  /** Adjustment Period Start — X12 code "154". */
   ADJUSTMENT_PERIOD_START("154", "Adjustment Period Start"),
+  /** Adjustment Period End — X12 code "155". */
   ADJUSTMENT_PERIOD_END("155", "Adjustment Period End"),
+  /** Allotment Period Start — X12 code "156". */
   ALLOTMENT_PERIOD_START("156", "Allotment Period Start"),
+  /** Test Period Start — X12 code "157". */
   TEST_PERIOD_START("157", "Test Period Start"),
+  /** Test Period Ending — X12 code "158". */
   TEST_PERIOD_ENDING("158", "Test Period Ending"),
+  /** Bid Price Exception — X12 code "159". */
   BID_PRICE_EXCEPTION("159", "Bid Price Exception"),
+  /** Samples to be Returned By — X12 code "160". */
   SAMPLES_TO_BE_RETURNED_BY("160", "Samples to be Returned By"),
+  /** Loaded on Vessel — X12 code "161". */
   LOADED_ON_VESSEL("161", "Loaded on Vessel"),
+  /** Pending Archive — X12 code "162". */
   PENDING_ARCHIVE("162", "Pending Archive"),
+  /** Actual Archive — X12 code "163". */
   ACTUAL_ARCHIVE("163", "Actual Archive"),
+  /** First Issue — X12 code "164". */
   FIRST_ISSUE("164", "First Issue"),
+  /** Final Issue — X12 code "165". */
   FINAL_ISSUE("165", "Final Issue"),
+  /** Message — X12 code "166". */
   MESSAGE("166", "Message"),
+  /** Most Recent Revision (or Initial Version) — X12 code "167". */
   MOST_RECENT_REVISION("167", "Most Recent Revision (or Initial Version)"),
+  /** Release — X12 code "168". */
   RELEASE("168", "Release"),
+  /** Product Availability Date — X12 code "169". */
   PRODUCT_AVAILABILITY_DATE("169", "Product Availability Date"),
+  /** Supplemental Issue — X12 code "170". */
   SUPPLEMENTAL_ISSUE("170", "Supplemental Issue"),
+  /** Revision — X12 code "171". */
   REVISION("171", "Revision"),
+  /** Correction — X12 code "172". */
   CORRECTION("172", "Correction"),
+  /** Week Ending — X12 code "173". */
   WEEK_ENDING("173", "Week Ending"),
+  /** Month Ending — X12 code "174". */
   MONTH_ENDING("174", "Month Ending"),
+  /** Cancel if not shipped by — X12 code "175". */
   CANCEL_IF_NOT_SHIPPED_BY("175", "Cancel if not shipped by"),
+  /** Expedited on — X12 code "176". */
   EXPEDITED_ON("176", "Expedited on"),
+  /** Cancellation — X12 code "177". */
   CANCELLATION("177", "Cancellation"),
+  /** Hold (as of) — X12 code "178". */
   HOLD_AS_OF("178", "Hold (as of)"),
+  /** Hold as Stock (as of) — X12 code "179". */
   HOLD_AS_STOCK("179", "Hold as Stock (as of)"),
+  /** No Promise (as of) — X12 code "180". */
   NO_PROMISE("180", "No Promise (as of)"),
+  /** Stop Work (as of) — X12 code "181". */
   STOP_WORK("181", "Stop Work (as of)"),
+  /** Will Advise (as of) — X12 code "182". */
   WILL_ADVISE("182", "Will Advise (as of)"),
+  /** Connection — X12 code "183". */
   CONNECTION("183", "Connection"),
+  /** Inventory — X12 code "184". */
   INVENTORY("184", "Inventory"),
+  /** Vessel Registry — X12 code "185". */
   VESSEL_REGISTRY("185", "Vessel Registry"),
+  /** Invoice Period Start — X12 code "186". */
   INVOICE_PERIOD_START("186", "Invoice Period Start"),
+  /** Invoice Period End — X12 code "187". */
   INVOICE_PERIOD_END("187", "Invoice Period End"),
+  /** Credit Advice — X12 code "188". */
   CREDIT_ADVICE("188", "Credit Advice"),
+  /** Debit Advice — X12 code "189". */
   DEBIT_ADVICE("189", "Debit Advice"),
+  /** Released to Vessel — X12 code "190". */
   RELEASED_TO_VESSEL("190", "Released to Vessel"),
+  /** Material Specification — X12 code "191". */
   MATERIAL_SPECIFICATION("191", "Material Specification"),
+  /** Delivery Ticket — X12 code "192". */
   DELIVERY_TICKET("192", "Delivery Ticket"),
+  /** Period Start — X12 code "193". */
   PERIOD_START("193", "Period Start"),
+  /** Period End — X12 code "194". */
   PERIOD_END("194", "Period End"),
+  /** Contract Re-Open — X12 code "195". */
   CONTRACT_RE_OPEN("195", "Contract Re-Open"),
+  /** Start — X12 code "196". */
   START("196", "Start"),
+  /** End — X12 code "197". */
   END("197", "End"),
+  /** Completion — X12 code "198". */
   COMPLETION("198", "Completion"),
+  /** Seal — X12 code "199". */
   SEAL("199", "Seal"),
+  /** Assembly Start — X12 code "200". */
   ASSEMBLY_START("200", "Assembly Start"),
+  /** Acceptance — X12 code "201". */
   ACCEPTANCE("201", "Acceptance"),
+  /** Master Lease Agreement — X12 code "202". */
   MASTER_LEASE_AGREEMENT("202", "Master Lease Agreement"),
+  /** First Produced — X12 code "203". */
   FIRST_PRODUCED("203", "First Produced"),
+  /** Official Rail Car Interchange (Either Actual or Agreed Upon) — X12 code "204". */
   OFFICIAL_RAIL_CAR_INTERCHANGE(
       "204", "Official Rail Car Interchange (Either Actual or Agreed Upon)"),
+  /** Transmitted — X12 code "205". */
   TRANSMITTED("205", "Transmitted"),
+  /** Status (Outside Processor) — X12 code "206". */
   STATUS_OUTSIDE_PROCESSOR("206", "Status (Outside Processor)"),
+  /** Status (Commercial) — X12 code "207". */
   STATUS_COMMERCIAL("207", "Status (Commercial)"),
+  /** Lot Number Expiration — X12 code "208". */
   LOT_NUMBER_EXPIRATION("208", "Lot Number Expiration"),
+  /** Contract Performance Start — X12 code "209". */
   CONTRACT_PERFORMANCE_START("209", "Contract Performance Start"),
+  /** Contract Performance Delivery — X12 code "210". */
   CONTRACT_PERFORMANCE_DELIVERY("210", "Contract Performance Delivery"),
+  /** Service Requested — X12 code "211". */
   SERVICE_REQUESTED("211", "Service Requested"),
+  /** Returned to Customer — X12 code "212". */
   RETURNED_TO_CUSTOMER("212", "Returned to Customer"),
+  /** Adjustment to Bill Dated — X12 code "213". */
   ADJUSTMENT_TO_BILL_DATED("213", "Adjustment to Bill Dated"),
+  /** Date of Repair/Service — X12 code "214". */
   DATE_OF_REPAIR_SERVICE("214", "Date of Repair/Service"),
+  /** Interruption Start — X12 code "215". */
   INTERRUPTION_START("215", "Interruption Start"),
+  /** Interruption End — X12 code "216". */
   INTERRUPTION_END("216", "Interruption End"),
+  /** Spud — X12 code "217". */
   SPUD("217", "Spud"),
+  /** Initial Completion — X12 code "218". */
   INITIAL_COMPLETION("218", "Initial Completion"),
+  /** Plugged and Abandoned — X12 code "219". */
   PLUGGED_AND_ABANDONED("219", "Plugged and Abandoned"),
+  /** Penalty — X12 code "220". */
   PENALTY("220", "Penalty"),
+  /** Penalty Begin — X12 code "221". */
   PENALTY_BEGIN("221", "Penalty Begin"),
+  /** Birth — X12 code "222". */
   BIRTH("222", "Birth"),
+  /** Birth Certificate — X12 code "223". */
   BIRTH_CERTIFICATE("223", "Birth Certificate"),
+  /** Adoption — X12 code "224". */
   ADOPTION("224", "Adoption"),
+  /** Christening — X12 code "225". */
   CHRISTENING("225", "Christening"),
+  /** Lease Commencement — X12 code "226". */
   LEASE_COMMENCEMENT("226", "Lease Commencement"),
+  /** Lease Term Start — X12 code "227". */
   LEASE_TERM_START("227", "Lease Term Start"),
+  /** Lease Term End — X12 code "228". */
   LEASE_TERM_END("228", "Lease Term End"),
+  /** Rent Start — X12 code "229". */
   RENT_START("229", "Rent Start"),
+  /** Installation — X12 code "230". */
   INSTALLATION("230", "Installation"),
+  /** Progress Payment — X12 code "231". */
   PROGRESS_PAYMENT("231", "Progress Payment"),
+  /** Claim Statement Period Start — X12 code "232". */
   CLAIM_STATEMENT_PERIOD_START("232", "Claim Statement Period Start"),
+  /** Claim Statement Period End — X12 code "233". */
   CLAIM_STATEMENT_PERIOD_END("233", "Claim Statement Period End"),
+  /** Settlement Date — X12 code "234". */
   SETTLEMENT_DATE("234", "Settlement Date"),
+  /** Delayed Billing (Not Delayed Payment) — X12 code "235". */
   DELAYED_BILLING("235", "Delayed Billing (Not Delayed Payment)"),
+  /** Lender Credit Check — X12 code "236". */
   LENDER_CREDIT_CHECK("236", "Lender Credit Check"),
+  /** Student Signed — X12 code "237". */
   STUDENT_SIGNED("237", "Student Signed"),
+  /** Schedule Release — X12 code "238". */
   SCHEDULE_RELEASE("238", "Schedule Release"),
+  /** Baseline — X12 code "239". */
   BASELINE("239", "Baseline"),
+  /** Baseline Start — X12 code "240". */
   BASELINE_START("240", "Baseline Start"),
+  /** Baseline Complete — X12 code "241". */
   BASELINE_COMPLETE("241", "Baseline Complete"),
+  /** Actual Start — X12 code "242". */
   ACTUAL_START("242", "Actual Start"),
+  /** Actual Complete — X12 code "243". */
   ACTUAL_COMPLETE("243", "Actual Complete"),
+  /** Estimated Start — X12 code "244". */
   ESTIMATED_START("244", "Estimated Start"),
+  /** Estimated Completion — X12 code "245". */
   ESTIMATED_COMPLETION("245", "Estimated Completion"),
+  /** Start no earlier than — X12 code "246". */
   START_NO_EARLIER_THAN("246", "Start no earlier than"),
+  /** Start no later than — X12 code "247". */
   START_NO_LATER_THAN("247", "Start no later than"),
+  /** Finish no later than — X12 code "248". */
   FINISH_NO_LATER_THAN("248", "Finish no later than"),
+  /** Finish no earlier than — X12 code "249". */
   FINISH_NO_EARLIER_THAN("249", "Finish no earlier than"),
+  /** Mandatory (or Target) Start — X12 code "250". */
   MANDATORY_START("250", "Mandatory (or Target) Start"),
+  /** Mandatory (or Target) Finish — X12 code "251". */
   MANDATORY_FINISH("251", "Mandatory (or Target) Finish"),
+  /** Early Start — X12 code "252". */
   EARLY_START("252", "Early Start"),
+  /** Early Finish — X12 code "253". */
   EARLY_FINISH("253", "Early Finish"),
+  /** Late Start — X12 code "254". */
   LATE_START("254", "Late Start"),
+  /** Late Finish — X12 code "255". */
   LATE_FINISH("255", "Late Finish"),
+  /** Scheduled Start — X12 code "256". */
   SCHEDULED_START("256", "Scheduled Start"),
+  /** Scheduled Finish — X12 code "257". */
   SCHEDULED_FINISH("257", "Scheduled Finish"),
+  /** Original Early Start — X12 code "258". */
   ORIGINAL_EARLY_START("258", "Original Early Start"),
+  /** Original Early Finish — X12 code "259". */
   ORIGINAL_EARLY_FINISH("259", "Original Early Finish"),
+  /** Rest Day — X12 code "260". */
   REST_DAY("260", "Rest Day"),
+  /** Rest Start — X12 code "261". */
   REST_START("261", "Rest Start"),
+  /** Rest Finish — X12 code "262". */
   REST_FINISH("262", "Rest Finish"),
+  /** Holiday — X12 code "263". */
   HOLIDAY("263", "Holiday"),
+  /** Holiday Start — X12 code "264". */
   HOLIDAY_START("264", "Holiday Start"),
+  /** Holiday Finish — X12 code "265". */
   HOLIDAY_FINISH("265", "Holiday Finish"),
+  /** Base — X12 code "266". */
   BASE("266", "Base"),
+  /** Timenow — X12 code "267". */
   TIMENOW("267", "Timenow"),
+  /** End Date of Support — X12 code "268". */
   END_DATE_OF_SUPPORT("268", "End Date of Support"),
+  /** Date Account Matures — X12 code "269". */
   DATE_ACCOUNT_MATURES("269", "Date Account Matures"),
+  /** Date Filed — X12 code "270". */
   DATE_FILED("270", "Date Filed"),
+  /** Penalty End — X12 code "271". */
   PENALTY_END("271", "Penalty End"),
+  /** Exit Plant Date — X12 code "272". */
   EXIT_PLANT_DATE("272", "Exit Plant Date"),
+  /** Latest On Board Carrier Date — X12 code "273". */
   LATEST_ON_BOARD_CARRIER_DATE("273", "Latest On Board Carrier Date"),
+  /** Requested Departure Date — X12 code "274". */
   REQUESTED_DEPARTURE_DATE("274", "Requested Departure Date"),
+  /** Approved — X12 code "275". */
   APPROVED("275", "Approved"),
+  /** Contract Start — X12 code "276". */
   CONTRACT_START("276", "Contract Start"),
+  /** Contract Definition — X12 code "277". */
   CONTRACT_DEFINITION("277", "Contract Definition"),
+  /** Last Item Delivery — X12 code "278". */
   LAST_ITEM_DELIVERY("278", "Last Item Delivery"),
+  /** Contract Completion — X12 code "279". */
   CONTRACT_COMPLETION("279", "Contract Completion"),
+  /** Date Course of Orthodontics Treatment Began or is Expected to Begin — X12 code "280". */
   DATE_COURSE_OF_ORTHODONTICS(
       "280", "Date Course of Orthodontics Treatment Began or is Expected to Begin"),
+  /** Over Target Baseline Month — X12 code "281". */
   OVER_TARGET_BASELINE_MONTH("281", "Over Target Baseline Month"),
+  /** Previous Report — X12 code "282". */
   PREVIOUS_REPORT("282", "Previous Report"),
+  /** Funds Appropriation - Start — X12 code "283". */
   FUNDS_APPROPRIATION_START("283", "Funds Appropriation - Start"),
+  /** Funds Appropriation - End — X12 code "284". */
   FUNDS_APPROPRIATION_END("284", "Funds Appropriation - End"),
+  /** Employment or Hire — X12 code "285". */
   EMPLOYMENT_OR_HIRE("285", "Employment or Hire"),
+  /** Retirement — X12 code "286". */
   RETIREMENT("286", "Retirement"),
+  /** Medicare — X12 code "287". */
   MEDICARE("287", "Medicare"),
+  /** Consolidated Omnibus Budget Reconciliation Act (COBRA) — X12 code "288". */
   COBRA("288", "Consolidated Omnibus Budget Reconciliation Act (COBRA)"),
+  /** Premium Paid to Date — X12 code "289". */
   PREMIUM_PAID_TO_DATE("289", "Premium Paid to Date"),
+  /** Coordination of Benefits — X12 code "290". */
   COORDINATION_OF_BENEFITS("290", "Coordination of Benefits"),
+  /** Plan — X12 code "291". */
   PLAN("291", "Plan"),
+  /** Benefit — X12 code "292". */
   BENEFIT("292", "Benefit"),
+  /** Education — X12 code "293". */
   EDUCATION("293", "Education"),
+  /** Earnings Effective Date — X12 code "294". */
   EARNINGS_EFFECTIVE_DATE("294", "Earnings Effective Date"),
+  /** Primary Care Provider — X12 code "295". */
   PRIMARY_CARE_PROVIDER("295", "Primary Care Provider"),
+  /** Initial Disability Period Return To Work — X12 code "296". */
   INITIAL_DISABILITY_PERIOD_RETURN_TO_WORK("296", "Initial Disability Period Return To Work"),
+  /** Initial Disability Period Last Day Worked — X12 code "297". */
   INITIAL_DISABILITY_PERIOD_LAST_DAY_WORKED("297", "Initial Disability Period Last Day Worked"),
+  /** Latest Absence — X12 code "298". */
   LATEST_ABSENCE("298", "Latest Absence"),
+  /** Illness — X12 code "299". */
   ILLNESS("299", "Illness"),
+  /** Enrollment Signature Date — X12 code "300". */
   ENROLLMENT_SIGNATURE_DATE("300", "Enrollment Signature Date"),
+  /** Consolidated Omnibus Budget Reconciliation Act (COBRA) Qualifying Event — X12 code "301". */
   COBRA_QUALIFYING_EVENT(
       "301", "Consolidated Omnibus Budget Reconciliation Act (COBRA) Qualifying Event"),
+  /** Maintenance — X12 code "302". */
   MAINTENANCE("302", "Maintenance"),
+  /** Maintenance Effective — X12 code "303". */
   MAINTENANCE_EFFECTIVE("303", "Maintenance Effective"),
+  /** Latest Visit or Consultation — X12 code "304". */
   LATEST_VISIT_OR_CONSULTATION("304", "Latest Visit or Consultation"),
+  /** Net Credit Service Date — X12 code "305". */
   NET_CREDIT_SERVICE_DATE("305", "Net Credit Service Date"),
+  /** Adjustment Effective Date — X12 code "306". */
   ADJUSTMENT_EFFECTIVE_DATE("306", "Adjustment Effective Date"),
+  /** Eligibility — X12 code "307". */
   ELIGIBILITY("307", "Eligibility"),
+  /** Pre-Award Survey — X12 code "308". */
   PRE_AWARD_SURVEY("308", "Pre-Award Survey"),
+  /** Plan Termination — X12 code "309". */
   PLAN_TERMINATION("309", "Plan Termination"),
+  /** Date of Closing — X12 code "310". */
   DATE_OF_CLOSING("310", "Date of Closing"),
+  /** Latest Receiving Date/Cutoff Date — X12 code "311". */
   LATEST_RECEIVING_DATE("311", "Latest Receiving Date/Cutoff Date"),
+  /** Salary Deferral — X12 code "312". */
   SALARY_DEFERRAL("312", "Salary Deferral"),
+  /** Cycle — X12 code "313". */
   CYCLE("313", "Cycle"),
+  /** Disability — X12 code "314". */
   DISABILITY("314", "Disability"),
+  /** Offset — X12 code "315". */
   OFFSET("315", "Offset"),
+  /** Prior Incorrect Date of Birth — X12 code "316". */
   PRIOR_INCORRECT_DATE_OF_BIRTH("316", "Prior Incorrect Date of Birth"),
+  /** Corrected Date of Birth — X12 code "317". */
   CORRECTED_DATE_OF_BIRTH("317", "Corrected Date of Birth"),
+  /** Added — X12 code "318". */
   ADDED("318", "Added"),
+  /** Failed — X12 code "319". */
   FAILED("319", "Failed"),
+  /** Date Foreclosure Proceedings Instituted — X12 code "320". */
   DATE_FORECLOSURE_PROCEEDINGS_INSTITUTED("320", "Date Foreclosure Proceedings Instituted"),
+  /** Purchased — X12 code "321". */
   PURCHASED("321", "Purchased"),
+  /** Put into Service — X12 code "322". */
   PUT_INTO_SERVICE("322", "Put into Service"),
+  /** Replaced — X12 code "323". */
   REPLACED("323", "Replaced"),
+  /** Returned — X12 code "324". */
   RETURNED("324", "Returned"),
+  /** Disbursement Date — X12 code "325". */
   DISBURSEMENT_DATE("325", "Disbursement Date"),
+  /** Guarantee Date — X12 code "326". */
   GUARANTEE_DATE("326", "Guarantee Date"),
+  /** Quarter Ending — X12 code "327". */
   QUARTER_ENDING("327", "Quarter Ending"),
+  /** Changed — X12 code "328". */
   CHANGED("328", "Changed"),
+  /** Terminated — X12 code "329". */
   TERMINATED("329", "Terminated"),
+  /** Referral Date — X12 code "330". */
   REFERRAL_DATE("330", "Referral Date"),
+  /** Evaluation Date — X12 code "331". */
   EVALUATION_DATE("331", "Evaluation Date"),
+  /** Placement Date — X12 code "332". */
   PLACEMENT_DATE("332", "Placement Date"),
+  /** Individual Education Plan (IEP) — X12 code "333". */
   INDIVIDUAL_EDUCATION_PLAN("333", "Individual Education Plan (IEP)"),
+  /** Re-evaluation Date — X12 code "334". */
   RE_EVALUATION_DATE("334", "Re-evaluation Date"),
+  /** Dismissal Date — X12 code "335". */
   DISMISSAL_DATE("335", "Dismissal Date"),
+  /** Employment Begin — X12 code "336". */
   EMPLOYMENT_BEGIN("336", "Employment Begin"),
+  /** Employment End — X12 code "337". */
   EMPLOYMENT_END("337", "Employment End"),
+  /** Medicare Begin — X12 code "338". */
   MEDICARE_BEGIN("338", "Medicare Begin"),
+  /** Medicare End — X12 code "339". */
   MEDICARE_END("339", "Medicare End"),
+  /** Consolidated Omnibus Budget Reconciliation Act (COBRA) Begin — X12 code "340". */
   COBRA_BEGIN("340", "Consolidated Omnibus Budget Reconciliation Act (COBRA) Begin"),
+  /** Consolidated Omnibus Budget Reconciliation Act (COBRA) End — X12 code "341". */
   COBRA_END("341", "Consolidated Omnibus Budget Reconciliation Act (COBRA) End"),
+  /** Premium Paid to Date Begin — X12 code "342". */
   PREMIUM_PAID_TO_DATE_BEGIN("342", "Premium Paid to Date Begin"),
+  /** Premium Paid to Date End — X12 code "343". */
   PREMIUM_PAID_TO_DATE_END("343", "Premium Paid to Date End"),
+  /** Coordination of Benefits Begin — X12 code "344". */
   COORDINATION_OF_BENEFITS_BEGIN("344", "Coordination of Benefits Begin"),
+  /** Coordination of Benefits End — X12 code "345". */
   COORDINATION_OF_BENEFITS_END("345", "Coordination of Benefits End"),
+  /** Plan Begin — X12 code "346". */
   PLAN_BEGIN("346", "Plan Begin"),
+  /** Plan End — X12 code "347". */
   PLAN_END("347", "Plan End"),
+  /** Benefit Begin — X12 code "348". */
   BENEFIT_BEGIN("348", "Benefit Begin"),
+  /** Benefit End — X12 code "349". */
   BENEFIT_END("349", "Benefit End"),
+  /** Education Begin — X12 code "350". */
   EDUCATION_BEGIN("350", "Education Begin"),
+  /** Education End — X12 code "351". */
   EDUCATION_END("351", "Education End"),
+  /** Primary Care Provider Begin — X12 code "352". */
   PRIMARY_CARE_PROVIDER_BEGIN("352", "Primary Care Provider Begin"),
+  /** Primary Care Provider End — X12 code "353". */
   PRIMARY_CARE_PROVIDER_END("353", "Primary Care Provider End"),
+  /** Illness Begin — X12 code "354". */
   ILLNESS_BEGIN("354", "Illness Begin"),
+  /** Illness End — X12 code "355". */
   ILLNESS_END("355", "Illness End"),
+  /** Eligibility Begin — X12 code "356". */
   ELIGIBILITY_BEGIN("356", "Eligibility Begin"),
+  /** Eligibility End — X12 code "357". */
   ELIGIBILITY_END("357", "Eligibility End"),
+  /** Cycle Begin — X12 code "358". */
   CYCLE_BEGIN("358", "Cycle Begin"),
+  /** Cycle End — X12 code "359". */
   CYCLE_END("359", "Cycle End"),
+  /** Initial Disability Period Start — X12 code "360". */
   INITIAL_DISABILITY_PERIOD_START("360", "Initial Disability Period Start"),
+  /** Initial Disability Period End — X12 code "361". */
   INITIAL_DISABILITY_PERIOD_END("361", "Initial Disability Period End"),
+  /** Offset Begin — X12 code "362". */
   OFFSET_BEGIN("362", "Offset Begin"),
+  /** Offset End — X12 code "363". */
   OFFSET_END("363", "Offset End"),
+  /** Plan Period Election Begin — X12 code "364". */
   PLAN_PERIOD_ELECTION_BEGIN("364", "Plan Period Election Begin"),
+  /** Plan Period Election End — X12 code "365". */
   PLAN_PERIOD_ELECTION_END("365", "Plan Period Election End"),
+  /** Plan Period Election — X12 code "366". */
   PLAN_PERIOD_ELECTION("366", "Plan Period Election"),
+  /** Due to Customer — X12 code "367". */
   DUE_TO_CUSTOMER("367", "Due to Customer"),
+  /** Submittal — X12 code "368". */
   SUBMITTAL("368", "Submittal"),
+  /** Estimated Departure Date — X12 code "369". */
   ESTIMATED_DEPARTURE_DATE("369", "Estimated Departure Date"),
+  /** Actual Departure Date — X12 code "370". */
   ACTUAL_DEPARTURE_DATE("370", "Actual Departure Date"),
+  /** Estimated Arrival Date — X12 code "371". */
   ESTIMATED_ARRIVAL_DATE("371", "Estimated Arrival Date"),
+  /** Actual Arrival Date — X12 code "372". */
   ACTUAL_ARRIVAL_DATE("372", "Actual Arrival Date"),
+  /** Order Start — X12 code "373". */
   ORDER_START("373", "Order Start"),
+  /** Order End — X12 code "374". */
   ORDER_END("374", "Order End"),
+  /** Delivery Start — X12 code "375". */
   DELIVERY_START("375", "Delivery Start"),
+  /** Delivery End — X12 code "376". */
   DELIVERY_END("376", "Delivery End"),
+  /** Contract Costs Through — X12 code "377". */
   CONTRACT_COSTS_THROUGH("377", "Contract Costs Through"),
+  /** Financial Information Submission — X12 code "378". */
   FINANCIAL_INFORMATION_SUBMISSION("378", "Financial Information Submission"),
+  /** Business Termination — X12 code "379". */
   BUSINESS_TERMINATION("379", "Business Termination"),
+  /** Applicant Signed — X12 code "380". */
   APPLICANT_SIGNED("380", "Applicant Signed"),
+  /** Cosigner Signed — X12 code "381". */
   COSIGNER_SIGNED("381", "Cosigner Signed"),
+  /** Enrollment — X12 code "382". */
   ENROLLMENT("382", "Enrollment"),
+  /** Adjusted Hire — X12 code "383". */
   ADJUSTED_HIRE("383", "Adjusted Hire"),
+  /** Credited Service — X12 code "384". */
   CREDITED_SERVICE("384", "Credited Service"),
+  /** Credited Service Begin — X12 code "385". */
   CREDITED_SERVICE_BEGIN("385", "Credited Service Begin"),
+  /** Credited Service End — X12 code "386". */
   CREDITED_SERVICE_END("386", "Credited Service End"),
+  /** Deferred Distribution — X12 code "387". */
   DEFERRED_DISTRIBUTION("387", "Deferred Distribution"),
+  /** Payment Commencement — X12 code "388". */
   PAYMENT_COMMENCEMENT("388", "Payment Commencement"),
+  /** Payroll Period — X12 code "389". */
   PAYROLL_PERIOD("389", "Payroll Period"),
+  /** Payroll Period Begin — X12 code "390". */
   PAYROLL_PERIOD_BEGIN("390", "Payroll Period Begin"),
+  /** Payroll Period End — X12 code "391". */
   PAYROLL_PERIOD_END("391", "Payroll Period End"),
+  /** Plan Entry — X12 code "392". */
   PLAN_ENTRY("392", "Plan Entry"),
+  /** Plan Participation Suspension — X12 code "393". */
   PLAN_PARTICIPATION_SUSPENSION("393", "Plan Participation Suspension"),
+  /** Rehire — X12 code "394". */
   REHIRE("394", "Rehire"),
+  /** Retermination — X12 code "395". */
   RETERMINATION("395", "Retermination"),
+  /** Termination — X12 code "396". */
   TERMINATION("396", "Termination"),
+  /** Valuation — X12 code "397". */
   VALUATION("397", "Valuation"),
+  /** Vesting Service — X12 code "398". */
   VESTING_SERVICE("398", "Vesting Service"),
+  /** Vesting Service Begin — X12 code "399". */
   VESTING_SERVICE_BEGIN("399", "Vesting Service Begin"),
+  /** Vesting Service End — X12 code "400". */
   VESTING_SERVICE_END("400", "Vesting Service End"),
+  /** Last Premium Paid Date — X12 code "543". */
   LAST_PREMIUM_PAID_DATE("543", "Last Premium Paid Date"),
+  /** Previous Period — X12 code "695". */
   PREVIOUS_PERIOD("695", "Previous Period");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/DisabilityTypeCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/DisabilityTypeCode.java
@@ -27,11 +27,17 @@ import lombok.Getter;
  */
 @Getter
 public enum DisabilityTypeCode implements EdiCodeEnum {
+  /** Short Term Disability — X12 code "1". */
   SHORT_TERM_DISABILITY("1", "Short Term Disability"),
+  /** Long Term Disability — X12 code "2". */
   LONG_TERM_DISABILITY("2", "Long Term Disability"),
+  /** Permanent or Total Disability — X12 code "3". */
   PERMANENT_OR_TOTAL_DISABILITY("3", "Permanent or Total Disability"),
+  /** No Disability — X12 code "4". */
   NO_DISABILITY("4", "No Disability"),
+  /** Partial Disability — X12 code "5". */
   PARTIAL_DISABILITY("5", "Partial Disability"),
+  /** Mutually Defined — X12 code "Z". */
   MUTUALLY_DEFINED("Z", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/EntityIdentifierCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/EntityIdentifierCode.java
@@ -24,186 +24,354 @@ import lombok.Getter;
  */
 @Getter
 public enum EntityIdentifierCode implements EdiCodeEnum {
+  /** Alternate Insurer — X12 code "00". */
   ALTERNATE_INSURER("00", "Alternate Insurer"),
+  /** Comparable Rentals — X12 code "0A". */
   COMPARABLE_RENTALS("0A", "Comparable Rentals"),
+  /** Interim Funding Organization — X12 code "0B". */
   INTERIM_FUNDING_ORGANIZATION("0B", "Interim Funding Organization"),
+  /** Non-occupant Co-borrower — X12 code "0D". */
   NON_OCCUPANT_CO_BORROWER("0D", "Non-occupant Co-borrower"),
+  /** List Owner — X12 code "0E". */
   LIST_OWNER("0E", "List Owner"),
+  /** List Mailer — X12 code "0F". */
   LIST_MAILER("0F", "List Mailer"),
+  /** Primary Electronic Business Contact — X12 code "0G". */
   PRIMARY_ELECTRONIC_BUSINESS_CONTACT("0G", "Primary Electronic Business Contact"),
+  /** State Division — X12 code "0H". */
   STATE_DIVISION("0H", "State Division"),
+  /** Alternate Electronic Business Contact — X12 code "0I". */
   ALTERNATE_ELECTRONIC_BUSINESS_CONTACT("0I", "Alternate Electronic Business Contact"),
+  /** Primary Practice Location — X12 code "0J". */
   PRIMARY_PRACTICE_LOCATION("0J", "Primary Practice Location"),
+  /** Party to Declare Goods — X12 code "0P". */
   PARTY_TO_DECLARE_GOODS("0P", "Party to Declare Goods"),
+  /** Loan Applicant — X12 code "01". */
   LOAN_APPLICANT("01", "Loan Applicant"),
+  /** Pumper — X12 code "001". */
   PUMPER("001", "Pumper"),
+  /** Subgroup — X12 code "1A". */
   SUBGROUP("1A", "Subgroup"),
+  /** Applicant — X12 code "1B". */
   APPLICANT("1B", "Applicant"),
+  /** Group Purchasing Organization (GPO) — X12 code "1C". */
   GROUP_PURCHASING_ORGANIZATION("1C", "Group Purchasing Organization (GPO)"),
+  /** Co-operative — X12 code "1D". */
   COOPERATIVE("1D", "Co-operative"),
+  /** Health Maintenance Organization (HMO) — X12 code "1E". */
   HEALTH_MAINTENANCE_ORGANIZATION("1E", "Health Maintenance Organization (HMO)"),
+  /** Alliance — X12 code "1F". */
   ALLIANCE("1F", "Alliance"),
+  /** Oncology Center — X12 code "1G". */
   ONCOLOGY_CENTER("1G", "Oncology Center"),
+  /** Kidney Dialysis Unit — X12 code "1H". */
   KIDNEY_DIALYSIS_UNIT("1H", "Kidney Dialysis Unit"),
+  /** Preferred Provider Organization (PPO) — X12 code "1I". */
   PREFERRED_PROVIDER_ORGANIZATION("1I", "Preferred Provider Organization (PPO)"),
+  /**
+   * ConnectionThe name of pipeline company to which a well, lease or field is connected — X12 code
+   * "1J".
+   */
   CONNECTION(
       "1J", "ConnectionThe name of pipeline company to which a well, lease or field is connected"),
+  /** Franchisor — X12 code "1K". */
   FRANCHISOR("1K", "Franchisor"),
+  /** Franchisee — X12 code "1L". */
   FRANCHISEE("1L", "Franchisee"),
+  /** Previous Group — X12 code "1M". */
   PREVIOUS_GROUP("1M", "Previous Group"),
+  /** Shareholder — X12 code "1N". */
   SHAREHOLDER("1N", "Shareholder"),
+  /** Acute Care Hospital — X12 code "1O". */
   ACUTE_CARE_HOSPITAL("1O", "Acute Care Hospital"),
+  /** Provider — X12 code "1P". */
   PROVIDER("1P", "Provider"),
+  /** Military Facility — X12 code "1Q". */
   MILITARY_FACILITY("1Q", "Military Facility"),
+  /** University, College or School — X12 code "1R". */
   UNIVERSITY_COLLEGE_SCHOOL("1R", "University, College or School"),
+  /** Outpatient Surgicenter — X12 code "1S". */
   OUTPATIENT_SURGICENTER("1S", "Outpatient Surgicenter"),
+  /** Physician, Clinic or Group Practice — X12 code "1T". */
   PHYSICIAN_CLINIC_GROUP_PRACTICE("1T", "Physician, Clinic or Group Practice"),
+  /** Long Term Care Facility — X12 code "1U". */
   LONG_TERM_CARE_FACILITY("1U", "Long Term Care Facility"),
+  /** Extended Care Facility — X12 code "1V". */
   EXTENDED_CARE_FACILITY("1V", "Extended Care Facility"),
+  /** Psychiatric Health Facility — X12 code "1W". */
   PSYCHIATRIC_HEALTH_FACILITY("1W", "Psychiatric Health Facility"),
+  /** Laboratory — X12 code "1X". */
   LABORATORY("1X", "Laboratory"),
+  /** Retail Pharmacy — X12 code "1Y". */
   RETAIL_PHARMACY("1Y", "Retail Pharmacy"),
+  /** Home Health Care — X12 code "1Z". */
   HOME_HEALTH_CARE("1Z", "Home Health Care"),
+  /** Loan Broker — X12 code "02". */
   LOAN_BROKER("02", "Loan Broker"),
+  /** Surface Management Entity — X12 code "002". */
   SURFACE_MANAGEMENT_ENTITY("002", "Surface Management Entity"),
+  /** Federal, State, County or City Facility — X12 code "2A". */
   FEDERAL_STATE_COUNTY_CITY_FACILITY("2A", "Federal, State, County or City Facility"),
+  /** Third-Party Administrator — X12 code "2B". */
   THIRD_PARTY_ADMINISTRATOR("2B", "Third-Party Administrator"),
+  /** Co-Participant — X12 code "2C". */
   CO_PARTICIPANT("2C", "Co-Participant"),
+  /** Miscellaneous Health Care Facility — X12 code "2D". */
   MISCELLANEOUS_HEALTH_CARE_FACILITY("2D", "Miscellaneous Health Care Facility"),
+  /** Non-Health Care Miscellaneous Facility — X12 code "2E". */
   NON_HEALTH_CARE_MISCELLANEOUS_FACILITY("2E", "Non-Health Care Miscellaneous Facility"),
+  /** State — X12 code "2F". */
   STATE("2F", "State"),
+  /** Assigner — X12 code "2G". */
   ASSIGNER("2G", "Assigner"),
+  /** Hospital District or Authority — X12 code "2H". */
   HOSPITAL_DISTRICT_OR_AUTHORITY("2H", "Hospital District or Authority"),
+  /** Church Operated Facility — X12 code "2I". */
   CHURCH_OPERATED_FACILITY("2I", "Church Operated Facility"),
+  /** Individual — X12 code "2J". */
   INDIVIDUAL("2J", "Individual"),
+  /** Partnership — X12 code "2K". */
   PARTNERSHIP("2K", "Partnership"),
+  /** Corporation — X12 code "2L". */
   CORPORATION("2L", "Corporation"),
+  /** Air Force Facility — X12 code "2M". */
   AIR_FORCE_FACILITY("2M", "Air Force Facility"),
+  /** Army Facility — X12 code "2N". */
   ARMY_FACILITY("2N", "Army Facility"),
+  /** Navy Facility — X12 code "2O". */
   NAVY_FACILITY("2O", "Navy Facility"),
+  /** Public Health Service Facility — X12 code "2P". */
   PUBLIC_HEALTH_SERVICE_FACILITY("2P", "Public Health Service Facility"),
+  /** Veterans Administration Facility — X12 code "2Q". */
   VETERANS_ADMINISTRATION_FACILITY("2Q", "Veterans Administration Facility"),
+  /** Federal Facility — X12 code "2R". */
   FEDERAL_FACILITY("2R", "Federal Facility"),
+  /** Public Health Service Indian Service Facility — X12 code "2S". */
   PUBLIC_HEALTH_SERVICE_INDIAN_SERVICE_FACILITY(
       "2S", "Public Health Service Indian Service Facility"),
+  /** Department of Justice Facility — X12 code "2T". */
   DEPARTMENT_OF_JUSTICE_FACILITY("2T", "Department of Justice Facility"),
+  /** Other Not-for-profit Facility — X12 code "2U". */
   OTHER_NOT_FOR_PROFIT_FACILITY("2U", "Other Not-for-profit Facility"),
+  /** Individual for-profit Facility — X12 code "2V". */
   INDIVIDUAL_FOR_PROFIT_FACILITY("2V", "Individual for-profit Facility"),
+  /** Partnership for-profit Facility — X12 code "2W". */
   PARTNERSHIP_FOR_PROFIT_FACILITY("2W", "Partnership for-profit Facility"),
+  /** Corporation for-profit Facility — X12 code "2X". */
   CORPORATION_FOR_PROFIT_FACILITY("2X", "Corporation for-profit Facility"),
+  /** General Medical and Surgical Facility — X12 code "2Y". */
   GENERAL_MEDICAL_AND_SURGICAL_FACILITY("2Y", "General Medical and Surgical Facility"),
+  /** Hospital Unit of an Institution (prison hospital, college infirmary, etc.) — X12 code "2Z". */
   HOSPITAL_UNIT_OF_AN_INSTITUTION(
       "2Z", "Hospital Unit of an Institution (prison hospital, college infirmary, etc.)"),
+  /** Dependent — X12 code "03". */
   DEPENDENT("03", "Dependent"),
+  /** Application Party — X12 code "003". */
   APPLICATION_PARTY("003", "Application Party"),
+  /** Hospital Unit Within an Institution for the Mentally Retarded — X12 code "3A". */
   HOSPITAL_UNIT_WITHIN_INSTITUTION_FOR_MENTALLY_RETARDED(
       "3A", "Hospital Unit Within an Institution for the Mentally Retarded"),
+  /** Psychiatric Facility — X12 code "3B". */
   PSYCHIATRIC_FACILITY("3B", "Psychiatric Facility"),
+  /** Tuberculosis and Other Respiratory Diseases Facility — X12 code "3C". */
   TUBERCULOSIS_AND_OTHER_RESPIRATORY_DISEASES_FACILITY(
       "3C", "Tuberculosis and Other Respiratory Diseases Facility"),
+  /** Obstetrics and Gynecology Facility — X12 code "3D". */
   OBSTETRICS_AND_GYNECOLOGY_FACILITY("3D", "Obstetrics and Gynecology Facility"),
+  /** Eye, Ear, Nose and Throat Facility — X12 code "3E". */
   EYE_EAR_NOSE_AND_THROAT_FACILITY("3E", "Eye, Ear, Nose and Throat Facility"),
+  /** Rehabilitation Facility — X12 code "3F". */
   REHABILITATION_FACILITY("3F", "Rehabilitation Facility"),
+  /** Orthopedic Facility — X12 code "3G". */
   ORTHOPEDIC_FACILITY("3G", "Orthopedic Facility"),
+  /** Chronic Disease Facility — X12 code "3H". */
   CHRONIC_DISEASE_FACILITY("3H", "Chronic Disease Facility"),
+  /** Other Specialty Facility — X12 code "3I". */
   OTHER_SPECIALTY_FACILITY("3I", "Other Specialty Facility"),
+  /** Children's General Facility — X12 code "3J". */
   CHILDRENS_GENERAL_FACILITY("3J", "Children's General Facility"),
+  /** Children's Hospital Unit of an Institution — X12 code "3K". */
   CHILDRENS_HOSPITAL_UNIT_OF_AN_INSTITUTION("3K", "Children's Hospital Unit of an Institution"),
+  /** Children's Psychiatric Facility — X12 code "3L". */
   CHILDRENS_PSYCHIATRIC_FACILITY("3L", "Children's Psychiatric Facility"),
+  /** Children's Tuberculosis and Other Respiratory Diseases Facility — X12 code "3M". */
   CHILDRENS_TUBERCULOSIS_AND_OTHER_RESPIRATORY_DISEASES_FACILITY(
       "3M", "Children's Tuberculosis and Other Respiratory Diseases Facility"),
+  /** Children's Eye, Ear, Nose and Throat Facility — X12 code "3N". */
   CHILDRENS_EYE_EAR_NOSE_AND_THROAT_FACILITY("3N", "Children's Eye, Ear, Nose and Throat Facility"),
+  /** Children's Rehabilitation Facility — X12 code "3O". */
   CHILDRENS_REHABILITATION_FACILITY("3O", "Children's Rehabilitation Facility"),
+  /** Children's Orthopedic Facility — X12 code "3P". */
   CHILDRENS_ORTHOPEDIC_FACILITY("3P", "Children's Orthopedic Facility"),
+  /** Children's Chronic Disease Facility — X12 code "3Q". */
   CHILDRENS_CHRONIC_DISEASE_FACILITY("3Q", "Children's Chronic Disease Facility"),
+  /** Children's Other Specialty Facility — X12 code "3R". */
   CHILDRENS_OTHER_SPECIALTY_FACILITY("3R", "Children's Other Specialty Facility"),
+  /** Institution for Mental Retardation — X12 code "3S". */
   INSTITUTION_FOR_MENTAL_RETARDATION("3S", "Institution for Mental Retardation"),
+  /** Alcoholism and Other Chemical Dependency Facility — X12 code "3T". */
   ALCOHOLISM_AND_OTHER_CHEMICAL_DEPENDENCY_FACILITY(
       "3T", "Alcoholism and Other Chemical Dependency Facility"),
+  /** General Inpatient Care for AIDS/ARC Facility — X12 code "3U". */
   GENERAL_INPATIENT_CARE_FOR_AIDS_ARC_FACILITY(
       "3U", "General Inpatient Care for AIDS/ARC Facility"),
+  /** AIDS/ARC Unit — X12 code "3V". */
   AIDS_ARC_UNIT("3V", "AIDS/ARC Unit"),
+  /** Specialized Outpatient Program for AIDS/ARC — X12 code "3W". */
   SPECIALIZED_OUTPATIENT_PROGRAM_FOR_AIDS_ARC("3W", "Specialized Outpatient Program for AIDS/ARC"),
+  /** Alcohol/Drug Abuse or Dependency Inpatient Unit — X12 code "3X". */
   ALCOHOL_DRUG_ABUSE_OR_DEPENDENCY_INPATIENT_UNIT(
       "3X", "Alcohol/Drug Abuse or Dependency Inpatient Unit"),
+  /** Alcohol/Drug Abuse or Dependency Outpatient Services — X12 code "3Y". */
   ALCOHOL_DRUG_ABUSE_OR_DEPENDENCY_OUTPATIENT_SERVICES(
       "3Y", "Alcohol/Drug Abuse or Dependency Outpatient Services"),
+  /** Arthritis Treatment Center — X12 code "3Z". */
   ARTHRITIS_TREATMENT_CENTER("3Z", "Arthritis Treatment Center"),
+  /** Asset Account Holder — X12 code "04". */
   ASSET_ACCOUNT_HOLDER("04", "Asset Account Holder"),
+  /** Site Operator — X12 code "004". */
   SITE_OPERATOR("004", "Site Operator"),
+  /** Birthing Room/LDRP Room — X12 code "4A". */
   BIRTHING_ROOM_LDRP_ROOM("4A", "Birthing Room/LDRP Room"),
+  /** Burn Care Unit — X12 code "4B". */
   BURN_CARE_UNIT("4B", "Burn Care Unit"),
+  /** Cardiac Catherization Laboratory — X12 code "4C". */
   CARDIAC_CATHERIZATION_LABORATORY("4C", "Cardiac Catherization Laboratory"),
+  /** Open-Heart Surgery Facility — X12 code "4D". */
   OPEN_HEART_SURGERY_FACILITY("4D", "Open-Heart Surgery Facility"),
+  /** Cardiac Intensive Care Unit — X12 code "4E". */
   CARDIAC_INTENSIVE_CARE_UNIT("4E", "Cardiac Intensive Care Unit"),
+  /** Angioplasty Facility — X12 code "4F". */
   ANGIOPLASTY_FACILITY("4F", "Angioplasty Facility"),
+  /** Chronic Obstructive Pulmonary Disease Service Facility — X12 code "4G". */
   CHRONIC_OBSTRUCTIVE_PULMONARY_DISEASE_SERVICE_FACILITY(
       "4G", "Chronic Obstructive Pulmonary Disease Service Facility"),
+  /** Emergency Department — X12 code "4H". */
   EMERGENCY_DEPARTMENT("4H", "Emergency Department"),
+  /** Trauma Center (Certified) — X12 code "4I". */
   TRAUMA_CENTER("4I", "Trauma Center (Certified)"),
+  /** Extracorporeal Shock-Wave Lithotripter (ESWL) Unit — X12 code "4J". */
   EXTRACORPOREAL_SHOCK_WAVE_LITHOTRIPTER_UNIT(
       "4J", "Extracorporeal Shock-Wave Lithotripter (ESWL) Unit"),
+  /** Fitness Center — X12 code "4K". */
   FITNESS_CENTER("4K", "Fitness Center"),
+  /** Genetic Counseling/Screening Services — X12 code "4L". */
   GENETIC_COUNSELING_SCREENING_SERVICES("4L", "Genetic Counseling/Screening Services"),
+  /** Adult Day Care Program Facility — X12 code "4M". */
   ADULT_DAY_CARE_PROGRAM_FACILITY("4M", "Adult Day Care Program Facility"),
+  /** Alzheimer's Diagnostic/Assessment Services — X12 code "4N". */
   ALZHEIMERS_DIAGNOSTIC_ASSESSMENT_SERVICES("4N", "Alzheimer's Diagnostic/Assessment Services"),
+  /** Comprehensive Geriatric Assessment Facility — X12 code "4O". */
   COMPREHENSIVE_GERIATRIC_ASSESSMENT_FACILITY("4O", "Comprehensive Geriatric Assessment Facility"),
+  /** Emergency Response (Geriatric) Unit — X12 code "4P". */
   EMERGENCY_RESPONSE_GERIATRIC_UNIT("4P", "Emergency Response (Geriatric) Unit"),
+  /** Geriatric Acute Care Unit — X12 code "4Q". */
   GERIATRIC_ACUTE_CARE_UNIT("4Q", "Geriatric Acute Care Unit"),
+  /** Geriatric Clinics — X12 code "4R". */
   GERIATRIC_CLINICS("4R", "Geriatric Clinics"),
+  /** Respite Care Facility — X12 code "4S". */
   RESPITE_CARE_FACILITY("4S", "Respite Care Facility"),
+  /** Senior Membership Program — X12 code "4T". */
   SENIOR_MEMBERSHIP_PROGRAM("4T", "Senior Membership Program"),
+  /** Patient Education Unit — X12 code "4U". */
   PATIENT_EDUCATION_UNIT("4U", "Patient Education Unit"),
+  /** Community Health Promotion Facility — X12 code "4V". */
   COMMUNITY_HEALTH_PROMOTION_FACILITY("4V", "Community Health Promotion Facility"),
+  /** Worksite Health Promotion Facility — X12 code "4W". */
   WORKSITE_HEALTH_PROMOTION_FACILITY("4W", "Worksite Health Promotion Facility"),
+  /** Hemodialysis Facility — X12 code "4X". */
   HEMODIALYSIS_FACILITY("4X", "Hemodialysis Facility"),
+  /** Home Health Services — X12 code "4Y". */
   HOME_HEALTH_SERVICES("4Y", "Home Health Services"),
+  /** Hospice — X12 code "4Z". */
   HOSPICE("4Z", "Hospice"),
+  /** Tenant — X12 code "05". */
   TENANT("05", "Tenant"),
+  /** Construction Contractor — X12 code "005". */
   CONSTRUCTION_CONTRACTOR("005", "Construction Contractor"),
+  /** Medical Surgical or Other Intensive Care Unit — X12 code "5A". */
   MEDICAL_SURGICAL_OR_OTHER_INTENSIVE_CARE_UNIT(
       "5A", "Medical Surgical or Other Intensive Care Unit"),
+  /** Hisopathology Laboratory — X12 code "5B". */
   HISOPATHOLOGY_LABORATORY("5B", "Hisopathology Laboratory"),
+  /** Blood Bank — X12 code "5C". */
   BLOOD_BANK("5C", "Blood Bank"),
+  /** Neonatal Intensive Care Unit — X12 code "5D". */
   NEONATAL_INTENSIVE_CARE_UNIT("5D", "Neonatal Intensive Care Unit"),
+  /** Obstetrics Unit — X12 code "5E". */
   OBSTETRICS_UNIT("5E", "Obstetrics Unit"),
+  /** Occupational Health Services — X12 code "5F". */
   OCCUPATIONAL_HEALTH_SERVICES("5F", "Occupational Health Services"),
+  /** Organized Outpatient Services — X12 code "5G". */
   ORGANIZED_OUTPATIENT_SERVICES("5G", "Organized Outpatient Services"),
+  /** Pediatric Acute Inpatient Unit — X12 code "5H". */
   PEDIATRIC_ACUTE_INPATIENT_UNIT("5H", "Pediatric Acute Inpatient Unit"),
+  /** Psychiatric Child/Adolescent Services — X12 code "5I". */
   PSYCHIATRIC_CHILD_ADOLESCENT_SERVICES("5I", "Psychiatric Child/Adolescent Services"),
+  /** Psychiatric Consultation-Liaison Services — X12 code "5J". */
   PSYCHIATRIC_CONSULTATION_LIAISON_SERVICES("5J", "Psychiatric Consultation-Liaison Services"),
+  /** Psychiatric Education Services — X12 code "5K". */
   PSYCHIATRIC_EDUCATION_SERVICES("5K", "Psychiatric Education Services"),
+  /** Psychiatric Emergency Services — X12 code "5L". */
   PSYCHIATRIC_EMERGENCY_SERVICES("5L", "Psychiatric Emergency Services"),
+  /** Psychiatric Geriatric Services — X12 code "5M". */
   PSYCHIATRIC_GERIATRIC_SERVICES("5M", "Psychiatric Geriatric Services"),
+  /** Psychiatric Inpatient Unit — X12 code "5N". */
   PSYCHIATRIC_INPATIENT_UNIT("5N", "Psychiatric Inpatient Unit"),
+  /** Psychiatric Outpatient Services — X12 code "5O". */
   PSYCHIATRIC_OUTPATIENT_SERVICES("5O", "Psychiatric Outpatient Services"),
+  /** Psychiatric Partial Hospitalization Program — X12 code "5P". */
   PSYCHIATRIC_PARTIAL_HOSPITALIZATION_PROGRAM("5P", "Psychiatric Partial Hospitalization Program"),
+  /** Megavoltage Radiation Therapy Unit — X12 code "5Q". */
   MEGAVOLTAGE_RADIATION_THERAPY_UNIT("5Q", "Megavoltage Radiation Therapy Unit"),
+  /** Radioactive Implants Unit — X12 code "5R". */
   RADIOACTIVE_IMPLANTS_UNIT("5R", "Radioactive Implants Unit"),
+  /** Therapeutic Radioisotope Facility — X12 code "5S". */
   THERAPEUTIC_RADIOISOTOPE_FACILITY("5S", "Therapeutic Radioisotope Facility"),
+  /** X-Ray Radiation Therapy Unit — X12 code "5T". */
   X_RAY_RADIATION_THERAPY_UNIT("5T", "X-Ray Radiation Therapy Unit"),
+  /** CT Scanner Unit — X12 code "5U". */
   CT_SCANNER_UNIT("5U", "CT Scanner Unit"),
+  /** Diagnostic Radioisotope Facility — X12 code "5V". */
   DIAGNOSTIC_RADIOISOTOPE_FACILITY("5V", "Diagnostic Radioisotope Facility"),
+  /** Magnetic Resonance Imaging (MRI) Facility — X12 code "5W". */
   MAGNETIC_RESONANCE_IMAGING_FACILITY("5W", "Magnetic Resonance Imaging (MRI) Facility"),
+  /** Ultrasound Unit — X12 code "5X". */
   ULTRASOUND_UNIT("5X", "Ultrasound Unit"),
+  /** Rehabilitation Inpatient Unit — X12 code "5Y". */
   REHABILITATION_INPATIENT_UNIT("5Y", "Rehabilitation Inpatient Unit"),
+  /** Rehabilitation Outpatient Services — X12 code "5Z". */
   REHABILITATION_OUTPATIENT_SERVICES("5Z", "Rehabilitation Outpatient Services"),
+  /** Recipient of Civil or Legal Liability Payment — X12 code "06". */
   RECIPIENT_OF_CIVIL_OR_LEGAL_LIABILITY_PAYMENT(
       "06", "Recipient of Civil or Legal Liability Payment"),
+  /** Drilling Contractor — X12 code "006". */
   DRILLING_CONTRACTOR("006", "Drilling Contractor"),
+  /** Insurer — X12 code "IN". */
   INSURER("IN", "Insurer"),
+  /** Terminal Location — X12 code "T3". */
   TERMINAL_LOCATION("T3", "Terminal Location"),
+  /** Plan Sponsor — X12 code "P5". */
   PLAN_SPONSOR("P5", "Plan Sponsor"),
+  /** Primary Taxpayer — X12 code "TP". */
   PRIMARY_TAX_PAYER("TP", "Primary Taxpayer"),
+  /** Third Party Administrator (TPA) — X12 code "TV". */
   THIRD_PARTY_ADMINISTRATOR_TPA("TV", "Third Party Administrator (TPA)"),
+  /** Broker or Sales Office — X12 code "BO". */
   BROKER_OR_SALES_OFFICE("BO", "Broker or Sales Office"),
+  /** Insured or Subscriber — X12 code "IL". */
   INSURED_OR_SUBSCRIBER("IL", "Insured or Subscriber"),
+  /** Corrected Insured — X12 code "74". */
   CORRECTED_INSURED("74", "Corrected Insured"),
+  /** Employer — X12 code "36". */
   EMPLOYER("36", "Employer"),
+  /** Information Source — X12 code "ACV". */
   INFORMATION_SOURCE("ACV", "Information Source"),
+  /** Managed Care — X12 code "QK". */
   MANAGED_CARE("QK", "Managed Care"),
   /** NM101 of the 2100C mailing-address loop — the position this library already emits. */
   POSTAL_MAILING_ADDRESS("31", "Postal Mailing Address"),
+  /** Participant — X12 code "75". */
   PARTICIPANT("75", "Participant");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/FrequencyCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/FrequencyCode.java
@@ -25,28 +25,51 @@ import lombok.Getter;
  */
 @Getter
 public enum FrequencyCode implements EdiCodeEnum {
+  /** Annualized; 12-month equivalent — X12 code "0". */
   ANNUALIZED("0", "Annualized; 12-month equivalent"),
+  /** Weekly — X12 code "1". */
   WEEKLY("1", "Weekly"),
+  /** Biweekly — X12 code "2". */
   BIWEEKLY("2", "Biweekly"),
+  /** Semimonthly — X12 code "3". */
   SEMIMONTHLY("3", "Semimonthly"),
+  /** Monthly — X12 code "4". */
   MONTHLY("4", "Monthly"),
+  /** Other — X12 code "5". */
   OTHER("5", "Other"),
+  /** Daily — X12 code "6". */
   DAILY("6", "Daily"),
+  /** Annual — X12 code "7". */
   ANNUAL("7", "Annual"),
+  /** Two Calendar Months — X12 code "8". */
   TWO_CALENDAR_MONTHS("8", "Two Calendar Months"),
+  /** Lump-Sum Separation Allowance — X12 code "9". */
   LUMP_SUM_SEPARATION_ALLOWANCE("9", "Lump-Sum Separation Allowance"),
+  /** Quarter-to-Date — X12 code "A". */
   QUARTER_TO_DATE("A", "Quarter-to-Date"),
+  /** Year-to-Date — X12 code "B". */
   YEAR_TO_DATE("B", "Year-to-Date"),
+  /** Single — X12 code "C". */
   SINGLE("C", "Single"),
+  /** Policy Period — X12 code "D". */
   POLICY_PERIOD("D", "Policy Period"),
+  /** Claim Period — X12 code "E". */
   CLAIM_PERIOD("E", "Claim Period"),
+  /** Unit Report Identifier — X12 code "F". */
   UNIT_REPORT_IDENTIFIER("F", "Unit Report Identifier"),
+  /** Month-to-Date — X12 code "G". */
   MONTH_TO_DATE("G", "Month-to-Date"),
+  /** Hourly — X12 code "H". */
   HOURLY("H", "Hourly"),
+  /** Current Period — X12 code "J". */
   CURRENT_PERIOD("J", "Current Period"),
+  /** Quarterly — X12 code "Q". */
   QUARTERLY("Q", "Quarterly"),
+  /** Semiannual — X12 code "S". */
   SEMIANNUAL("S", "Semiannual"),
+  /** Unknown — X12 code "U". */
   UNKNOWN("U", "Unknown"),
+  /** Mutually Defined — X12 code "Z". */
   MUTUALLY_DEFINED("Z", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/FunctionalIdentifierCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/FunctionalIdentifierCode.java
@@ -24,274 +24,537 @@ import lombok.Getter;
  */
 @Getter
 public enum FunctionalIdentifierCode implements EdiCodeEnum {
+  /** Account Analysis (822) — X12 code "AA". */
   ACCOUNT_ANALYSIS("AA", "Account Analysis (822)"),
+  /** Logistics Service Request (219) — X12 code "AB". */
   LOGISTICS_SERVICE_REQUEST("AB", "Logistics Service Request (219)"),
+  /** Associated Data (102) — X12 code "AC". */
   ASSOCIATED_DATA("AC", "Associated Data (102)"),
+  /** Individual Life, Annuity and Disability Application (267) — X12 code "AD". */
   LIFE_ANNUITY_APPLICATION("AD", "Individual Life, Annuity and Disability Application (267)"),
+  /** Premium Audit Request and Return (187) — X12 code "AE". */
   PREMIUM_AUDIT("AE", "Premium Audit Request and Return (187)"),
+  /** Application for Admission to Educational Institutions (189) — X12 code "AF". */
   EDUCATIONAL_ADMISSION("AF", "Application for Admission to Educational Institutions (189)"),
+  /** Application Advice (824) — X12 code "AG". */
   APPLICATION_ADVICE("AG", "Application Advice (824)"),
+  /** Logistics Service Response (220) — X12 code "AH". */
   LOGISTICS_SERVICE_RESPONSE("AH", "Logistics Service Response (220)"),
+  /** Automotive Inspection Detail (928) — X12 code "AI". */
   AUTOMOTIVE_INSPECTION("AI", "Automotive Inspection Detail (928)"),
+  /** Student Educational Record (Transcript) Acknowledgment (131) — X12 code "AK". */
   TRANSCRIPT_ACKNOWLEDGMENT("AK", "Student Educational Record (Transcript) Acknowledgment (131)"),
+  /** Set Cancellation (998) — X12 code "AL". */
   SET_CANCELLATION("AL", "Set Cancellation (998)"),
+  /** Item Information Request (893) — X12 code "AM". */
   ITEM_INFORMATION_REQUEST("AM", "Item Information Request (893)"),
+  /** Return Merchandise Authorization and Notification (180) — X12 code "AN". */
   RETURN_MERCHANDISE_AUTH("AN", "Return Merchandise Authorization and Notification (180)"),
+  /** Income or Asset Offset (521) — X12 code "AO". */
   INCOME_ASSET_OFFSET("AO", "Income or Asset Offset (521)"),
+  /** Abandoned Property Filings (103) — X12 code "AP". */
   ABANDONED_PROPERTY("AP", "Abandoned Property Filings (103)"),
+  /** U.S. Customs Manifest (309) — X12 code "AQ". */
   CUSTOMS_MANIFEST("AQ", "U.S. Customs Manifest (309)"),
+  /** Warehouse Stock Transfer Shipment Advice (943) — X12 code "AR". */
   WAREHOUSE_STOCK_TRANSFER("AR", "Warehouse Stock Transfer Shipment Advice (943)"),
+  /** Transportation Appointment Schedule Information (163) — X12 code "AS". */
   TRANSPORTATION_APPOINTMENT("AS", "Transportation Appointment Schedule Information (163)"),
+  /** Animal Toxicological Data (249) — X12 code "AT". */
   ANIMAL_TOXICOLOGICAL_DATA("AT", "Animal Toxicological Data (249)"),
+  /** U.S. Customs Status Information (350) — X12 code "AU". */
   CUSTOMS_STATUS_INFO("AU", "U.S. Customs Status Information (350)"),
+  /** U.S. Customs Carrier General Order Status (352) — X12 code "AV". */
   CUSTOMS_GENERAL_ORDER("AV", "U.S. Customs Carrier General Order Status (352)"),
+  /** Warehouse Inventory Adjustment Advice (947) — X12 code "AW". */
   WAREHOUSE_INVENTORY_ADJ("AW", "Warehouse Inventory Adjustment Advice (947)"),
+  /** U.S. Customs Events Advisory Details (353) — X12 code "AX". */
   CUSTOMS_EVENTS_ADVISORY("AX", "U.S. Customs Events Advisory Details (353)"),
+  /** U.S. Customs Automated Manifest Archive Status (354) — X12 code "AY". */
   CUSTOMS_MANIFEST_ARCHIVE("AY", "U.S. Customs Automated Manifest Archive Status (354)"),
+  /** U.S. Customs Acceptance/Rejection (355) — X12 code "AZ". */
   CUSTOMS_ACCEPTANCE("AZ", "U.S. Customs Acceptance/Rejection (355)"),
+  /** U.S. Customs Permit to Transfer Request (356) — X12 code "BA". */
   CUSTOMS_PERMIT_TRANSFER("BA", "U.S. Customs Permit to Transfer Request (356)"),
+  /** U.S. Customs In-Bond Information (357) — X12 code "BB". */
   CUSTOMS_IN_BOND("BB", "U.S. Customs In-Bond Information (357)"),
+  /** Business Credit Report (155) — X12 code "BC". */
   BUSINESS_CREDIT_REPORT("BC", "Business Credit Report (155)"),
+  /** U.S. Customs Consist Information (358) — X12 code "BD". */
   CUSTOMS_CONSIST_INFO("BD", "U.S. Customs Consist Information (358)"),
+  /** Benefit Enrollment and Maintenance (834) — X12 code "BE". */
   BENEFIT_ENROLLMENT("BE", "Benefit Enrollment and Maintenance (834)"),
+  /** Business Entity Filings (105) — X12 code "BF". */
   BUSINESS_ENTITY_FILINGS("BF", "Business Entity Filings (105)"),
+  /** Motor Carrier Bill of Lading (211) — X12 code "BL". */
   MOTOR_CARRIER_BILL_LADING("BL", "Motor Carrier Bill of Lading (211)"),
+  /** Shipment and Billing Notice (857) — X12 code "BS". */
   SHIPMENT_BILLING_NOTICE("BS", "Shipment and Billing Notice (857)"),
+  /** Purchase Order Change Acknowledgment/Request - Seller Initiated (865) — X12 code "CA". */
   PURCHASE_ORDER_CHANGE(
       "CA", "Purchase Order Change Acknowledgment/Request - Seller Initiated (865)"),
+  /** Unemployment Insurance Tax Claim or Charge Information (153) — X12 code "CB". */
   UNEMPLOYMENT_INSURANCE("CB", "Unemployment Insurance Tax Claim or Charge Information (153)"),
+  /** Clauses and Provisions (504) — X12 code "CC". */
   CLAUSES_PROVISIONS("CC", "Clauses and Provisions (504)"),
+  /** Credit/Debit Adjustment (812) — X12 code "CD". */
   CREDIT_DEBIT_ADJUSTMENT("CD", "Credit/Debit Adjustment (812)"),
+  /** Cartage Work Assignment (222) — X12 code "CE". */
   CARTAGE_WORK_ASSIGNMENT("CE", "Cartage Work Assignment (222)"),
+  /** Corporate Financial Adjustment Information (844 and 849) — X12 code "CF". */
   CORPORATE_FINANCIAL("CF", "Corporate Financial Adjustment Information (844 and 849)"),
+  /** Car Handling Information (420) — X12 code "CH". */
   CAR_HANDLING_INFO("CH", "Car Handling Information (420)"),
+  /** Consolidated Service Invoice/Statement (811) — X12 code "CI". */
   CONSOLIDATED_INVOICE("CI", "Consolidated Service Invoice/Statement (811)"),
+  /** Manufacturer Coupon Family Code Structure (877) — X12 code "CJ". */
   MANUFACTURER_COUPON_FAMILY("CJ", "Manufacturer Coupon Family Code Structure (877)"),
+  /** Manufacturer Coupon Redemption Detail (881) — X12 code "CK". */
   MANUFACTURER_COUPON_REDEMPTION("CK", "Manufacturer Coupon Redemption Detail (881)"),
+  /** Election Campaign and Lobbyist Reporting (113) — X12 code "CL". */
   ELECTION_CAMPAIGN("CL", "Election Campaign and Lobbyist Reporting (113)"),
+  /** Component Parts Content (871) — X12 code "CM". */
   COMPONENT_PARTS("CM", "Component Parts Content (871)"),
+  /** Coupon Notification (887) — X12 code "CN". */
   COUPON_NOTIFICATION("CN", "Coupon Notification (887)"),
+  /** Cooperative Advertising Agreements (290) — X12 code "CO". */
   COOPERATIVE_ADVERTISING("CO", "Cooperative Advertising Agreements (290)"),
+  /** Electronic Proposal Information (251, 805) — X12 code "CP". */
   ELECTRONIC_PROPOSAL("CP", "Electronic Proposal Information (251, 805)"),
+  /** Commodity Movement Services Response (874) — X12 code "CQ". */
   COMMODITY_MOVEMENT_RESPONSE("CQ", "Commodity Movement Services Response (874)"),
+  /** Rail Carhire Settlements (414) — X12 code "CR". */
   RAIL_CARHIRE_SETTLEMENTS("CR", "Rail Carhire Settlements (414)"),
+  /** Cryptographic Service Message (815) — X12 code "CS". */
   CRYPTOGRAPHIC_SERVICE("CS", "Cryptographic Service Message (815)"),
+  /** Application Control Totals (831) — X12 code "CT". */
   APPLICATION_CONTROL("CT", "Application Control Totals (831)"),
+  /** Commodity Movement Services (873) — X12 code "CU". */
   COMMODITY_MOVEMENT_SERVICE("CU", "Commodity Movement Services (873)"),
+  /** Commercial Vehicle Safety and Credentials Information Exchange (285) — X12 code "CV". */
   COMMERCIAL_VEHICLE_SAFETY(
       "CV", "Commercial Vehicle Safety and Credentials Information Exchange (285)"),
+  /** Educational Institution Record (133) — X12 code "CW". */
   EDUCATIONAL_INSTITUTION_RECORD("CW", "Educational Institution Record (133)"),
+  /** Contract Completion Status (567) — X12 code "D3". */
   CONTRACT_COMPLETION("D3", "Contract Completion Status (567)"),
+  /** Contract Abstract (561) — X12 code "D4". */
   CONTRACT_ABSTRACT("D4", "Contract Abstract (561)"),
+  /** Contract Payment Management Report (568) — X12 code "D5". */
   CONTRACT_PAYMENT("D5", "Contract Payment Management Report (568)"),
+  /** Debit Authorization (828) — X12 code "DA". */
   DEBIT_AUTHORIZATION("DA", "Debit Authorization (828)"),
+  /** Shipment Delivery Discrepancy Information (854) — X12 code "DD". */
   SHIPMENT_DELIVERY_DISCREPANCY("DD", "Shipment Delivery Discrepancy Information (854)"),
+  /** Market Development Fund Allocation (883) — X12 code "DF". */
   MARKET_DEVELOPMENT_FUND("DF", "Market Development Fund Allocation (883)"),
+  /** Dealer Information (128) — X12 code "DI". */
   DEALER_INFORMATION("DI", "Dealer Information (128)"),
+  /** Equipment Order (422) — X12 code "DM". */
   EQUIPMENT_ORDER("DM", "Equipment Order (422)"),
+  /** Data Status Tracking (242) — X12 code "DS". */
   DATA_STATUS_TRACKING("DS", "Data Status Tracking (242)"),
+  /** Direct Exchange Delivery and Return Information (894, 895) — X12 code "DX". */
   DIRECT_EXCHANGE("DX", "Direct Exchange Delivery and Return Information (894, 895)"),
+  /** Educational Course Inventory (188) — X12 code "EC". */
   EDUCATIONAL_COURSE("EC", "Educational Course Inventory (188)"),
+  /** Student Educational Record (Transcript) (130) — X12 code "ED". */
   STUDENT_EDUCATIONAL_RECORD("ED", "Student Educational Record (Transcript) (130)"),
+  /** Railroad Equipment Inquiry or Advice (456) — X12 code "EI". */
   RAILROAD_EQUIPMENT_INQUIRY("EI", "Railroad Equipment Inquiry or Advice (456)"),
+  /** Equipment Inspection — X12 code "EN". */
   EQUIPMENT_INSPECTION("EN", "Equipment Inspection"),
+  /** Environmental Compliance Reporting (179) — X12 code "EP". */
   ENVIRONMENTAL_COMPLIANCE("EP", "Environmental Compliance Reporting (179)"),
+  /** Revenue Receipts Statement (170) — X12 code "ER". */
   REVENUE_RECEIPTS("ER", "Revenue Receipts Statement (170)"),
+  /** Notice of Employment Status (540) — X12 code "ES". */
   EMPLOYMENT_STATUS("ES", "Notice of Employment Status (540)"),
+  /** Railroad Event Report (451) — X12 code "EV". */
   RAILROAD_EVENT_REPORT("EV", "Railroad Event Report (451)"),
+  /** Excavation Communication (620) — X12 code "EX". */
   EXCAVATION_COMMUNICATION("EX", "Excavation Communication (620)"),
+  /** Functional or Implementation Acknowledgment Transaction Sets (997, 999) — X12 code "FA". */
   FUNCTIONAL_ACKNOWLEDGMENT(
       "FA", "Functional or Implementation Acknowledgment Transaction Sets (997, 999)"),
+  /** Freight Invoice (859) — X12 code "FB". */
   FREIGHT_INVOICE("FB", "Freight Invoice (859)"),
+  /** Court and Law Enforcement Information (175, 176) — X12 code "FC". */
   COURT_LAW_ENFORCEMENT("FC", "Court and Law Enforcement Information (175, 176)"),
+  /** Motor Carrier Loading and Route Guide (217) — X12 code "FG". */
   MOTOR_CARRIER_LOADING("FG", "Motor Carrier Loading and Route Guide (217)"),
+  /** Financial Reporting (821, 827) — X12 code "FR". */
   FINANCIAL_REPORTING("FR", "Financial Reporting (821, 827)"),
+  /** File Transfer (996) — X12 code "FT". */
   FILE_TRANSFER("FT", "File Transfer (996)"),
+  /** Damage Claim Transaction Sets (920, 924, 925, 926) — X12 code "GC". */
   DAMAGE_CLAIM("GC", "Damage Claim Transaction Sets (920, 924, 925, 926)"),
+  /** General Request, Response or Confirmation (814) — X12 code "GE". */
   GENERAL_REQUEST("GE", "General Request, Response or Confirmation (814)"),
+  /** Response to a Load Tender (990) — X12 code "GF". */
   RESPONSE_TO_LOAD_TENDER("GF", "Response to a Load Tender (990)"),
+  /** Intermodal Group Loading Plan (715) — X12 code "GL". */
   INTERMODAL_GROUP_LOADING("GL", "Intermodal Group Loading Plan (715)"),
+  /** Grocery Products Invoice (880) — X12 code "GP". */
   GROCERY_PRODUCTS_INVOICE("GP", "Grocery Products Invoice (880)"),
+  /** Statistical Government Information (152) — X12 code "GR". */
   STATISTICAL_GOVERNMENT("GR", "Statistical Government Information (152)"),
+  /** Grant or Assistance Application (194) — X12 code "GT". */
   GRANT_ASSISTANCE("GT", "Grant or Assistance Application (194)"),
+  /** Eligibility, Coverage or Benefit Information (271) — X12 code "HB". */
   ELIGIBILITY_BENEFIT_INFO("HB", "Eligibility, Coverage or Benefit Information (271)"),
+  /** Health Care Claim (837) — X12 code "HC". */
   HEALTH_CARE_CLAIM("HC", "Health Care Claim (837)"),
+  /** Health Care Services Review Information (278) — X12 code "HI". */
   HEALTH_CARE_SERVICES_REVIEW("HI", "Health Care Services Review Information (278)"),
+  /** Health Care Information Status Notification (277) — X12 code "HN". */
   HEALTH_CARE_INFO_STATUS("HN", "Health Care Information Status Notification (277)"),
+  /** Health Care Claim Payment/Advice (835) — X12 code "HP". */
   HEALTH_CARE_CLAIM_PAYMENT("HP", "Health Care Claim Payment/Advice (835)"),
+  /** Health Care Claim Status Request (276) — X12 code "HR". */
   HEALTH_CARE_CLAIM_STATUS("HR", "Health Care Claim Status Request (276)"),
+  /** Eligibility, Coverage or Benefit Inquiry (270) — X12 code "HS". */
   ELIGIBILITY_INQUIRY("HS", "Eligibility, Coverage or Benefit Inquiry (270)"),
+  /** Human Resource Information (132) — X12 code "HU". */
   HUMAN_RESOURCE_INFO("HU", "Human Resource Information (132)"),
+  /** Health Care Benefit Coordination Verification (269) — X12 code "HV". */
   HEALTH_CARE_BENEFIT_COORDINATION("HV", "Health Care Benefit Coordination Verification (269)"),
+  /** Air Freight Details and Invoice (110, 980) — X12 code "IA". */
   AIR_FREIGHT_DETAILS("IA", "Air Freight Details and Invoice (110, 980)"),
+  /** Inventory Inquiry/Advice (846) — X12 code "IB". */
   INVENTORY_INQUIRY("IB", "Inventory Inquiry/Advice (846)"),
+  /** Rail Advance Interchange Consist (418) — X12 code "IC". */
   RAIL_ADVANCE_INTERCHANGE("IC", "Rail Advance Interchange Consist (418)"),
+  /** Insurance/Annuity Application Status (273) — X12 code "ID". */
   INSURANCE_APPLICATION_STATUS("ID", "Insurance/Annuity Application Status (273)"),
+  /** Insurance Producer Administration (252) — X12 code "IE". */
   INSURANCE_PRODUCER_ADMIN("IE", "Insurance Producer Administration (252)"),
+  /** Individual Insurance Policy and Client Information (111) — X12 code "IF". */
   INDIVIDUAL_INSURANCE_POLICY("IF", "Individual Insurance Policy and Client Information (111)"),
+  /** Direct Store Delivery Summary Information (882) — X12 code "IG". */
   DIRECT_STORE_DELIVERY("IG", "Direct Store Delivery Summary Information (882)"),
+  /** Commercial Vehicle Safety Reports (284) — X12 code "IH". */
   COMMERCIAL_VEHICLE_SAFETY_REPORTS("IH", "Commercial Vehicle Safety Reports (284)"),
+  /** Report of Injury, Illness or Incident (148) — X12 code "IJ". */
   INJURY_ILLNESS_REPORT("IJ", "Report of Injury, Illness or Incident (148)"),
+  /** Motor Carrier Freight Details and Invoice (210, 980) — X12 code "IM". */
   MOTOR_CARRIER_FREIGHT("IM", "Motor Carrier Freight Details and Invoice (210, 980)"),
+  /** Invoice Information (810) — X12 code "IN". */
   INVOICE_INFORMATION("IN", "Invoice Information (810)"),
+  /** Ocean Shipment Billing Details (310, 312, 980) — X12 code "IO". */
   OCEAN_SHIPMENT_BILLING("IO", "Ocean Shipment Billing Details (310, 312, 980)"),
+  /** Rail Carrier Freight Details and Invoice (410, 980) — X12 code "IR". */
   RAIL_CARRIER_FREIGHT("IR", "Rail Carrier Freight Details and Invoice (410, 980)"),
+  /** Estimated Time of Arrival and Car Scheduling (421) — X12 code "IS". */
   ESTIMATED_TIME_ARRIVAL("IS", "Estimated Time of Arrival and Car Scheduling (421)"),
+  /** Joint Interest Billing and Operating Expense Statement (819) — X12 code "JB". */
   JOINT_INTEREST_BILLING("JB", "Joint Interest Billing and Operating Expense Statement (819)"),
+  /** Commercial Vehicle Credentials (286) — X12 code "KM". */
   COMMERCIAL_VEHICLE_CREDENTIALS("KM", "Commercial Vehicle Credentials (286)"),
+  /** Federal Communications Commission (FCC) License Application (195) — X12 code "LA". */
   FCC_LICENSE_APPLICATION(
       "LA", "Federal Communications Commission (FCC) License Application (195)"),
+  /** Lockbox (823) — X12 code "LB". */
   LOCKBOX("LB", "Lockbox (823)"),
+  /** Locomotive Information (436) — X12 code "LI". */
   LOCOMOTIVE_INFORMATION("LI", "Locomotive Information (436)"),
+  /** Property and Casualty Loss Notification (272) — X12 code "LN". */
   PROPERTY_CASUALTY_LOSS("LN", "Property and Casualty Loss Notification (272)"),
+  /** Logistics Reassignment (536) — X12 code "LR". */
   LOGISTICS_REASSIGNMENT("LR", "Logistics Reassignment (536)"),
+  /** Asset Schedule (851) — X12 code "LS". */
   ASSET_SCHEDULE("LS", "Asset Schedule (851)"),
+  /** Student Loan Transfer and Status Verification (144) — X12 code "LT". */
   STUDENT_LOAN_TRANSFER("LT", "Student Loan Transfer and Status Verification (144)"),
+  /** Motor Carrier Summary Freight Bill Manifest (224) — X12 code "MA". */
   MOTOR_CARRIER_SUMMARY("MA", "Motor Carrier Summary Freight Bill Manifest (224)"),
+  /** Request for Motor Carrier Rate Proposal (107) — X12 code "MC". */
   REQUEST_MOTOR_CARRIER_RATE("MC", "Request for Motor Carrier Rate Proposal (107)"),
+  /** Department of Defense Inventory Management (527) — X12 code "MD". */
   DOD_INVENTORY_MANAGEMENT("MD", "Department of Defense Inventory Management (527)"),
+  /** Mortgage Origination (198, 200, 201, 245, 261, 262, 263, 833, 872) — X12 code "ME". */
   MORTGAGE_ORIGINATION("ME", "Mortgage Origination (198, 200, 201, 245, 261, 262, 263, 833, 872)"),
+  /** Market Development Fund Settlement (884) — X12 code "MF". */
   MARKET_DEVELOPMENT_FUND_SETTLEMENT("MF", "Market Development Fund Settlement (884)"),
+  /** Mortgage Servicing Transaction Sets (203, 206, 259, 260, 264, 266) — X12 code "MG". */
   MORTGAGE_SERVICING("MG", "Mortgage Servicing Transaction Sets (203, 206, 259, 260, 264, 266)"),
+  /** Motor Carrier Rate Proposal (106) — X12 code "MH". */
   MOTOR_CARRIER_RATE_PROPOSAL("MH", "Motor Carrier Rate Proposal (106)"),
+  /** Motor Carrier Shipment Status Inquiry (213) — X12 code "MI". */
   MOTOR_CARRIER_SHIPMENT_STATUS("MI", "Motor Carrier Shipment Status Inquiry (213)"),
+  /** Secondary Mortgage Market Loan Delivery (202) — X12 code "MJ". */
   SECONDARY_MORTGAGE_MARKET("MJ", "Secondary Mortgage Market Loan Delivery (202)"),
+  /** Response to a Motor Carrier Rate Proposal (108) — X12 code "MK". */
   RESPONSE_MOTOR_CARRIER_RATE("MK", "Response to a Motor Carrier Rate Proposal (108)"),
+  /** Medical Event Reporting (500) — X12 code "MM". */
   MEDICAL_EVENT_REPORTING("MM", "Medical Event Reporting (500)"),
+  /** Mortgage Note (205) — X12 code "MN". */
   MORTGAGE_NOTE("MN", "Mortgage Note (205)"),
+  /** Maintenance Service Order (650) — X12 code "MO". */
   MAINTENANCE_SERVICE_ORDER("MO", "Maintenance Service Order (650)"),
+  /** Motion Picture Booking Confirmation (159) — X12 code "MP". */
   MOTION_PICTURE_BOOKING("MP", "Motion Picture Booking Confirmation (159)"),
+  /** Consolidators Freight Bill and Invoice (223) — X12 code "MQ". */
   CONSOLIDATORS_FREIGHT_BILL("MQ", "Consolidators Freight Bill and Invoice (223)"),
+  /** Multilevel Railcar Load Details (125) — X12 code "MR". */
   MULTILEVEL_RAILCAR_LOAD("MR", "Multilevel Railcar Load Details (125)"),
+  /** Material Safety Data Sheet (848) — X12 code "MS". */
   MATERIAL_SAFETY_DATA("MS", "Material Safety Data Sheet (848)"),
+  /** Electronic Form Structure (868) — X12 code "MT". */
   ELECTRONIC_FORM_STRUCTURE("MT", "Electronic Form Structure (868)"),
+  /** Material Obligation Validation (517) — X12 code "MV". */
   MATERIAL_OBLIGATION_VALIDATION("MV", "Material Obligation Validation (517)"),
+  /** Rail Waybill Response (427) — X12 code "MW". */
   RAIL_WAYBILL_RESPONSE("MW", "Rail Waybill Response (427)"),
+  /** Material Claim (847) — X12 code "MX". */
   MATERIAL_CLAIM("MX", "Material Claim (847)"),
+  /** Response to a Cartage Work Assignment (225) — X12 code "MY". */
   RESPONSE_TO_CARTAGE("MY", "Response to a Cartage Work Assignment (225)"),
+  /** Motor Carrier Package Status (240) — X12 code "MZ". */
   MOTOR_CARRIER_PACKAGE_STATUS("MZ", "Motor Carrier Package Status (240)"),
+  /** Nonconformance Report (842) — X12 code "NC". */
   NONCONFORMANCE_REPORT("NC", "Nonconformance Report (842)"),
+  /** Name and Address Lists (101) — X12 code "NL". */
   NAME_AND_ADDRESS_LISTS("NL", "Name and Address Lists (101)"),
+  /** Notice of Power of Attorney (157) — X12 code "NP". */
   NOTICE_OF_POWER_OF_ATTORNEY("NP", "Notice of Power of Attorney (157)"),
+  /** Secured Receipt or Acknowledgment (993) — X12 code "NR". */
   SECURED_RECEIPT("NR", "Secured Receipt or Acknowledgment (993)"),
+  /** Notice of Tax Adjustment or Assessment (149) — X12 code "NT". */
   NOTICE_OF_TAX_ADJUSTMENT("NT", "Notice of Tax Adjustment or Assessment (149)"),
+  /** Cargo Insurance Advice of Shipment (362) — X12 code "OC". */
   CARGO_INSURANCE_ADVICE("OC", "Cargo Insurance Advice of Shipment (362)"),
+  /** Order Group - Grocery (875, 876) — X12 code "OG". */
   ORDER_GROUP_GROCERY("OG", "Order Group - Grocery (875, 876)"),
+  /** Organizational Relationships (816) — X12 code "OR". */
   ORGANIZATIONAL_RELATIONSHIPS("OR", "Organizational Relationships (816)"),
+  /** Warehouse Shipping Order (940) — X12 code "OW". */
   WAREHOUSE_SHIPPING_ORDER("OW", "Warehouse Shipping Order (940)"),
+  /** Price Authorization Acknowledgment/Status (845) — X12 code "PA". */
   PRICE_AUTHORIZATION("PA", "Price Authorization Acknowledgment/Status (845)"),
+  /** Railroad Parameter Trace Registration (455) — X12 code "PB". */
   RAILROAD_PARAMETER_TRACE("PB", "Railroad Parameter Trace Registration (455)"),
+  /** Purchase Order Change Request - Buyer Initiated (860) — X12 code "PC". */
   PURCHASE_ORDER_CHANGE_REQUEST("PC", "Purchase Order Change Request - Buyer Initiated (860)"),
+  /** Product Activity Data (852) — X12 code "PD". */
   PRODUCT_ACTIVITY_DATA("PD", "Product Activity Data (852)"),
+  /** Periodic Compensation (256) — X12 code "PE". */
   PERIODIC_COMPENSATION("PE", "Periodic Compensation (256)"),
+  /** Annuity Activity (268) — X12 code "PF". */
   ANNUITY_ACTIVITY("PF", "Annuity Activity (268)"),
+  /** Insurance Plan Description (100) — X12 code "PG". */
   INSURANCE_PLAN_DESCRIPTION("PG", "Insurance Plan Description (100)"),
+  /** Pricing History (503) — X12 code "PH". */
   PRICING_HISTORY("PH", "Pricing History (503)"),
+  /** Patient Information (275) — X12 code "PI". */
   PATIENT_INFORMATION("PI", "Patient Information (275)"),
+  /** Project Schedule Reporting (806) — X12 code "PJ". */
   PROJECT_SCHEDULE("PJ", "Project Schedule Reporting (806)"),
+  /** Project Cost Reporting (839) and Contractor Cost Data Reporting (196) — X12 code "PK". */
   PROJECT_COST_REPORTING(
       "PK", "Project Cost Reporting (839) and Contractor Cost Data Reporting (196)"),
+  /** Railroad Problem Log Inquiry or Advice (452) — X12 code "PL". */
   RAILROAD_PROBLEM_LOG("PL", "Railroad Problem Log Inquiry or Advice (452)"),
+  /** Product Source Information (244) — X12 code "PN". */
   PRODUCT_SOURCE_INFORMATION("PN", "Product Source Information (244)"),
+  /** Purchase Order (850) — X12 code "PO". */
   PURCHASE_ORDER("PO", "Purchase Order (850)"),
+  /** Property Damage Report (112) — X12 code "PQ". */
   PROPERTY_DAMAGE_REPORT("PQ", "Property Damage Report (112)"),
+  /** Purchase Order Acknowledgment (855) — X12 code "PR". */
   PURCHASE_ORDER_ACKNOWLEDGMENT("PR", "Purchase Order Acknowledgment (855)"),
+  /** Planning Schedule with Release Capability (830) — X12 code "PS". */
   PLANNING_SCHEDULE("PS", "Planning Schedule with Release Capability (830)"),
+  /** Product Transfer and Resale Report (867) — X12 code "PT". */
   PRODUCT_TRANSFER("PT", "Product Transfer and Resale Report (867)"),
+  /** Motor Carrier Shipment Pickup Notification (216) — X12 code "PU". */
   MOTOR_CARRIER_SHIPMENT_PICKUP("PU", "Motor Carrier Shipment Pickup Notification (216)"),
+  /** Purchase Order Shipment Management Document (250) — X12 code "PV". */
   PURCHASE_ORDER_SHIPMENT("PV", "Purchase Order Shipment Management Document (250)"),
+  /** Healthcare Provider Information (274) — X12 code "PW". */
   HEALTHCARE_PROVIDER_INFO("PW", "Healthcare Provider Information (274)"),
+  /** Payment Cancellation Request (829) — X12 code "PY". */
   PAYMENT_CANCELLATION_REQUEST("PY", "Payment Cancellation Request (829)"),
+  /** Product Information (878, 879, 888, 889, 896) — X12 code "QG". */
   PRODUCT_INFORMATION("QG", "Product Information (878, 879, 888, 889, 896)"),
+  /** Transportation Carrier Shipment Status Message (214) — X12 code "QM". */
   TRANSPORTATION_CARRIER_SHIPMENT("QM", "Transportation Carrier Shipment Status Message (214)"),
+  /** Ocean Shipment Status Information (313, 315) — X12 code "QO". */
   OCEAN_SHIPMENT_STATUS("QO", "Ocean Shipment Status Information (313, 315)"),
+  /** Payment Order/Remittance Advice (820) — X12 code "RA". */
   PAYMENT_ORDER("RA", "Payment Order/Remittance Advice (820)"),
+  /** Railroad Clearance (470) — X12 code "RB". */
   RAILROAD_CLEARANCE("RB", "Railroad Clearance (470)"),
+  /** Receiving Advice/Acceptance Certificate (861) — X12 code "RC". */
   RECEIVING_ADVICE("RC", "Receiving Advice/Acceptance Certificate (861)"),
+  /** Royalty Regulatory Report (185) — X12 code "RD". */
   ROYALTY_REGULATORY_REPORT("RD", "Royalty Regulatory Report (185)"),
+  /** Warehouse Stock Receipt Advice (944) — X12 code "RE". */
   WAREHOUSE_STOCK_RECEIPT("RE", "Warehouse Stock Receipt Advice (944)"),
+  /** Request for Routing Instructions (753) — X12 code "RF". */
   REQUEST_FOR_ROUTING("RF", "Request for Routing Instructions (753)"),
+  /** Routing Instructions (754) — X12 code "RG". */
   ROUTING_INSTRUCTIONS("RG", "Routing Instructions (754)"),
+  /** Railroad Reciprocal Switch File (433) — X12 code "RH". */
   RAILROAD_RECIPROCAL_SWITCH("RH", "Railroad Reciprocal Switch File (433)"),
+  /** Routing and Carrier Instruction (853) — X12 code "RI". */
   ROUTING_AND_CARRIER("RI", "Routing and Carrier Instruction (853)"),
+  /** Railroad Mark Register Update Activity (434) — X12 code "RJ". */
   RAILROAD_MARK_REGISTER("RJ", "Railroad Mark Register Update Activity (434)"),
+  /** Standard Transportation Commodity Code Master (435) — X12 code "RK". */
   STANDARD_TRANSPORTATION_CODE("RK", "Standard Transportation Commodity Code Master (435)"),
+  /** Rail Industrial Switch List (423) — X12 code "RL". */
   RAIL_INDUSTRIAL_SWITCH("RL", "Rail Industrial Switch List (423)"),
+  /** Railroad Station Master File (431) — X12 code "RM". */
   RAILROAD_STATION_MASTER("RM", "Railroad Station Master File (431)"),
+  /** Requisition Transaction (511) — X12 code "RN". */
   REQUISITION_TRANSACTION("RN", "Requisition Transaction (511)"),
+  /** Ocean Booking Information (300, 301, 303) — X12 code "RO". */
   OCEAN_BOOKING_INFORMATION("RO", "Ocean Booking Information (300, 301, 303)"),
+  /** Commission Sales Report (818) — X12 code "RP". */
   COMMISSION_SALES_REPORT("RP", "Commission Sales Report (818)"),
+  /** Request for Quotation (840) and Procurement Notices (836) — X12 code "RQ". */
   REQUEST_FOR_QUOTATION("RQ", "Request for Quotation (840) and Procurement Notices (836)"),
+  /** Response to Request For Quotation (843) — X12 code "RR". */
   RESPONSE_TO_REQUEST_FOR_QUOTATION("RR", "Response to Request For Quotation (843)"),
+  /** Order Status Information (869, 870) — X12 code "RS". */
   ORDER_STATUS_INFORMATION("RS", "Order Status Information (869, 870)"),
+  /** Report of Test Results (863) — X12 code "RT". */
   TEST_RESULTS_REPORT("RT", "Report of Test Results (863)"),
+  /** Railroad Retirement Activity (429) — X12 code "RU". */
   RAILROAD_RETIREMENT("RU", "Railroad Retirement Activity (429)"),
+  /** Railroad Junctions and Interchanges Activity (437) — X12 code "RV". */
   RAILROAD_JUNCTIONS("RV", "Railroad Junctions and Interchanges Activity (437)"),
+  /** Rail Revenue Waybill (426) — X12 code "RW". */
   RAIL_REVENUE_WAYBILL("RW", "Rail Revenue Waybill (426)"),
+  /** Rail Deprescription (432) — X12 code "RX". */
   RAIL_DEPRESCRIPTION("RX", "Rail Deprescription (432)"),
+  /** Request for Student Educational Record (Transcript) (146) — X12 code "RY". */
   REQUEST_STUDENT_RECORD("RY", "Request for Student Educational Record (Transcript) (146)"),
+  /** Response to Request for Student Educational Record (Transcript) (147) — X12 code "RZ". */
   RESPONSE_STUDENT_RECORD(
       "RZ", "Response to Request for Student Educational Record (Transcript) (147)"),
+  /** Air Shipment Information (104) — X12 code "SA". */
   AIR_SHIPMENT_INFORMATION("SA", "Air Shipment Information (104)"),
+  /** Rail Carrier Services Settlement (424) — X12 code "SB". */
   RAIL_CARRIER_SERVICES("SB", "Rail Carrier Services Settlement (424)"),
+  /** Price/Sales Catalog (832) — X12 code "SC". */
   PRICE_SALES_CATALOG("SC", "Price/Sales Catalog (832)"),
+  /** Student Loan Pre-Claims and Claims (191) — X12 code "SD". */
   STUDENT_LOAN_CLAIMS("SD", "Student Loan Pre-Claims and Claims (191)"),
+  /** Shipper's Export Declaration (601) — X12 code "SE". */
   SHIPPERS_EXPORT_DECLARATION("SE", "Shipper's Export Declaration (601)"),
+  /** Ship Notice/Manifest (856) — X12 code "SH". */
   SHIP_NOTICE_MANIFEST("SH", "Ship Notice/Manifest (856)"),
+  /** Shipment Information (858) — X12 code "SI". */
   SHIPMENT_INFORMATION("SI", "Shipment Information (858)"),
+  /** Transportation Automatic Equipment Identification (160) — X12 code "SJ". */
   TRANSPORTATION_EQUIPMENT_ID("SJ", "Transportation Automatic Equipment Identification (160)"),
+  /** Student Aid Origination Record (135, 139) — X12 code "SL". */
   STUDENT_AID_ORIGINATION("SL", "Student Aid Origination Record (135, 139)"),
+  /** Motor Carrier Load Tender (204) — X12 code "SM". */
   MOTOR_CARRIER_LOAD_TENDER("SM", "Motor Carrier Load Tender (204)"),
+  /** Rail Route File Maintenance (475) — X12 code "SN". */
   RAIL_ROUTE_FILE("SN", "Rail Route File Maintenance (475)"),
+  /**
+   * Ocean Shipment Information (304, 309, 311, 317, 319, 322, 323, 324, 325, 326, 350, 352, 353,
+   * 354, 355, 356, 357, 358, 361) — X12 code "SO".
+   */
   OCEAN_SHIPMENT_INFORMATION(
       "SO",
       "Ocean Shipment Information (304, 309, 311, 317, 319, 322, 323, 324, 325, 326, 350, 352, 353, 354, 355, 356, 357, 358, 361)"),
+  /** Specifications/Technical Information (841) — X12 code "SP". */
   SPECIFICATIONS_TECHNICAL("SP", "Specifications/Technical Information (841)"),
+  /** Production Sequence (866) — X12 code "SQ". */
   PRODUCTION_SEQUENCE("SQ", "Production Sequence (866)"),
+  /** Rail Carrier Shipment Information (404, 419) — X12 code "SR". */
   RAIL_CARRIER_SHIPMENT("SR", "Rail Carrier Shipment Information (404, 419)"),
+  /** Shipping Schedule (862) — X12 code "SS". */
   SHIPPING_SCHEDULE("SS", "Shipping Schedule (862)"),
+  /** Railroad Service Commitment Advice (453) — X12 code "ST". */
   RAILROAD_SERVICE_COMMITMENT("ST", "Railroad Service Commitment Advice (453)"),
+  /** Account Assignment/Inquiry and Service/Status (248) — X12 code "SU". */
   ACCOUNT_ASSIGNMENT("SU", "Account Assignment/Inquiry and Service/Status (248)"),
+  /** Student Enrollment Verification (190) — X12 code "SV". */
   STUDENT_ENROLLMENT_VERIFICATION("SV", "Student Enrollment Verification (190)"),
+  /** Warehouse Shipping Advice (945) — X12 code "SW". */
   WAREHOUSE_SHIPPING_ADVICE("SW", "Warehouse Shipping Advice (945)"),
+  /** Electronic Filing of Tax Return Data Acknowledgment (151) — X12 code "TA". */
   TAX_RETURN_ACKNOWLEDGMENT("TA", "Electronic Filing of Tax Return Data Acknowledgment (151)"),
+  /** Trailer or Container Repair Billing (412) — X12 code "TB". */
   TRAILER_CONTAINER_REPAIR("TB", "Trailer or Container Repair Billing (412)"),
+  /** Trading Partner Profile (838) — X12 code "TD". */
   TRADING_PARTNER_PROFILE("TD", "Trading Partner Profile (838)"),
+  /** Tax or Fee Exemption Certification (283) — X12 code "TE". */
   TAX_FEE_EXEMPTION("TE", "Tax or Fee Exemption Certification (283)"),
+  /** Electronic Filing of Tax Return Data (813) — X12 code "TF". */
   ELECTRONIC_TAX_FILING("TF", "Electronic Filing of Tax Return Data (813)"),
+  /** Tax Information Exchange (826) — X12 code "TI". */
   TAX_INFORMATION_EXCHANGE("TI", "Tax Information Exchange (826)"),
+  /** Tax Jurisdiction Sourcing (158) — X12 code "TJ". */
   TAX_JURISDICTION_SOURCING("TJ", "Tax Jurisdiction Sourcing (158)"),
+  /** Motor Carrier Delivery Trailer Manifest (212) — X12 code "TM". */
   MOTOR_CARRIER_DELIVERY("TM", "Motor Carrier Delivery Trailer Manifest (212)"),
+  /** Tax Rate Notification (150) — X12 code "TN". */
   TAX_RATE_NOTIFICATION("TN", "Tax Rate Notification (150)"),
+  /** Real Estate Title Services (197, 199, 265, 485, 486) — X12 code "TO". */
   REAL_ESTATE_TITLE("TO", "Real Estate Title Services (197, 199, 265, 485, 486)"),
+  /** Rail Rate Transactions (460, 463, 466, 468, 485, 486, 490, 492, 494) — X12 code "TP". */
   RAIL_RATE_TRANSACTIONS(
       "TP", "Rail Rate Transactions (460, 463, 466, 468, 485, 486, 490, 492, 494)"),
+  /** Train Sheet (161) — X12 code "TR". */
   TRAIN_SHEET("TR", "Train Sheet (161)"),
+  /** Transportation Services Tender (602) — X12 code "TS". */
   TRANSPORTATION_SERVICES_TENDER("TS", "Transportation Services Tender (602)"),
+  /** Educational Testing and Prospect Request and Report (138) — X12 code "TT". */
   EDUCATIONAL_TESTING("TT", "Educational Testing and Prospect Request and Report (138)"),
+  /** Trailer Usage Report (227) — X12 code "TU". */
   TRAILER_USAGE_REPORT("TU", "Trailer Usage Report (227)"),
+  /** Text Message (864) — X12 code "TX". */
   TEXT_MESSAGE("TX", "Text Message (864)"),
+  /** Retail Account Characteristics (885) — X12 code "UA". */
   RETAIL_ACCOUNT_CHARACTERISTICS("UA", "Retail Account Characteristics (885)"),
+  /** Customer Call Reporting (886) — X12 code "UB". */
   CUSTOMER_CALL_REPORTING("UB", "Customer Call Reporting (886)"),
+  /** Secured Interest Filing (154) — X12 code "UC". */
   SECURED_INTEREST_FILING("UC", "Secured Interest Filing (154)"),
+  /** Deduction Research Report (891) — X12 code "UD". */
   DEDUCTION_RESEARCH_REPORT("UD", "Deduction Research Report (891)"),
+  /** Underwriting Information Services (255) — X12 code "UI". */
   UNDERWRITING_INFORMATION("UI", "Underwriting Information Services (255)"),
+  /** Motor Carrier Pickup Manifest (215) — X12 code "UP". */
   MOTOR_CARRIER_PICKUP_MANIFEST("UP", "Motor Carrier Pickup Manifest (215)"),
+  /** Insurance Underwriting Requirements Reporting (186) — X12 code "UW". */
   INSURANCE_UNDERWRITING("UW", "Insurance Underwriting Requirements Reporting (186)"),
+  /** Vehicle Application Advice (126) — X12 code "VA". */
   VEHICLE_APPLICATION_ADVICE("VA", "Vehicle Application Advice (126)"),
+  /** Vehicle Baying Order (127) — X12 code "VB". */
   VEHICLE_BAYING_ORDER("VB", "Vehicle Baying Order (127)"),
+  /** Vehicle Shipping Order (120) — X12 code "VC". */
   VEHICLE_SHIPPING_ORDER("VC", "Vehicle Shipping Order (120)"),
+  /** Vehicle Damage (124) — X12 code "VD". */
   VEHICLE_DAMAGE("VD", "Vehicle Damage (124)"),
+  /** Vessel Content Details (109) — X12 code "VE". */
   VESSEL_CONTENT_DETAILS("VE", "Vessel Content Details (109)"),
+  /** Vehicle Carrier Rate Update (129) — X12 code "VH". */
   VEHICLE_CARRIER_RATE("VH", "Vehicle Carrier Rate Update (129)"),
+  /** Voter Registration Information (280) — X12 code "VI". */
   VOTER_REGISTRATION("VI", "Voter Registration Information (280)"),
+  /** Vehicle Service (121) — X12 code "VS". */
   VEHICLE_SERVICE("VS", "Vehicle Service (121)"),
+  /** Product Service Transaction Sets (140, 141, 142, 143) — X12 code "WA". */
   PRODUCT_SERVICE("WA", "Product Service Transaction Sets (140, 141, 142, 143)"),
+  /** Rail Carrier Waybill Interchange (417) — X12 code "WB". */
   RAIL_WAYBILL_INTERCHANGE("WB", "Rail Carrier Waybill Interchange (417)"),
+  /** Vendor Performance Review (501) — X12 code "WG". */
   VENDOR_PERFORMANCE("WG", "Vendor Performance Review (501)"),
+  /** Wage Determination (288) — X12 code "WI". */
   WAGE_DETERMINATION("WI", "Wage Determination (288)"),
+  /** Well Information (625) — X12 code "WL". */
   WELL_INFORMATION("WL", "Well Information (625)"),
+  /** Shipment Weights (440) — X12 code "WR". */
   SHIPMENT_WEIGHTS("WR", "Shipment Weights (440)"),
+  /** Rail Waybill Request (425) — X12 code "WT". */
   RAIL_WAYBILL_REQUEST("WT", "Rail Waybill Request (425)");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/HealthRelatedCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/HealthRelatedCode.java
@@ -28,10 +28,15 @@ import lombok.Getter;
  */
 @Getter
 public enum HealthRelatedCode implements EdiCodeEnum {
+  /** None — X12 code "N". */
   NONE("N", "None"),
+  /** Substance Abuse — X12 code "S". */
   SUBSTANCE_ABUSE("S", "Substance Abuse"),
+  /** Tobacco Use — X12 code "T". */
   TOBACCO_USE("T", "Tobacco Use"),
+  /** Unknown — X12 code "U". */
   UNKNOWN("U", "Unknown"),
+  /** Tobacco Use and Substance Abuse — X12 code "X". */
   TOBACCO_USE_AND_SUBSTANCE_ABUSE("X", "Tobacco Use and Substance Abuse");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/IdentificationCodeQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/IdentificationCodeQualifier.java
@@ -24,255 +24,521 @@ import lombok.Getter;
  */
 @Getter
 public enum IdentificationCodeQualifier implements EdiCodeEnum {
+  /** Petroleum Industry Exchange (PETROEX) Number — X12 code "0". */
   PETROEX("0", "Petroleum Industry Exchange (PETROEX) Number"),
+  /** D-U-N-S Number, Dun &amp; Bradstreet — X12 code "1". */
   DUNS("1", "D-U-N-S Number, Dun & Bradstreet"),
+  /** Standard Carrier Alpha Code (SCAC) — X12 code "2". */
   SCAC("2", "Standard Carrier Alpha Code (SCAC)"),
+  /** Federal Maritime Commission (Ocean) (FMC) — X12 code "3". */
   FMC("3", "Federal Maritime Commission (Ocean) (FMC)"),
+  /** International Air Transport Association (IATA) — X12 code "4". */
   IATA("4", "International Air Transport Association (IATA)"),
+  /** Plant Code — X12 code "6". */
   PLANT_CODE("6", "Plant Code"),
+  /** Loading Dock — X12 code "7". */
   LOADING_DOCK("7", "Loading Dock"),
+  /** D-U-N-S+4, D-U-N-S Number with Four Character Suffix — X12 code "9". */
   DUNS_PLUS_4("9", "D-U-N-S+4, D-U-N-S Number with Four Character Suffix"),
+  /** Department of Defense Activity Address Code (DODAAC) — X12 code "10". */
   DODAAC("10", "Department of Defense Activity Address Code (DODAAC)"),
+  /** Drug Enforcement Administration (DEA) — X12 code "11". */
   DEA("11", "Drug Enforcement Administration (DEA)"),
+  /** Telephone Number (Phone) — X12 code "12". */
   PHONE("12", "Telephone Number (Phone)"),
+  /** Federal Reserve Routing Code (FRRC) — X12 code "13". */
   FRRC("13", "Federal Reserve Routing Code (FRRC)"),
+  /** Standard Address Number (SAN) — X12 code "15". */
   SAN("15", "Standard Address Number (SAN)"),
+  /** ZIP Code — X12 code "16". */
   ZIP_CODE("16", "ZIP Code"),
+  /** Automated Broker Interface (ABI) Routing Code — X12 code "17". */
   ABI("17", "Automated Broker Interface (ABI) Routing Code"),
+  /** FIPS-55 (Named Populated Places) — X12 code "19". */
   FIPS_55("19", "FIPS-55 (Named Populated Places)"),
+  /** Standard Point Location Code (SPLC) — X12 code "20". */
   SPLC("20", "Standard Point Location Code (SPLC)"),
+  /** Health Industry Number (HIN) — X12 code "21". */
   HIN("21", "Health Industry Number (HIN)"),
+  /** Council of Petroleum Accounting Societies code (COPAS) — X12 code "22". */
   COPAS("22", "Council of Petroleum Accounting Societies code (COPAS)"),
+  /** Journal of Commerce (JOC) — X12 code "23". */
   JOC("23", "Journal of Commerce (JOC)"),
+  /** Employer's Identification Number — X12 code "24". */
   EIN("24", "Employer's Identification Number"),
+  /** Carrier's Customer Code — X12 code "25". */
   CARRIER_CUSTOMER_CODE("25", "Carrier's Customer Code"),
+  /** Petroleum Accountants Society of Canada Company Code — X12 code "26". */
   PASC("26", "Petroleum Accountants Society of Canada Company Code"),
+  /** Government Bill Of Lading Office Code (GBLOC) — X12 code "27". */
   GBLOC("27", "Government Bill Of Lading Office Code (GBLOC)"),
+  /** American Paper Institute — X12 code "28". */
   API("28", "American Paper Institute"),
+  /** Grid Location and Facility Code — X12 code "29". */
   GRID_LOCATION("29", "Grid Location and Facility Code"),
+  /** American Petroleum Institute Location Code — X12 code "30". */
   API_LOCATION("30", "American Petroleum Institute Location Code"),
+  /**
+   * Bank Identification Code/Number assigned to a bank within a country (non-USA) — X12 code "31".
+   */
   BANK_ID("31", "Bank Identification Code/Number assigned to a bank within a country (non-USA)"),
+  /** Assigned by Property Operator — X12 code "32". */
   PROPERTY_OPERATOR("32", "Assigned by Property Operator"),
+  /** Commercial and Government Entity (CAGE) — X12 code "33". */
   CAGE("33", "Commercial and Government Entity (CAGE)"),
+  /** Social Security Number — X12 code "34". */
   SSN("34", "Social Security Number"),
+  /** Electronic Mail Internal System Address Code — X12 code "35". */
   EMAIL_INTERNAL("35", "Electronic Mail Internal System Address Code"),
+  /** Customs House Broker License Number — X12 code "36". */
   CUSTOMS_BROKER("36", "Customs House Broker License Number"),
+  /** United Nations Vendor Code — X12 code "37". */
   UN_VENDOR("37", "United Nations Vendor Code"),
+  /** Country Code — X12 code "38". */
   COUNTRY_CODE("38", "Country Code"),
+  /** Local Union Number — X12 code "39". */
   LOCAL_UNION("39", "Local Union Number"),
+  /** Electronic Mail User Code — X12 code "40". */
   EMAIL_USER("40", "Electronic Mail User Code"),
+  /** Telecommunications Carrier Identification Code — X12 code "41". */
   TELECOM_CARRIER("41", "Telecommunications Carrier Identification Code"),
+  /** Telecommunications Pseudo Carrier Identification Code — X12 code "42". */
   TELECOM_PSEUDO("42", "Telecommunications Pseudo Carrier Identification Code"),
+  /** Alternate Social Security Number — X12 code "43". */
   ALT_SSN("43", "Alternate Social Security Number"),
+  /** Return Sequence Number — X12 code "44". */
   RETURN_SEQUENCE("44", "Return Sequence Number"),
+  /** Declaration Control Number — X12 code "45". */
   DECLARATION_CONTROL("45", "Declaration Control Number"),
+  /** Electronic Transmitter Identification Number (ETIN) — X12 code "46". */
   ETIN("46", "Electronic Transmitter Identification Number (ETIN)"),
+  /** Tax Authority Identification — X12 code "47". */
   TAX_AUTHORITY("47", "Tax Authority Identification"),
+  /** Electronic Filer Identification Number (EFIN) — X12 code "48". */
   EFIN("48", "Electronic Filer Identification Number (EFIN)"),
+  /** State Identification Number — X12 code "49". */
   STATE_ID("49", "State Identification Number"),
+  /** Business License Number — X12 code "50". */
   BUS_LICENSE("50", "Business License Number"),
+  /** Fuel Inventory Adjustment Identification — X12 code "51". */
   FUEL_INV_ADJ("51", "Fuel Inventory Adjustment Identification"),
+  /** Building — X12 code "53". */
   BUILDING("53", "Building"),
+  /** Warehouse — X12 code "54". */
   WAREHOUSE("54", "Warehouse"),
+  /** Post Office Box — X12 code "55". */
   PO_BOX("55", "Post Office Box"),
+  /** Division — X12 code "56". */
   DIVISION("56", "Division"),
+  /** Department — X12 code "57". */
   DEPARTMENT("57", "Department"),
+  /** Originating Company Number — X12 code "58". */
   ORIGINATING_CO("58", "Originating Company Number"),
+  /** Receiving Company Number — X12 code "59". */
   RECEIVING_CO("59", "Receiving Company Number"),
+  /** Holding Mortgagee Number — X12 code "61". */
   HOLDING_MORTGAGEE("61", "Holding Mortgagee Number"),
+  /** Servicing Mortgagee Number — X12 code "62". */
   SERVICING_MORTGAGEE("62", "Servicing Mortgagee Number"),
+  /** Servicer-holder Mortgagee Number — X12 code "63". */
   SERVICER_HOLDER("63", "Servicer-holder Mortgagee Number"),
+  /** One Call Agency — X12 code "64". */
   ONE_CALL_AGENCY("64", "One Call Agency"),
+  /** Integrated Postsecondary Education Data System (IPEDS) — X12 code "71". */
   IPEDS("71", "Integrated Postsecondary Education Data System (IPEDS)"),
+  /** The College Board's Admission Testing Program (ATP) — X12 code "72". */
   ATP("72", "The College Board's Admission Testing Program (ATP)"),
+  /** Federal Interagency Commission on Education (FICE) number — X12 code "73". */
   FICE("73", "Federal Interagency Commission on Education (FICE) number"),
+  /**
+   * American College Testing (ACT) list of postsecondary educational institutions — X12 code "74".
+   */
   ACT("74", "American College Testing (ACT) list of postsecondary educational institutions"),
+  /** State or Province Assigned Number — X12 code "75". */
   STATE_PROVINCE("75", "State or Province Assigned Number"),
+  /** Local School District or Jurisdiction Number — X12 code "76". */
   LOCAL_SCHOOL("76", "Local School District or Jurisdiction Number"),
+  /** National Center for Education Statistics (NCES) Common Core of Data (CCD) — X12 code "77". */
   NCES_CCD("77", "National Center for Education Statistics (NCES) Common Core of Data (CCD)"),
+  /**
+   * The College Board and ACT 6 digit code list of secondary educational institutions — X12 code
+   * "78".
+   */
   COLLEGE_BOARD_ACT(
       "78", "The College Board and ACT 6 digit code list of secondary educational institutions"),
+  /** Classification of Instructional Programs (CIP) coding structure — X12 code "81". */
   CIP("81", "Classification of Instructional Programs (CIP) coding structure"),
+  /** Higher Education General Information Survey (HEGIS) — X12 code "82". */
   HEGIS("82", "Higher Education General Information Survey (HEGIS)"),
+  /** Congressional District — X12 code "83". */
   CONGRESSIONAL_DISTRICT("83", "Congressional District"),
+  /** California Ethnic Subgroups Code Table — X12 code "90". */
   CA_ETHNIC("90", "California Ethnic Subgroups Code Table"),
+  /** Assigned by Seller or Seller's Agent — X12 code "91". */
   SELLER_ASSIGNED("91", "Assigned by Seller or Seller's Agent"),
+  /** Assigned by Buyer or Buyer's Agent — X12 code "92". */
   BUYER_ASSIGNED("92", "Assigned by Buyer or Buyer's Agent"),
+  /** Code assigned by the organization originating the transaction set — X12 code "93". */
   ORIG_CODE("93", "Code assigned by the organization originating the transaction set"),
+  /** Code assigned by the organization that is the ultimate destination — X12 code "94". */
   DEST_CODE("94", "Code assigned by the organization that is the ultimate destination"),
+  /** Assigned By Transporter — X12 code "95". */
   TRANSPORTER("95", "Assigned By Transporter"),
+  /** Assigned By Pipeline Operator — X12 code "96". */
   PIPELINE_OPERATOR("96", "Assigned By Pipeline Operator"),
+  /** Receiver's Code — X12 code "97". */
   RECEIVERS_CODE("97", "Receiver's Code"),
+  /** Purchasing Office — X12 code "98". */
   PURCHASING_OFFICE("98", "Purchasing Office"),
+  /** Office of Workers Compensation Programs (OWCP) Agency Code — X12 code "99". */
   OWCP("99", "Office of Workers Compensation Programs (OWCP) Agency Code"),
+  /** U.S. Customs Carrier Identification — X12 code "A". */
   CUSTOMS_CARRIER("A", "U.S. Customs Carrier Identification"),
+  /** Approver ID — X12 code "A1". */
   APPROVER_ID("A1", "Approver ID"),
+  /** Military Assistance Program Address Code (MAPAC) — X12 code "A2". */
   MAPAC("A2", "Military Assistance Program Address Code (MAPAC)"),
+  /** Assigned by Third Party — X12 code "A3". */
   THIRD_PARTY("A3", "Assigned by Third Party"),
+  /** Assigned by Clearinghouse — X12 code "A4". */
   CLEARINGHOUSE("A4", "Assigned by Clearinghouse"),
+  /** Committee on Uniform Security Identification Procedures (CUSIP) Number — X12 code "A5". */
   CUSIP("A5", "Committee on Uniform Security Identification Procedures (CUSIP) Number"),
+  /** Financial Identification Numbering System (FINS) Number — X12 code "A6". */
   FINS("A6", "Financial Identification Numbering System (FINS) Number"),
+  /** Automated Commercial Environment Identification Code (ACEID) — X12 code "A7". */
   ACEID("A7", "Automated Commercial Environment Identification Code (ACEID)"),
+  /** Postal Service Code — X12 code "AA". */
   POSTAL_CODE("AA", "Postal Service Code"),
+  /** US Environmental Protection Agency (EPA) Identification Number — X12 code "AB". */
   EPA_ID("AB", "US Environmental Protection Agency (EPA) Identification Number"),
+  /** Attachment Control Number — X12 code "AC". */
   ATTACHMENT_CONTROL("AC", "Attachment Control Number"),
+  /** Blue Cross Blue Shield Association Plan Code — X12 code "AD". */
   BCBS_PLAN("AD", "Blue Cross Blue Shield Association Plan Code"),
+  /** Alberta Energy Resources Conservation Board — X12 code "AE". */
   ALBERTA_ENERGY("AE", "Alberta Energy Resources Conservation Board"),
+  /** Rental Location Identifier — X12 code "AF". */
   RENTAL_LOCATION("AF", "Rental Location Identifier"),
+  /** Automotive Identifier for Canada Customs — X12 code "AI". */
   AUTOMOTIVE_CA("AI", "Automotive Identifier for Canada Customs"),
+  /** Anesthesia License Number — X12 code "AL". */
   ANESTHESIA_LICENSE("AL", "Anesthesia License Number"),
+  /** Alberta Petroleum Marketing Commission — X12 code "AP". */
   ALBERTA_PETROLEUM("AP", "Alberta Petroleum Marketing Commission"),
+  /** British Columbia Ministry of Energy Mines and Petroleum Resources — X12 code "BC". */
   BC_MINISTRY("BC", "British Columbia Ministry of Energy Mines and Petroleum Resources"),
+  /** Blue Cross Provider Number — X12 code "BD". */
   BLUE_CROSS("BD", "Blue Cross Provider Number"),
+  /** Common Language Location Identification (CLLI) — X12 code "BE". */
   CLLI("BE", "Common Language Location Identification (CLLI)"),
+  /** Badge Number — X12 code "BG". */
   BADGE("BG", "Badge Number"),
+  /** Canada Customs &amp; Revenue Agency (CCRA) Business Number — X12 code "BN". */
   CCRA_BUSINESS("BN", "Canada Customs & Revenue Agency (CCRA) Business Number"),
+  /** Benefit Plan — X12 code "BP". */
   BENEFIT_PLAN("BP", "Benefit Plan"),
+  /** Blue Shield Provider Number — X12 code "BS". */
   BLUE_SHIELD("BS", "Blue Shield Provider Number"),
+  /** Insured's Changed Unique Identification Number — X12 code "C". */
   CHANGED_INSURED("C", "Insured's Changed Unique Identification Number"),
+  /** Insured or Subscriber — X12 code "C1". */
   INSURED("C1", "Insured or Subscriber"),
+  /** Health Maintenance Organization (HMO) Provider Number — X12 code "C2". */
   HMO_PROVIDER("C2", "Health Maintenance Organization (HMO) Provider Number"),
+  /** Customer Identification File — X12 code "C5". */
   CUSTOMER_ID("C5", "Customer Identification File"),
+  /** Statistics Canada Canadian College Student Information System Course Codes — X12 code "CA". */
   STATS_CAN_COLLEGE_COURSE(
       "CA", "Statistics Canada Canadian College Student Information System Course Codes"),
+  /**
+   * Statistics Canada Canadian College Student Information System Institution Codes — X12 code
+   * "CB".
+   */
   STATS_CAN_COLLEGE_INST(
       "CB", "Statistics Canada Canadian College Student Information System Institution Codes"),
+  /** Statistics Canada University Student Information System Curriculum Codes — X12 code "CC". */
   STATS_CAN_UNIV_CURR(
       "CC", "Statistics Canada University Student Information System Curriculum Codes"),
+  /** Contract Division — X12 code "CD". */
   CONTRACT_DIVISION("CD", "Contract Division"),
+  /** Bureau of the Census Filer Identification Code — X12 code "CE". */
   CENSUS_FILER("CE", "Bureau of the Census Filer Identification Code"),
+  /** Canadian Financial Institution Routing Number — X12 code "CF". */
   CAN_FINANCIAL("CF", "Canadian Financial Institution Routing Number"),
+  /**
+   * CHAMPUS (Civilian Health and Medical Program of the Uniformed Services) Identification Number —
+   * X12 code "CI".
+   */
   CHAMPUS(
       "CI",
       "CHAMPUS (Civilian Health and Medical Program of the Uniformed Services) Identification Number"),
+  /** Corrected Loan Number — X12 code "CL". */
   CORRECTED_LOAN("CL", "Corrected Loan Number"),
+  /** U.S. Customs Service (USCS) Manufacturer Identifier (MID) — X12 code "CM". */
   CUSTOMS_MID("CM", "U.S. Customs Service (USCS) Manufacturer Identifier (MID)"),
+  /**
+   * National Center for Education Statistics (NCES) Course Classification System — X12 code "CN".
+   */
   NCES_COURSE("CN", "National Center for Education Statistics (NCES) Course Classification System"),
+  /** Canadian Petroleum Association — X12 code "CP". */
   CAN_PETROLEUM("CP", "Canadian Petroleum Association"),
+  /** Credit Repository — X12 code "CR". */
   CREDIT_REPOSITORY("CR", "Credit Repository"),
+  /** Statistics Canada University Student Information System University Codes — X12 code "CS". */
   STATS_CAN_UNIV("CS", "Statistics Canada University Student Information System University Codes"),
+  /** Court Identification Code — X12 code "CT". */
   COURT_ID("CT", "Court Identification Code"),
+  /** Census Schedule D — X12 code "D". */
   CENSUS_SCHEDULE_D("D", "Census Schedule D"),
+  /** United States Department of Education Guarantor Identification Code — X12 code "DG". */
   DOE_GUARANTOR("DG", "United States Department of Education Guarantor Identification Code"),
+  /** United States Department of Education Lender Identification Code — X12 code "DL". */
   DOE_LENDER("DL", "United States Department of Education Lender Identification Code"),
+  /** Dentist License Number — X12 code "DN". */
   DENTIST_LICENSE("DN", "Dentist License Number"),
+  /** Door — X12 code "DO". */
   DOOR("DO", "Door"),
+  /** Data Processing Point — X12 code "DP". */
   DATA_PROCESSING("DP", "Data Processing Point"),
+  /** Gas Industry Standards Board (GISB) Data Reference Number (DRN) — X12 code "DR". */
   GISB_DRN("DR", "Gas Industry Standards Board (GISB) Data Reference Number (DRN)"),
+  /** United States Department of Education School Identification Code — X12 code "DS". */
   DOE_SCHOOL("DS", "United States Department of Education School Identification Code"),
+  /** Hazard Insurance Policy Number — X12 code "E". */
   HAZARD_INSURANCE("E", "Hazard Insurance Policy Number"),
+  /** ARI Electronic Commerce Location ID Code — X12 code "EC". */
   ARI_EC_LOCATION("EC", "ARI Electronic Commerce Location ID Code"),
+  /** Theatre Number — X12 code "EH". */
   THEATRE("EH", "Theatre Number"),
+  /** Employee Identification Number — X12 code "EI". */
   EMPLOYEE_ID("EI", "Employee Identification Number"),
+  /** Elevator — X12 code "EL". */
   ELEVATOR("EL", "Elevator"),
+  /** U.S. Environmental Protection Agency (EPA) — X12 code "EP". */
   EPA("EP", "U.S. Environmental Protection Agency (EPA)"),
+  /** Insurance Company Assigned Identification Number — X12 code "EQ". */
   INS_CO_ASSIGNED("EQ", "Insurance Company Assigned Identification Number"),
+  /** Mortgagee Assigned Identification Number — X12 code "ER". */
   MORTGAGEE_ASSIGNED("ER", "Mortgagee Assigned Identification Number"),
+  /** Automated Export System (AES) Filer Identification Code — X12 code "ES". */
   AES_FILER("ES", "Automated Export System (AES) Filer Identification Code"),
+  /**
+   * Educational Testing Service List of International Postsecondary Institutions — X12 code "ET".
+   */
   ETS_INTL("ET", "Educational Testing Service List of International Postsecondary Institutions"),
+  /** Document Custodian Identification Number — X12 code "F". */
   DOC_CUSTODIAN("F", "Document Custodian Identification Number"),
+  /** Facility Identification — X12 code "FA". */
   FACILITY_ID("FA", "Facility Identification"),
+  /** Field Code — X12 code "FB". */
   FIELD_CODE("FB", "Field Code"),
+  /** Federal Court Jurisdiction Identifier — X12 code "FC". */
   FED_COURT_JURISDICTION("FC", "Federal Court Jurisdiction Identifier"),
+  /** Federal Court Divisional Office Number — X12 code "FD". */
   FED_COURT_DIVISION("FD", "Federal Court Divisional Office Number"),
+  /** Facility Federal Identification Number — X12 code "FE". */
   FACILITY_FED_ID("FE", "Facility Federal Identification Number"),
+  /** Federal Taxpayer's Identification Number — X12 code "FI". */
   FEDERAL_TIN("FI", "Federal Taxpayer's Identification Number"),
+  /** Federal Jurisdiction — X12 code "FJ". */
   FED_JURISDICTION("FJ", "Federal Jurisdiction"),
+  /** Floor — X12 code "FL". */
   FLOOR("FL", "Floor"),
+  /**
+   * U.S. Environmental Protection Agency (EPA) Laboratory Certification Identification — X12 code
+   * "FN".
+   */
   EPA_LAB_CERT(
       "FN", "U.S. Environmental Protection Agency (EPA) Laboratory Certification Identification"),
+  /** Payee Identification Number — X12 code "G". */
   PAYEE_ID("G", "Payee Identification Number"),
+  /** Primary Agent Identification — X12 code "GA". */
   PRIMARY_AGENT("GA", "Primary Agent Identification"),
+  /** GAS*CODE — X12 code "GC". */
   GAS_CODE("GC", "GAS*CODE"),
+  /** Centers for Medicare and Medicaid Services — X12 code "HC". */
   CMS("HC", "Centers for Medicare and Medicaid Services"),
+  /** Health Insurance Claim (HIC) Number — X12 code "HN". */
   HIC("HN", "Health Insurance Claim (HIC) Number"),
+  /** House (Canadian Grain Elevator) — X12 code "HS". */
   HOUSE_GRAIN("HS", "House (Canadian Grain Elevator)"),
+  /** Secondary Marketing Investor Assigned Number — X12 code "I". */
   SEC_MARKETING("I", "Secondary Marketing Investor Assigned Number"),
+  /** UCC EDI Communications ID (Comm ID) — X12 code "ID". */
   UCC_EDI_COMM_ID("ID", "UCC EDI Communications ID (Comm ID)"),
+  /** Standard Unique Health Identifier for each Individual in the United States — X12 code "II". */
   HEALTH_ID("II", "Standard Unique Health Identifier for each Individual in the United States"),
+  /**
+   * U.S. Customs Carrier Initiative Program (CIP) Participant Identification Number — X12 code
+   * "IP".
+   */
   CIP_PARTICIPANT(
       "IP", "U.S. Customs Carrier Initiative Program (CIP) Participant Identification Number"),
+  /** Mortgage Electronic Registration System Organization Identifier — X12 code "J". */
   MERS_ORG_ID("J", "Mortgage Electronic Registration System Organization Identifier"),
+  /** Census Schedule K — X12 code "K". */
   CENSUS_SCHEDULE_K("K", "Census Schedule K"),
+  /** Investor Assigned Identification Number — X12 code "L". */
   INVESTOR_ASSIGNED("L", "Investor Assigned Identification Number"),
+  /** Agency Location Code (U.S. Government) — X12 code "LC". */
   AGENCY_LOCATION("LC", "Agency Location Code (U.S. Government)"),
+  /** NISO Z39.53 Language Codes — X12 code "LD". */
   NISO_LANGUAGE("LD", "NISO Z39.53 Language Codes"),
+  /** ISO 639 Language Codes — X12 code "LE". */
   ISO_LANGUAGE("LE", "ISO 639 Language Codes"),
+  /** Labeler Identification Code (LIC) — X12 code "LI". */
   LABELER_ID("LI", "Labeler Identification Code (LIC)"),
+  /** Loan Number — X12 code "LN". */
   LOAN_NUMBER("LN", "Loan Number"),
+  /** Certificate Number — X12 code "M". */
   CERTIFICATE("M", "Certificate Number"),
+  /** Disbursing Station — X12 code "M3". */
   DISBURSING_STATION("M3", "Disbursing Station"),
+  /** Department of Defense Routing Identifier Code (RIC) — X12 code "M4". */
   DOD_ROUTING("M4", "Department of Defense Routing Identifier Code (RIC)"),
+  /** Jurisdiction Code — X12 code "M5". */
   JURISDICTION_CODE("M5", "Jurisdiction Code"),
+  /** Division Office Code — X12 code "M6". */
   DIVISION_OFFICE("M6", "Division Office Code"),
+  /** Mail Stop — X12 code "MA". */
   MAIL_STOP("MA", "Mail Stop"),
+  /** Medical Information Bureau — X12 code "MB". */
   MED_INFO_BUREAU("MB", "Medical Information Bureau"),
+  /** Medicaid Provider Number — X12 code "MC". */
   MEDICAID_PROVIDER("MC", "Medicaid Provider Number"),
+  /** Manitoba Department of Mines and Resources — X12 code "MD". */
   MANITOBA_MINES("MD", "Manitoba Department of Mines and Resources"),
+  /** Member Identification Number — X12 code "MI". */
   MEMBER_ID("MI", "Member Identification Number"),
+  /** Market — X12 code "MK". */
   MARKET("MK", "Market"),
+  /** Multiple Listing Service Vendor - Multiple Listing Service Identification — X12 code "ML". */
   MLS_VENDOR("ML", "Multiple Listing Service Vendor - Multiple Listing Service Identification"),
+  /** Mortgage Identification Number — X12 code "MN". */
   MORTGAGE_ID("MN", "Mortgage Identification Number"),
+  /** Major Organizational Entity — X12 code "MO". */
   MAJOR_ORG_ENTITY("MO", "Major Organizational Entity"),
+  /** Medicare Provider Number — X12 code "MP". */
   MEDICARE_PROVIDER("MP", "Medicare Provider Number"),
+  /** Medicaid Recipient Identification Number — X12 code "MR". */
   MEDICAID_RECIPIENT("MR", "Medicaid Recipient Identification Number"),
+  /** Insured's Unique Identification Number — X12 code "N". */
   INSURED_ID("N", "Insured's Unique Identification Number"),
+  /** National Association of Realtors - Multiple Listing Service Identification — X12 code "NA". */
   NAR_MLS("NA", "National Association of Realtors - Multiple Listing Service Identification"),
+  /** Mode Designator — X12 code "ND". */
   MODE_DESIGNATOR("ND", "Mode Designator"),
+  /** National Association of Insurance Commissioners (NAIC) Identification — X12 code "NI". */
   NAIC("NI", "National Association of Insurance Commissioners (NAIC) Identification"),
+  /** National Criminal Information Center Originating Agency — X12 code "NO". */
   NCIC("NO", "National Criminal Information Center Originating Agency"),
+  /** Non Resident Alien Registration Number — X12 code "NR". */
   ALIEN_REG("NR", "Non Resident Alien Registration Number"),
+  /** Occupation Code — X12 code "OC". */
   OCCUPATION_CODE("OC", "Occupation Code"),
+  /** On-line Payment and Collection — X12 code "OP". */
   OPAC("OP", "On-line Payment and Collection"),
+  /** Secondary Agent Identification — X12 code "PA". */
   SECONDARY_AGENT("PA", "Secondary Agent Identification"),
+  /** Public Identification — X12 code "PB". */
   PUBLIC_ID("PB", "Public Identification"),
+  /** Provider Commercial Number — X12 code "PC". */
   PROVIDER_COMMERCIAL("PC", "Provider Commercial Number"),
+  /** Payor Identification — X12 code "PI". */
   PAYOR_ID("PI", "Payor Identification"),
+  /** Pharmacy Processor Number — X12 code "PP". */
   PHARMACY_PROCESSOR("PP", "Pharmacy Processor Number"),
+  /** Pier — X12 code "PR". */
   PIER("PR", "Pier"),
+  /** Regulatory Agency Number — X12 code "RA". */
   REGULATORY_AGENCY("RA", "Regulatory Agency Number"),
+  /** Real Estate Agent — X12 code "RB". */
   REAL_ESTATE_AGENT("RB", "Real Estate Agent"),
+  /** Real Estate Company — X12 code "RC". */
   REAL_ESTATE_COMPANY("RC", "Real Estate Company"),
+  /** Real Estate Broker Identification — X12 code "RD". */
   REAL_ESTATE_BROKER("RD", "Real Estate Broker Identification"),
+  /** Real Estate License Number — X12 code "RE". */
   REAL_ESTATE_LICENSE("RE", "Real Estate License Number"),
+  /** Office of Regulatory Information Systems (ORIS) Code — X12 code "RI". */
   ORIS_CODE("RI", "Office of Regulatory Information Systems (ORIS) Code"),
+  /** Ramp — X12 code "RP". */
   RAMP("RP", "Ramp"),
+  /** Railroad Track — X12 code "RT". */
   RAILROAD_TRACK("RT", "Railroad Track"),
+  /** Title Insurance Policy Number — X12 code "S". */
   TITLE_INSURANCE("S", "Title Insurance Policy Number"),
+  /** Tertiary Agent Identification — X12 code "SA". */
   TERTIARY_AGENT("SA", "Tertiary Agent Identification"),
+  /** Social Insurance Number — X12 code "SB". */
   SIN("SB", "Social Insurance Number"),
+  /** Saskatchewan Department of Energy Mines and Resources — X12 code "SD". */
   SASKATCHEWAN_ENERGY("SD", "Saskatchewan Department of Energy Mines and Resources"),
+  /** Suffix Code — X12 code "SF". */
   SUFFIX_CODE("SF", "Suffix Code"),
+  /** Standard Industry Code (SIC) — X12 code "SI". */
   SIC("SI", "Standard Industry Code (SIC)"),
+  /** State or Province Jurisdiction — X12 code "SJ". */
   STATE_JURISDICTION("SJ", "State or Province Jurisdiction"),
+  /** State/Provincial Lottery License Number — X12 code "SK". */
   STATE_LOTTERY("SK", "State/Provincial Lottery License Number"),
+  /** State License Number — X12 code "SL". */
   STATE_LICENSE("SL", "State License Number"),
+  /** Specialty License Number — X12 code "SP". */
   SPECIALTY_LICENSE("SP", "Specialty License Number"),
+  /** State/Province License Tag — X12 code "ST". */
   STATE_LICENSE_TAG("ST", "State/Province License Tag"),
+  /** Service Provider Number — X12 code "SV". */
   SERVICE_PROVIDER("SV", "Service Provider Number"),
+  /**
+   * Society for Worldwide Interbank Financial Telecommunications (SWIFT) Address — X12 code "SW".
+   */
   SWIFT_ADDRESS(
       "SW", "Society for Worldwide Interbank Financial Telecommunications (SWIFT) Address"),
+  /** Taxpayer ID Number — X12 code "TA". */
   TIN("TA", "Taxpayer ID Number"),
+  /** Internal Revenue Service Terminal Code — X12 code "TC". */
   IRS_TERMINAL("TC", "Internal Revenue Service Terminal Code"),
+  /** Transport4 Location Code — X12 code "TL". */
   TRANSPORT4_LOCATION("TL", "Transport4 Location Code"),
+  /** Transport4 Shipper Code — X12 code "TS". */
   TRANSPORT4_SHIPPER("TS", "Transport4 Shipper Code"),
+  /** Department Code — X12 code "TZ". */
   DEPARTMENT_CODE("TZ", "Department Code"),
+  /** Consumer Credit Identification Number — X12 code "UC". */
   CONSUMER_CREDIT("UC", "Consumer Credit Identification Number"),
+  /** Unit Identification Code — X12 code "UI". */
   UNIT_ID_CODE("UI", "Unit Identification Code"),
+  /** Global Location Number (GLN) — X12 code "UL". */
   GLN("UL", "Global Location Number (GLN)"),
+  /** Unique Physician Identification Number (UPIN) — X12 code "UP". */
   UPIN("UP", "Unique Physician Identification Number (UPIN)"),
+  /** Uniform Resource Locator (URL) — X12 code "UR". */
   URL("UR", "Uniform Resource Locator (URL)"),
+  /** Unique Supplier Identification Number (USIN) — X12 code "US". */
   USIN("US", "Unique Supplier Identification Number (USIN)"),
+  /** Unit — X12 code "UT". */
   UNIT("UT", "Unit"),
+  /** Wine Region Code — X12 code "WR". */
   WINE_REGION("WR", "Wine Region Code"),
+  /** Education Language Codes — X12 code "WS". */
   EDU_LANGUAGE("WS", "Education Language Codes"),
+  /** National Center for Education Statistics Unit Identification Number — X12 code "X1". */
   NCES_UNIT("X1", "National Center for Education Statistics Unit Identification Number"),
+  /** Centers for Medicare and Medicaid Services PlanID — X12 code "XV". */
   CMS_PLANID("XV", "Centers for Medicare and Medicaid Services PlanID"),
+  /** Centers for Medicare and Medicaid Services National Provider Identifier — X12 code "XX". */
   CMS_NPI("XX", "Centers for Medicare and Medicaid Services National Provider Identifier"),
+  /** District Assigned Number — X12 code "XY". */
   DISTRICT_ASSIGNED("XY", "District Assigned Number"),
+  /** Contractor Establishment Code — X12 code "ZC". */
   CONTRACTOR_ESTAB("ZC", "Contractor Establishment Code"),
+  /** Zone — X12 code "ZN". */
   ZONE("ZN", "Zone"),
+  /** Temporary Identification Number — X12 code "ZY". */
   TEMP_ID("ZY", "Temporary Identification Number"),
+  /** Mutually Defined — X12 code "ZZ". */
   MUTUALLY_DEFINED("ZZ", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeControlVersionNumber.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeControlVersionNumber.java
@@ -23,51 +23,113 @@ import lombok.Getter;
  */
 @Getter
 public enum InterchangeControlVersionNumber implements EdiCodeEnum {
+  /** ASC X12 Standards Issued by ANSI in 1987 — X12 code "00200". */
   X12_1987("00200", "ASC X12 Standards Issued by ANSI in 1987"),
+  /** Draft Standards for Trial Use Approved by ASC X12 Through August 1988 — X12 code "00201". */
   X12_DRAFT_1988("00201", "Draft Standards for Trial Use Approved by ASC X12 Through August 1988"),
+  /** Draft Standards for Trial Use Approved by ASC X12 Through May 1989 — X12 code "00204". */
   X12_DRAFT_1989("00204", "Draft Standards for Trial Use Approved by ASC X12 Through May 1989"),
+  /** ASC X12 Standards Issued by ANSI in 1992 — X12 code "00300". */
   X12_1992("00300", "ASC X12 Standards Issued by ANSI in 1992"),
+  /**
+   * Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board
+   * Through October 1990 — X12 code "00301".
+   */
   X12_DRAFT_OCT_1990(
       "00301",
       "Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board Through October 1990"),
+  /**
+   * Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board
+   * Through October 1991 — X12 code "00302".
+   */
   X12_DRAFT_OCT_1991(
       "00302",
       "Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board Through October 1991"),
+  /**
+   * Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board
+   * Through October 1992 — X12 code "00303".
+   */
   X12_DRAFT_OCT_1992(
       "00303",
       "Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board Through October 1992"),
+  /**
+   * Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board
+   * through October 1993 — X12 code "00304".
+   */
   X12_DRAFT_OCT_1993(
       "00304",
       "Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board through October 1993"),
+  /**
+   * Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board
+   * through October 1994 — X12 code "00305".
+   */
   X12_DRAFT_OCT_1994(
       "00305",
       "Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board through October 1994"),
+  /**
+   * Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board
+   * through October 1995 — X12 code "00306".
+   */
   X12_DRAFT_OCT_1995(
       "00306",
       "Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board through October 1995"),
+  /**
+   * Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board
+   * through October 1996 — X12 code "00307".
+   */
   X12_DRAFT_OCT_1996(
       "00307",
       "Draft Standards for Trial Use Approved for Publication by ASC X12 Procedures Review Board through October 1996"),
+  /** ASC X12 Standards Issued by ANSI in 1997 — X12 code "00400". */
   X12_1997("00400", "ASC X12 Standards Issued by ANSI in 1997"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 1997 —
+   * X12 code "00401".
+   */
   X12_OCT_1997(
       "00401",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 1997"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 1998 —
+   * X12 code "00402".
+   */
   X12_OCT_1998(
       "00402",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 1998"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 1999 —
+   * X12 code "00403".
+   */
   X12_OCT_1999(
       "00403",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 1999"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 2000 —
+   * X12 code "00404".
+   */
   X12_OCT_2000(
       "00404",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 2000"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 2001 —
+   * X12 code "00405".
+   */
   X12_OCT_2001(
       "00405",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 2001"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 2002 —
+   * X12 code "00406".
+   */
   X12_OCT_2002(
       "00406",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 2002"),
+  /** ASC X12 Standards Issued by ANSI in 2003 — X12 code "00500". */
   X12_2003("00500", "ASC X12 Standards Issued by ANSI in 2003"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 2003 —
+   * X12 code "00501".
+   */
   X12_OCT_2003(
       "00501",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 2003");

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeIdQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeIdQualifier.java
@@ -23,49 +23,97 @@ import lombok.Getter;
  */
 @Getter
 public enum InterchangeIdQualifier implements EdiCodeEnum {
+  /** Duns (Dun &amp; Bradstreet) — X12 code "01". */
   DUNS("01", "Duns (Dun & Bradstreet)"),
+  /** SCAC (Standard Carrier Alpha Code) — X12 code "02". */
   SCAC("02", "SCAC (Standard Carrier Alpha Code)"),
+  /** FMC (Federal Maritime Commission) — X12 code "03". */
   FMC("03", "FMC (Federal Maritime Commission)"),
+  /** IATA (International Air Transport Association) — X12 code "04". */
   IATA("04", "IATA (International Air Transport Association)"),
+  /** Global Location Number (GLN) — X12 code "07". */
   GLN("07", "Global Location Number (GLN)"),
+  /** UCC EDI Communications ID (Comm ID) — X12 code "08". */
   UCC_EDI_COMM_ID("08", "UCC EDI Communications ID (Comm ID)"),
+  /** X.121 (CCITT) — X12 code "09". */
   X121("09", "X.121 (CCITT)"),
+  /** Department of Defense (DoD) Activity Address Code — X12 code "10". */
   DOD_ACTIVITY_CODE("10", "Department of Defense (DoD) Activity Address Code"),
+  /** DEA (Drug Enforcement Administration) — X12 code "11". */
   DEA("11", "DEA (Drug Enforcement Administration)"),
+  /** Phone (Telephone Companies) — X12 code "12". */
   PHONE("12", "Phone (Telephone Companies)"),
+  /** UCS Code — X12 code "13". */
   UCS_CODE("13", "UCS Code"),
+  /** Duns Plus Suffix — X12 code "14". */
   DUNS_PLUS_SUFFIX("14", "Duns Plus Suffix"),
+  /** Petroleum Accountants Society of Canada Company Code — X12 code "15". */
   PASC_COMPANY_CODE("15", "Petroleum Accountants Society of Canada Company Code"),
+  /** Duns Number With 4-Character Suffix — X12 code "16". */
   DUNS_WITH_4CHAR_SUFFIX("16", "Duns Number With 4-Character Suffix"),
+  /** American Bankers Association (ABA) Transit Routing Number — X12 code "17". */
   ABA_ROUTING_NUMBER("17", "American Bankers Association (ABA) Transit Routing Number"),
+  /** Association of American Railroads (AAR) Standard Distribution Code — X12 code "18". */
   AAR_CODE("18", "Association of American Railroads (AAR) Standard Distribution Code"),
+  /** EDI Council of Australia (EDICA) Communications ID Number — X12 code "19". */
   EDICA_COMM_ID("19", "EDI Council of Australia (EDICA) Communications ID Number"),
+  /** Health Industry Number (HIN) — X12 code "20". */
   HIN("20", "Health Industry Number (HIN)"),
+  /** Integrated Postsecondary Education Data System (IPEDS) — X12 code "21". */
   IPEDS("21", "Integrated Postsecondary Education Data System (IPEDS)"),
+  /** Federal Interagency Commission on Education (FICE) — X12 code "22". */
   FICE("22", "Federal Interagency Commission on Education (FICE)"),
+  /**
+   * National Center for Education Statistics Common Core of Data 12-Digit Number — X12 code "23".
+   */
   NCES("23", "National Center for Education Statistics Common Core of Data 12-Digit Number"),
+  /** The College Board's Admission Testing Program 4-Digit Code — X12 code "24". */
   ATP_CODE("24", "The College Board's Admission Testing Program 4-Digit Code"),
+  /** ACT, Inc. 4-Digit Code of Postsecondary Institutions — X12 code "25". */
   ACT_CODE("25", "ACT, Inc. 4-Digit Code of Postsecondary Institutions"),
+  /** Statistics of Canada List of Postsecondary Institutions — X12 code "26". */
   STATS_CANADA_LIST("26", "Statistics of Canada List of Postsecondary Institutions"),
+  /** Carrier Identification Number as assigned by HCFA — X12 code "27". */
   CARRIER_ID_HCFA("27", "Carrier Identification Number as assigned by HCFA"),
+  /** Fiscal Intermediary Identification Number as assigned by HCFA — X12 code "28". */
   FISCAL_INTERMEDIARY_ID("28", "Fiscal Intermediary Identification Number as assigned by HCFA"),
+  /** Medicare Provider and Supplier Identification Number — X12 code "29". */
   MEDICARE_PROVIDER_ID("29", "Medicare Provider and Supplier Identification Number"),
+  /** U.S. Federal Tax Identification Number — X12 code "30". */
   US_FEDERAL_TAX_ID("30", "U.S. Federal Tax Identification Number"),
+  /** Jurisdiction Identification Number Plus 4 as assigned by IAIABC — X12 code "31". */
   IAIABC_ID("31", "Jurisdiction Identification Number Plus 4 as assigned by IAIABC"),
+  /** U.S. Federal Employer Identification Number (FEIN) — X12 code "32". */
   FEIN("32", "U.S. Federal Employer Identification Number (FEIN)"),
+  /** National Association of Insurance Commissioners Company Code (NAIC) — X12 code "33". */
   NAIC("33", "National Association of Insurance Commissioners Company Code (NAIC)"),
+  /** Medicaid Provider and Supplier Identification Number — X12 code "34". */
   MEDICAID_PROVIDER_ID("34", "Medicaid Provider and Supplier Identification Number"),
+  /**
+   * Statistics Canada Canadian College Student Information System Institution Codes — X12 code
+   * "35".
+   */
   STATS_CANADA_COLLEGE_CODES(
       "35", "Statistics Canada Canadian College Student Information System Institution Codes"),
+  /** Statistics Canada University Student Information System Institution Codes — X12 code "36". */
   STATS_CANADA_UNIVERSITY_CODES(
       "36", "Statistics Canada University Student Information System Institution Codes"),
+  /** Society of Property Information Compilers and Analysts — X12 code "37". */
   SPICA("37", "Society of Property Information Compilers and Analysts"),
+  /**
+   * The College Board and ACT, Inc. 6-Digit Code List of Secondary Institutions — X12 code "38".
+   */
   SECONDARY_INST_CODE(
       "38", "The College Board and ACT, Inc. 6-Digit Code List of Secondary Institutions"),
+  /** Association Mexicana del Codigo de Producto (AMECOP) Communication ID — X12 code "AM". */
   AMECOP("AM", "Association Mexicana del Codigo de Producto (AMECOP) Communication ID"),
+  /** National Retail Merchants Association (NRMA) - Assigned — X12 code "NR". */
   NRMA("NR", "National Retail Merchants Association (NRMA) - Assigned"),
+  /** User Identification Number as assigned by SAFER System — X12 code "SA". */
   SAFER_ID("SA", "User Identification Number as assigned by SAFER System"),
+  /** Standard Address Number — X12 code "SN". */
   STANDARD_ADDRESS_NUMBER("SN", "Standard Address Number"),
+  /** Mutually Defined — X12 code "ZZ". */
   MUTUALLY_DEFINED("ZZ", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeUsageIndicator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/InterchangeUsageIndicator.java
@@ -23,8 +23,11 @@ import lombok.Getter;
  */
 @Getter
 public enum InterchangeUsageIndicator implements EdiCodeEnum {
+  /** Information — X12 code "I". */
   INFORMATION("I", "Information"),
+  /** Production Data — X12 code "P". */
   PRODUCTION("P", "Production Data"),
+  /** Test Data — X12 code "T". */
   TEST("T", "Test Data");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/PayerResponsibilitySequenceCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/PayerResponsibilitySequenceCode.java
@@ -27,19 +27,33 @@ import lombok.Getter;
  */
 @Getter
 public enum PayerResponsibilitySequenceCode implements EdiCodeEnum {
+  /** Payer Responsibility Four — X12 code "A". */
   PAYER_RESPONSIBILITY_FOUR("A", "Payer Responsibility Four"),
+  /** Payer Responsibility Five — X12 code "B". */
   PAYER_RESPONSIBILITY_FIVE("B", "Payer Responsibility Five"),
+  /** Payer Responsibility Six — X12 code "C". */
   PAYER_RESPONSIBILITY_SIX("C", "Payer Responsibility Six"),
+  /** Payer Responsibility Seven — X12 code "D". */
   PAYER_RESPONSIBILITY_SEVEN("D", "Payer Responsibility Seven"),
+  /** Payer Responsibility Eight — X12 code "E". */
   PAYER_RESPONSIBILITY_EIGHT("E", "Payer Responsibility Eight"),
+  /** Payer Responsibility Nine — X12 code "F". */
   PAYER_RESPONSIBILITY_NINE("F", "Payer Responsibility Nine"),
+  /** Payer Responsibility Ten — X12 code "G". */
   PAYER_RESPONSIBILITY_TEN("G", "Payer Responsibility Ten"),
+  /** Payer Responsibility Eleven — X12 code "H". */
   PAYER_RESPONSIBILITY_ELEVEN("H", "Payer Responsibility Eleven"),
+  /** Unconfirmed — X12 code "N". */
   UNCONFIRMED("N", "Unconfirmed"),
+  /** Noncapitated Agreement — X12 code "O". */
   NONCAPITATED_AGREEMENT("O", "Noncapitated Agreement"),
+  /** Primary — X12 code "P". */
   PRIMARY("P", "Primary"),
+  /** Secondary — X12 code "S". */
   SECONDARY("S", "Secondary"),
+  /** Tertiary — X12 code "T". */
   TERTIARY("T", "Tertiary"),
+  /** Unknown — X12 code "U". */
   UNKNOWN("U", "Unknown");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/ReferenceIdentificationQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/ReferenceIdentificationQualifier.java
@@ -23,113 +23,224 @@ import lombok.Getter;
  */
 @Getter
 public enum ReferenceIdentificationQualifier implements EdiCodeEnum {
+  /** Contracting District Number — X12 code "00". */
   CONTRACTING_DISTRICT_NUMBER("00", "Contracting District Number"),
+  /** Supervisory Appraiser Certification Number — X12 code "0A". */
   SUPERVISORY_APPRAISER_CERTIFICATION_NUMBER("0A", "Supervisory Appraiser Certification Number"),
+  /** State License Number — X12 code "0B". */
   STATE_LICENSE_NUMBER("0B", "State License Number"),
+  /** Linking Identifier — X12 code "0C". */
   LINKING_IDENTIFIER("0C", "Linking Identifier"),
+  /** Subject Property Verification Source — X12 code "0D". */
   SUBJECT_PROPERTY_VERIFICATION_SOURCE("0D", "Subject Property Verification Source"),
+  /** Subject Property Reference Number — X12 code "0E". */
   SUBJECT_PROPERTY_REFERENCE_NUMBER("0E", "Subject Property Reference Number"),
+  /** Subscriber Number — X12 code "0F". */
   SUBSCRIBER_NUMBER("0F", "Subscriber Number"),
+  /** Reviewer File Number — X12 code "0G". */
   REVIEWER_FILE_NUMBER("0G", "Reviewer File Number"),
+  /** Comparable Property Pending Sale Reference Number — X12 code "0H". */
   COMPARABLE_PROPERTY_PENDING_SALE_REFERENCE_NUMBER(
       "0H", "Comparable Property Pending Sale Reference Number"),
+  /** Comparable Property Sale Reference Number — X12 code "0I". */
   COMPARABLE_PROPERTY_SALE_REFERENCE_NUMBER("0I", "Comparable Property Sale Reference Number"),
+  /** Subject Property Non-Sale Reference Number — X12 code "0J". */
   SUBJECT_PROPERTY_NON_SALE_REFERENCE_NUMBER("0J", "Subject Property Non-Sale Reference Number"),
+  /** Policy Form Identifying Number — X12 code "0K". */
   POLICY_FORM_IDENTIFYING_NUMBER("0K", "Policy Form Identifying Number"),
+  /** Referenced By — X12 code "0L". */
   REFERENCED_BY("0L", "Referenced By"),
+  /** Mortgage Identification Number — X12 code "0M". */
   MORTGAGE_IDENTIFICATION_NUMBER("0M", "Mortgage Identification Number"),
+  /** Attached To — X12 code "0N". */
   ATTACHED_TO("0N", "Attached To"),
+  /** Real Estate Owned Property Identifier — X12 code "0P". */
   REAL_ESTATE_OWNED_PROPERTY_IDENTIFIER("0P", "Real Estate Owned Property Identifier"),
+  /**
+   * American Bankers Assoc. (ABA) Transit/Routing Number (Including Check Digit, 9 Digits) — X12
+   * code "01".
+   */
   ABA_TRANSIT_ROUTING_NUMBER(
       "01",
       "American Bankers Assoc. (ABA) Transit/Routing Number (Including Check Digit, 9 Digits)"),
+  /** Blue Cross Provider Number — X12 code "1A". */
   BLUE_CROSS_PROVIDER_NUMBER("1A", "Blue Cross Provider Number"),
+  /** Catalog of Federal Domestic Assistance — X12 code "01A". */
   CATALOG_OF_FEDERAL_DOMESTIC_ASSISTANCE("01A", "Catalog of Federal Domestic Assistance"),
+  /** Blue Shield Provider Number — X12 code "1B". */
   BLUE_SHIELD_PROVIDER_NUMBER("1B", "Blue Shield Provider Number"),
+  /** Union Agreement — X12 code "01B". */
   UNION_AGREEMENT("01B", "Union Agreement"),
+  /** Medicare Provider Number — X12 code "1C". */
   MEDICARE_PROVIDER_NUMBER("1C", "Medicare Provider Number"),
+  /**
+   * Military Standard Requisitioning and Issue Procedures (MILSTRIP) Document Number — X12 code
+   * "01C".
+   */
   MILSTRIP_DOCUMENT_NUMBER(
       "01C", "Military Standard Requisitioning and Issue Procedures (MILSTRIP) Document Number"),
+  /** Medicaid Provider Number — X12 code "1D". */
   MEDICAID_PROVIDER_NUMBER("1D", "Medicaid Provider Number"),
+  /**
+   * Federal Standard Requisitioning and Issue Procedures (FEDSTRIP) Document Number — X12 code
+   * "01D".
+   */
   FEDSTRIP_DOCUMENT_NUMBER(
       "01D", "Federal Standard Requisitioning and Issue Procedures (FEDSTRIP) Document Number"),
+  /** Dentist License Number — X12 code "1E". */
   DENTIST_LICENSE_NUMBER("1E", "Dentist License Number"),
+  /** Federal Supply Schedule Special (FSS) Item Number — X12 code "01E". */
   FSS_ITEM_NUMBER("01E", "Federal Supply Schedule Special (FSS) Item Number"),
+  /** Anesthesia License Number — X12 code "1F". */
   ANESTHESIA_LICENSE_NUMBER("1F", "Anesthesia License Number"),
+  /** Provider UPIN Number — X12 code "1G". */
   PROVIDER_UPIN_NUMBER("1G", "Provider UPIN Number"),
+  /** Payment Related Clause — X12 code "01G". */
   PAYMENT_RELATED_CLAUSE("01G", "Payment Related Clause"),
+  /** TRICARE Identification Number — X12 code "1H". */
   TRICARE_IDENTIFICATION_NUMBER("1H", "TRICARE Identification Number"),
+  /** Special Price Authorization Number — X12 code "01H". */
   SPECIAL_PRICE_AUTHORIZATION_NUMBER("01H", "Special Price Authorization Number"),
+  /** Department of Defense Identification Code (DoDIC) — X12 code "1I". */
   DODIC("1I", "Department of Defense Identification Code (DoDIC)"),
+  /** Facility ID Number — X12 code "1J". */
   FACILITY_ID_NUMBER("1J", "Facility ID Number"),
+  /** Payer's Claim Number — X12 code "1K". */
   PAYERS_CLAIM_NUMBER("1K", "Payer's Claim Number"),
+  /** Group or Policy Number — X12 code "1L". */
   GROUP_OR_POLICY_NUMBER("1L", "Group or Policy Number"),
+  /** Preferred Provider Organization Site Number — X12 code "1M". */
   PPO_SITE_NUMBER("1M", "Preferred Provider Organization Site Number"),
+  /** Diagnosis Related Group (DRG) Number — X12 code "1N". */
   DRG_NUMBER("1N", "Diagnosis Related Group (DRG) Number"),
+  /** Consolidation Shipment Number — X12 code "1O". */
   CONSOLIDATION_SHIPMENT_NUMBER("1O", "Consolidation Shipment Number"),
+  /** Accessorial Status Code — X12 code "1P". */
   ACCESSORIAL_STATUS_CODE("1P", "Accessorial Status Code"),
+  /** Error Identification Code — X12 code "1Q". */
   ERROR_IDENTIFICATION_CODE("1Q", "Error Identification Code"),
+  /** Storage Information Code — X12 code "1R". */
   STORAGE_INFORMATION_CODE("1R", "Storage Information Code"),
+  /** Ambulatory Patient Group (APG) Number — X12 code "1S". */
   APG_NUMBER("1S", "Ambulatory Patient Group (APG) Number"),
+  /** Resource Utilization Group (RUG) Number — X12 code "1T". */
   RUG_NUMBER("1T", "Resource Utilization Group (RUG) Number"),
+  /** Pay Grade — X12 code "1U". */
   PAY_GRADE("1U", "Pay Grade"),
+  /** Related Vendor Order Number — X12 code "1V". */
   RELATED_VENDOR_ORDER_NUMBER("1V", "Related Vendor Order Number"),
+  /** Member Identification Number — X12 code "1W". */
   MEMBER_IDENTIFICATION_NUMBER("1W", "Member Identification Number"),
+  /** Credit or Debit Adjustment Number — X12 code "1X". */
   CREDIT_OR_DEBIT_ADJUSTMENT_NUMBER("1X", "Credit or Debit Adjustment Number"),
+  /** Repair Action Number — X12 code "1Y". */
   REPAIR_ACTION_NUMBER("1Y", "Repair Action Number"),
+  /** Financial Detail Code — X12 code "1Z". */
   FINANCIAL_DETAIL_CODE("1Z", "Financial Detail Code"),
+  /**
+   * Society for Worldwide Interbank Financial Telecommunication (S.W.I.F.T.) Identification (8 or
+   * 11 Characters) — X12 code "02".
+   */
   SWIFT_IDENTIFICATION(
       "02",
       "Society for Worldwide Interbank Financial Telecommunication (S.W.I.F.T.) Identification (8 or 11 Characters)"),
+  /** Import License Number — X12 code "2A". */
   IMPORT_LICENSE_NUMBER("2A", "Import License Number"),
+  /** Terminal Release Order Number — X12 code "2B". */
   TERMINAL_RELEASE_ORDER_NUMBER("2B", "Terminal Release Order Number"),
+  /** Long-term Disability Policy Number — X12 code "2C". */
   LONG_TERM_DISABILITY_POLICY_NUMBER("2C", "Long-term Disability Policy Number"),
+  /** Aeronautical Equipment Reference Number (AERNO) — X12 code "2D". */
   AERNO("2D", "Aeronautical Equipment Reference Number (AERNO)"),
+  /** Foreign Military Sales Case Number — X12 code "2E". */
   FOREIGN_MILITARY_SALES_CASE_NUMBER("2E", "Foreign Military Sales Case Number"),
+  /** Consolidated Invoice Number — X12 code "2F". */
   CONSOLIDATED_INVOICE_NUMBER("2F", "Consolidated Invoice Number"),
+  /** Amendment — X12 code "2G". */
   AMENDMENT("2G", "Amendment"),
+  /** Assigned by transaction set sender — X12 code "2H". */
   ASSIGNED_BY_TRANSACTION_SET_SENDER("2H", "Assigned by transaction set sender"),
+  /** Tracking Number — X12 code "2I". */
   TRACKING_NUMBER("2I", "Tracking Number"),
+  /** Floor Number — X12 code "2J". */
   FLOOR_NUMBER("2J", "Floor Number"),
+  /** Food and Drug Administration (FDA) Product Type — X12 code "2K". */
   FDA_PRODUCT_TYPE("2K", "Food and Drug Administration (FDA) Product Type"),
+  /** Association of American Railroads (AAR) Railway Accounting Rules — X12 code "2L". */
   AAR_RAILWAY_ACCOUNTING_RULES(
       "2L", "Association of American Railroads (AAR) Railway Accounting Rules"),
+  /** Federal Communications Commission (FCC) Identifier — X12 code "2M". */
   FCC_IDENTIFIER("2M", "Federal Communications Commission (FCC) Identifier"),
+  /** Federal Communications Commission (FCC) Trade/Brand Identifier — X12 code "2N". */
   FCC_TRADE_BRAND_IDENTIFIER(
       "2N", "Federal Communications Commission (FCC) Trade/Brand Identifier"),
+  /** Occupational Safety and Health Administration (OSHA) Claim Number — X12 code "2O". */
   OSHA_CLAIM_NUMBER("2O", "Occupational Safety and Health Administration (OSHA) Claim Number"),
+  /** Subdivision Identifier — X12 code "2P". */
   SUBDIVISION_IDENTIFIER("2P", "Subdivision Identifier"),
+  /** Food and Drug Administration (FDA) Accession Number — X12 code "2Q". */
   FDA_ACCESSION_NUMBER("2Q", "Food and Drug Administration (FDA) Accession Number"),
+  /** Coupon Redemption Number — X12 code "2R". */
   COUPON_REDEMPTION_NUMBER("2R", "Coupon Redemption Number"),
+  /** Catalog — X12 code "2S". */
   CATALOG("2S", "Catalog"),
+  /** Sub-subhouse Bill of Lading — X12 code "2T". */
   SUB_SUBHOUSE_BILL_OF_LADING("2T", "Sub-subhouse Bill of Lading"),
+  /** Payer Identification Number — X12 code "2U". */
   PAYER_IDENTIFICATION_NUMBER("2U", "Payer Identification Number"),
+  /** Special Government Accounting Classification Reference Number (ACRN) — X12 code "2V". */
   ACRN("2V", "Special Government Accounting Classification Reference Number (ACRN)"),
+  /** Change Order Authority — X12 code "2W". */
   CHANGE_ORDER_AUTHORITY("2W", "Change Order Authority"),
+  /** Supplemental Agreement Authority — X12 code "2X". */
   SUPPLEMENTAL_AGREEMENT_AUTHORITY("2X", "Supplemental Agreement Authority"),
+  /** Internal Order Number — X12 code "IL". */
   INTERNAL_ORDER_NUMBER("IL", "Internal Order Number"),
+  /** Mutually Defined — X12 code "ZZ". */
   MUTUALLY_DEFINED("ZZ", "Mutually Defined"),
+  /** Master Policy Number — X12 code "38". */
   MASTER_POLICY_NUMBER("38", "Master Policy Number"),
+  /** Department/Agency Number — X12 code "DX". */
   DEPARTMENT_NUMBER("DX", "Department/Agency Number"),
+  /** Client Reporting Category — X12 code "17". */
   CLIENT_REPORTING_CATEGORY("17", "Client Reporting Category"),
+  /** Client Number — X12 code "23". */
   CLIENT_NUMBER("23", "Client Number"),
+  /** Case Number — X12 code "3H". */
   CASE_NUMBER("3H", "Case Number"),
+  /** Personal Identification Number (PIN) — X12 code "4A". */
   PERSONAL_IDENTIFICATION_NUMBER("4A", "Personal Identification Number (PIN)"),
+  /** Cross Reference Number — X12 code "6O". */
   CROSS_REFERENCE_NUMBER("6O", "Cross Reference Number"),
+  /** Group Number — X12 code "6P". */
   GROUP_NUMBER("6P", "Group Number"),
+  /** Personal ID Number — X12 code "ABB". */
   PERSONAL_ID_NUMBER("ABB", "Personal ID Number"),
+  /** National Council for Prescription Drug Programs Pharmacy Number — X12 code "D3". */
   NCPDP_PHARMACY_NUMBER("D3", "National Council for Prescription Drug Programs Pharmacy Number"),
+  /** Health Insurance Claim (HIC) Number — X12 code "F6". */
   HEALTH_INSURANCE_CLAIM_NUMBER("F6", "Health Insurance Claim (HIC) Number"),
+  /** Position Code — X12 code "P5". */
   POSITION_CODE("P5", "Position Code"),
+  /** Prior Identifier Number — X12 code "Q4". */
   PRIOR_IDENTIFIER_NUMBER("Q4", "Prior Identifier Number"),
+  /** Unit Number — X12 code "QQ". */
   UNIT_NUMBER("QQ", "Unit Number"),
+  /** Payment Category — X12 code "9V". */
   PAYMENT_CATEGORY("9V", "Payment Category"),
+  /** Class of Contract Code — X12 code "CE". */
   CLASS_OF_CONTRACT_CODE("CE", "Class of Contract Code"),
+  /** Service Contract (Coverage) Number — X12 code "E8". */
   SERVICE_CONTRACT_NUMBER("E8", "Service Contract (Coverage) Number"),
+  /** Medical Assistance Category — X12 code "M7". */
   MEDICAL_ASSISTANCE_CATEGORY("M7", "Medical Assistance Category"),
+  /** Rate code number — X12 code "RB". */
   RATE_CODE_NUMBER("RB", "Rate code number"),
+  /** Internal Control Number — X12 code "X9". */
   INTERNAL_CONTROL_NUMBER("X9", "Internal Control Number"),
+  /** Social Security Number — X12 code "34". */
   SOCIAL_SECURITY_NUMBER("34", "Social Security Number"),
+  /** Wage Determination — X12 code "2Y". */
   WAGE_DETERMINATION("2Y", "Wage Determination");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/ResponsibleAgencyCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/ResponsibleAgencyCode.java
@@ -23,7 +23,9 @@ import lombok.Getter;
  */
 @Getter
 public enum ResponsibleAgencyCode implements EdiCodeEnum {
+  /** Transportation Data Coordinating Committee (TDCC) — X12 code "T". */
   TDCC("T", "Transportation Data Coordinating Committee (TDCC)"),
+  /** Accredited Standards Committee X12 — X12 code "X". */
   ASC_X12("X", "Accredited Standards Committee X12");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/SecurityInformationQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/SecurityInformationQualifier.java
@@ -23,7 +23,9 @@ import lombok.Getter;
  */
 @Getter
 public enum SecurityInformationQualifier implements EdiCodeEnum {
+  /** No Security Information Present — X12 code "00". */
   NO_SECURITY_INFORMATION("00", "No Security Information Present"),
+  /** Password — X12 code "01". */
   PASSWORD("01", "Password");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/SecurityLevelCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/SecurityLevelCode.java
@@ -23,22 +23,39 @@ import lombok.Getter;
  */
 @Getter
 public enum SecurityLevelCode implements EdiCodeEnum {
+  /** Company Non-Classified — X12 code "00". */
   COMPANY_NON_CLASSIFIED("00", "Company Non-Classified"),
+  /** Company Internal Use Only — X12 code "01". */
   COMPANY_INTERNAL("01", "Company Internal Use Only"),
+  /** Company Confidential — X12 code "02". */
   COMPANY_CONFIDENTIAL("02", "Company Confidential"),
+  /** Company Confidential, Restricted (Need to Know) — X12 code "03". */
   COMPANY_CONFIDENTIAL_RESTRICTED("03", "Company Confidential, Restricted (Need to Know)"),
+  /** Company Registered (Signature Required) — X12 code "04". */
   COMPANY_REGISTERED("04", "Company Registered (Signature Required)"),
+  /** Personal — X12 code "05". */
   PERSONAL("05", "Personal"),
+  /** Supplier Proprietary — X12 code "06". */
   SUPPLIER_PROPRIETARY("06", "Supplier Proprietary"),
+  /** Company Defined (Trading Partner Level) — X12 code "09". */
   COMPANY_DEFINED("09", "Company Defined (Trading Partner Level)"),
+  /** Competition Sensitive — X12 code "11". */
   COMPETITION_SENSITIVE("11", "Competition Sensitive"),
+  /** Court Restricted — X12 code "20". */
   COURT_RESTRICTED("20", "Court Restricted"),
+  /** Juvenile Record Restricted — X12 code "21". */
   JUVENILE_RECORD_RESTRICTED("21", "Juvenile Record Restricted"),
+  /** Government Non-Classified — X12 code "90". */
   GOVERNMENT_NON_CLASSIFIED("90", "Government Non-Classified"),
+  /** Government Confidential — X12 code "92". */
   GOVERNMENT_CONFIDENTIAL("92", "Government Confidential"),
+  /** Government Secret — X12 code "93". */
   GOVERNMENT_SECRET("93", "Government Secret"),
+  /** Government Top Secret — X12 code "94". */
   GOVERNMENT_TOP_SECRET("94", "Government Top Secret"),
+  /** Government Defined (Trading Partner Level) — X12 code "99". */
   GOVERNMENT_DEFINED("99", "Government Defined (Trading Partner Level)"),
+  /** Mutually Defined — X12 code "ZZ". */
   MUTUALLY_DEFINED("ZZ", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/TimeCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/TimeCode.java
@@ -23,56 +23,107 @@ import lombok.Getter;
  */
 @Getter
 public enum TimeCode implements EdiCodeEnum {
+  /** Equivalent to ISO P01 — X12 code "01". */
   ISO_P01("01", "Equivalent to ISO P01"),
+  /** Equivalent to ISO P02 — X12 code "02". */
   ISO_P02("02", "Equivalent to ISO P02"),
+  /** Equivalent to ISO P03 — X12 code "03". */
   ISO_P03("03", "Equivalent to ISO P03"),
+  /** Equivalent to ISO P04 — X12 code "04". */
   ISO_P04("04", "Equivalent to ISO P04"),
+  /** Equivalent to ISO P05 — X12 code "05". */
   ISO_P05("05", "Equivalent to ISO P05"),
+  /** Equivalent to ISO P06 — X12 code "06". */
   ISO_P06("06", "Equivalent to ISO P06"),
+  /** Equivalent to ISO P07 — X12 code "07". */
   ISO_P07("07", "Equivalent to ISO P07"),
+  /** Equivalent to ISO P08 — X12 code "08". */
   ISO_P08("08", "Equivalent to ISO P08"),
+  /** Equivalent to ISO P09 — X12 code "09". */
   ISO_P09("09", "Equivalent to ISO P09"),
+  /** Equivalent to ISO P10 — X12 code "10". */
   ISO_P10("10", "Equivalent to ISO P10"),
+  /** Equivalent to ISO P11 — X12 code "11". */
   ISO_P11("11", "Equivalent to ISO P11"),
+  /** Equivalent to ISO P12 — X12 code "12". */
   ISO_P12("12", "Equivalent to ISO P12"),
+  /** Equivalent to ISO M12 — X12 code "13". */
   ISO_M12("13", "Equivalent to ISO M12"),
+  /** Equivalent to ISO M11 — X12 code "14". */
   ISO_M11("14", "Equivalent to ISO M11"),
+  /** Equivalent to ISO M10 — X12 code "15". */
   ISO_M10("15", "Equivalent to ISO M10"),
+  /** Equivalent to ISO M09 — X12 code "16". */
   ISO_M09("16", "Equivalent to ISO M09"),
+  /** Equivalent to ISO M08 — X12 code "17". */
   ISO_M08("17", "Equivalent to ISO M08"),
+  /** Equivalent to ISO M07 — X12 code "18". */
   ISO_M07("18", "Equivalent to ISO M07"),
+  /** Equivalent to ISO M06 — X12 code "19". */
   ISO_M06("19", "Equivalent to ISO M06"),
+  /** Equivalent to ISO M05 — X12 code "20". */
   ISO_M05("20", "Equivalent to ISO M05"),
+  /** Equivalent to ISO M04 — X12 code "21". */
   ISO_M04("21", "Equivalent to ISO M04"),
+  /** Equivalent to ISO M03 — X12 code "22". */
   ISO_M03("22", "Equivalent to ISO M03"),
+  /** Equivalent to ISO M02 — X12 code "23". */
   ISO_M02("23", "Equivalent to ISO M02"),
+  /** Equivalent to ISO M01 — X12 code "24". */
   ISO_M01("24", "Equivalent to ISO M01"),
+  /** Alaska Daylight Time — X12 code "AD". */
   ALASKA_DAYLIGHT("AD", "Alaska Daylight Time"),
+  /** Alaska Standard Time — X12 code "AS". */
   ALASKA_STANDARD("AS", "Alaska Standard Time"),
+  /** Alaska Time — X12 code "AT". */
   ALASKA_TIME("AT", "Alaska Time"),
+  /** Central Daylight Time — X12 code "CD". */
   CENTRAL_DAYLIGHT("CD", "Central Daylight Time"),
+  /** Central Standard Time — X12 code "CS". */
   CENTRAL_STANDARD("CS", "Central Standard Time"),
+  /** Central Time — X12 code "CT". */
   CENTRAL_TIME("CT", "Central Time"),
+  /** Eastern Daylight Time — X12 code "ED". */
   EASTERN_DAYLIGHT("ED", "Eastern Daylight Time"),
+  /** Eastern Standard Time — X12 code "ES". */
   EASTERN_STANDARD("ES", "Eastern Standard Time"),
+  /** Eastern Time — X12 code "ET". */
   EASTERN_TIME("ET", "Eastern Time"),
+  /** Greenwich Mean Time — X12 code "GM". */
   GREENWICH_MEAN("GM", "Greenwich Mean Time"),
+  /** Hawaii-Aleutian Daylight Time — X12 code "HD". */
   HAWAII_ALEUTIAN_DAYLIGHT("HD", "Hawaii-Aleutian Daylight Time"),
+  /** Hawaii-Aleutian Standard Time — X12 code "HS". */
   HAWAII_ALEUTIAN_STANDARD("HS", "Hawaii-Aleutian Standard Time"),
+  /** Hawaii-Aleutian Time — X12 code "HT". */
   HAWAII_ALEUTIAN_TIME("HT", "Hawaii-Aleutian Time"),
+  /** Local Time — X12 code "LT". */
   LOCAL_TIME("LT", "Local Time"),
+  /** Mountain Daylight Time — X12 code "MD". */
   MOUNTAIN_DAYLIGHT("MD", "Mountain Daylight Time"),
+  /** Mountain Standard Time — X12 code "MS". */
   MOUNTAIN_STANDARD("MS", "Mountain Standard Time"),
+  /** Mountain Time — X12 code "MT". */
   MOUNTAIN_TIME("MT", "Mountain Time"),
+  /** Newfoundland Daylight Time — X12 code "ND". */
   NEWFOUNDLAND_DAYLIGHT("ND", "Newfoundland Daylight Time"),
+  /** Newfoundland Standard Time — X12 code "NS". */
   NEWFOUNDLAND_STANDARD("NS", "Newfoundland Standard Time"),
+  /** Newfoundland Time — X12 code "NT". */
   NEWFOUNDLAND_TIME("NT", "Newfoundland Time"),
+  /** Pacific Daylight Time — X12 code "PD". */
   PACIFIC_DAYLIGHT("PD", "Pacific Daylight Time"),
+  /** Pacific Standard Time — X12 code "PS". */
   PACIFIC_STANDARD("PS", "Pacific Standard Time"),
+  /** Pacific Time — X12 code "PT". */
   PACIFIC_TIME("PT", "Pacific Time"),
+  /** Atlantic Daylight Time — X12 code "TD". */
   ATLANTIC_DAYLIGHT("TD", "Atlantic Daylight Time"),
+  /** Atlantic Standard Time — X12 code "TS". */
   ATLANTIC_STANDARD("TS", "Atlantic Standard Time"),
+  /** Atlantic Time — X12 code "TT". */
   ATLANTIC_TIME("TT", "Atlantic Time"),
+  /** Universal Time Coordinate — X12 code "UT". */
   UNIVERSAL_TIME("UT", "Universal Time Coordinate");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionSetIdentifierCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionSetIdentifierCode.java
@@ -23,78 +23,147 @@ import lombok.Getter;
  */
 @Getter
 public enum TransactionSetIdentifierCode implements EdiCodeEnum {
+  /** Insurance Plan Description — X12 code "100". */
   INSURANCE_PLAN_DESCRIPTION("100", "Insurance Plan Description"),
+  /** Name and Address Lists — X12 code "101". */
   NAME_AND_ADDRESS_LISTS("101", "Name and Address Lists"),
+  /** Associated Data — X12 code "102". */
   ASSOCIATED_DATA("102", "Associated Data"),
+  /** Abandoned Property Filings — X12 code "103". */
   ABANDONED_PROPERTY_FILINGS("103", "Abandoned Property Filings"),
+  /** Air Shipment Information — X12 code "104". */
   AIR_SHIPMENT_INFORMATION("104", "Air Shipment Information"),
+  /** Business Entity Filings — X12 code "105". */
   BUSINESS_ENTITY_FILINGS("105", "Business Entity Filings"),
+  /** Motor Carrier Rate Proposal — X12 code "106". */
   MOTOR_CARRIER_RATE_PROPOSAL("106", "Motor Carrier Rate Proposal"),
+  /** Request for Motor Carrier Rate Proposal — X12 code "107". */
   REQUEST_FOR_MOTOR_CARRIER_RATE_PROPOSAL("107", "Request for Motor Carrier Rate Proposal"),
+  /** Response to a Motor Carrier Rate Proposal — X12 code "108". */
   RESPONSE_TO_MOTOR_CARRIER_RATE_PROPOSAL("108", "Response to a Motor Carrier Rate Proposal"),
+  /** Vessel Content Details — X12 code "109". */
   VESSEL_CONTENT_DETAILS("109", "Vessel Content Details"),
+  /** Air Freight Details and Invoice — X12 code "110". */
   AIR_FREIGHT_DETAILS_AND_INVOICE("110", "Air Freight Details and Invoice"),
+  /** Individual Insurance Policy and Client Information — X12 code "111". */
   INDIVIDUAL_INSURANCE_POLICY("111", "Individual Insurance Policy and Client Information"),
+  /** Property Damage Report — X12 code "112". */
   PROPERTY_DAMAGE_REPORT("112", "Property Damage Report"),
+  /** Election Campaign and Lobbyist Reporting — X12 code "113". */
   ELECTION_CAMPAIGN_REPORTING("113", "Election Campaign and Lobbyist Reporting"),
+  /** Vehicle Shipping Order — X12 code "120". */
   VEHICLE_SHIPPING_ORDER("120", "Vehicle Shipping Order"),
+  /** Vehicle Service — X12 code "121". */
   VEHICLE_SERVICE("121", "Vehicle Service"),
+  /** Vehicle Damage — X12 code "124". */
   VEHICLE_DAMAGE("124", "Vehicle Damage"),
+  /** Multilevel Railcar Load Details — X12 code "125". */
   MULTILEVEL_RAILCAR_LOAD_DETAILS("125", "Multilevel Railcar Load Details"),
+  /** Vehicle Application Advice — X12 code "126". */
   VEHICLE_APPLICATION_ADVICE("126", "Vehicle Application Advice"),
+  /** Vehicle Baying Order — X12 code "127". */
   VEHICLE_BAYING_ORDER("127", "Vehicle Baying Order"),
+  /** Dealer Information — X12 code "128". */
   DEALER_INFORMATION("128", "Dealer Information"),
+  /** Vehicle Carrier Rate Update — X12 code "129". */
   VEHICLE_CARRIER_RATE_UPDATE("129", "Vehicle Carrier Rate Update"),
+  /** Student Educational Record (Transcript) — X12 code "130". */
   STUDENT_EDUCATIONAL_RECORD("130", "Student Educational Record (Transcript)"),
+  /** Student Educational Record (Transcript) Acknowledgment — X12 code "131". */
   STUDENT_EDUCATIONAL_RECORD_ACKNOWLEDGMENT(
       "131", "Student Educational Record (Transcript) Acknowledgment"),
+  /** Human Resource Information — X12 code "132". */
   HUMAN_RESOURCE_INFORMATION("132", "Human Resource Information"),
+  /** Educational Institution Record — X12 code "133". */
   EDUCATIONAL_INSTITUTION_RECORD("133", "Educational Institution Record"),
+  /** Student Aid Origination Record — X12 code "135". */
   STUDENT_AID_ORIGINATION_RECORD("135", "Student Aid Origination Record"),
+  /** Educational Testing and Prospect Request and Report — X12 code "138". */
   EDUCATIONAL_TESTING("138", "Educational Testing and Prospect Request and Report"),
+  /** Student Loan Guarantee Result — X12 code "139". */
   STUDENT_LOAN_GUARANTEE_RESULT("139", "Student Loan Guarantee Result"),
+  /** Product Registration — X12 code "140". */
   PRODUCT_REGISTRATION("140", "Product Registration"),
+  /** Product Service Claim Response — X12 code "141". */
   PRODUCT_SERVICE_CLAIM_RESPONSE("141", "Product Service Claim Response"),
+  /** Product Service Claim — X12 code "142". */
   PRODUCT_SERVICE_CLAIM("142", "Product Service Claim"),
+  /** Product Service Notification — X12 code "143". */
   PRODUCT_SERVICE_NOTIFICATION("143", "Product Service Notification"),
+  /** Student Loan Transfer and Status Verification — X12 code "144". */
   STUDENT_LOAN_TRANSFER("144", "Student Loan Transfer and Status Verification"),
+  /** Request for Student Educational Record (Transcript) — X12 code "146". */
   REQUEST_FOR_STUDENT_RECORD("146", "Request for Student Educational Record (Transcript)"),
+  /** Response to Request for Student Educational Record (Transcript) — X12 code "147". */
   RESPONSE_TO_REQUEST_FOR_STUDENT_RECORD(
       "147", "Response to Request for Student Educational Record (Transcript)"),
+  /** Report of Injury, Illness or Incident — X12 code "148". */
   INJURY_REPORT("148", "Report of Injury, Illness or Incident"),
+  /** Notice of Tax Adjustment or Assessment — X12 code "149". */
   TAX_ADJUSTMENT_NOTICE("149", "Notice of Tax Adjustment or Assessment"),
+  /** Tax Rate Notification — X12 code "150". */
   TAX_RATE_NOTIFICATION("150", "Tax Rate Notification"),
+  /** Electronic Filing of Tax Return Data Acknowledgment — X12 code "151". */
   TAX_RETURN_DATA_ACKNOWLEDGMENT("151", "Electronic Filing of Tax Return Data Acknowledgment"),
+  /** Statistical Government Information — X12 code "152". */
   STATISTICAL_GOVERNMENT_INFORMATION("152", "Statistical Government Information"),
+  /** Unemployment Insurance Tax Claim or Charge Information — X12 code "153". */
   UNEMPLOYMENT_INSURANCE_TAX_CLAIM("153", "Unemployment Insurance Tax Claim or Charge Information"),
+  /** Secured Interest Filing — X12 code "154". */
   SECURED_INTEREST_FILING("154", "Secured Interest Filing"),
+  /** Business Credit Report — X12 code "155". */
   BUSINESS_CREDIT_REPORT("155", "Business Credit Report"),
+  /** Notice of Power of Attorney — X12 code "157". */
   NOTICE_OF_POWER_OF_ATTORNEY("157", "Notice of Power of Attorney"),
+  /** Tax Jurisdiction Sourcing — X12 code "158". */
   TAX_JURISDICTION_SOURCING("158", "Tax Jurisdiction Sourcing"),
+  /** Motion Picture Booking Confirmation — X12 code "159". */
   MOTION_PICTURE_BOOKING_CONFIRMATION("159", "Motion Picture Booking Confirmation"),
+  /** Transportation Automatic Equipment Identification — X12 code "160". */
   TRANSPORTATION_EQUIPMENT_IDENTIFICATION(
       "160", "Transportation Automatic Equipment Identification"),
+  /** Train Sheet — X12 code "161". */
   TRAIN_SHEET("161", "Train Sheet"),
+  /** Transportation Appointment Schedule Information — X12 code "163". */
   TRANSPORTATION_APPOINTMENT_SCHEDULE("163", "Transportation Appointment Schedule Information"),
+  /** Revenue Receipts Statement — X12 code "170". */
   REVENUE_RECEIPTS_STATEMENT("170", "Revenue Receipts Statement"),
+  /** Court and Law Enforcement Notice — X12 code "175". */
   COURT_NOTICE("175", "Court and Law Enforcement Notice"),
+  /** Court Submission — X12 code "176". */
   COURT_SUBMISSION("176", "Court Submission"),
+  /** Environmental Compliance Reporting — X12 code "179". */
   ENVIRONMENTAL_COMPLIANCE_REPORTING("179", "Environmental Compliance Reporting"),
+  /** Return Merchandise Authorization and Notification — X12 code "180". */
   RETURN_MERCHANDISE_AUTHORIZATION("180", "Return Merchandise Authorization and Notification"),
+  /** Royalty Regulatory Report — X12 code "185". */
   ROYALTY_REGULATORY_REPORT("185", "Royalty Regulatory Report"),
+  /** Insurance Underwriting Requirements Reporting — X12 code "186". */
   INSURANCE_UNDERWRITING_REQUIREMENTS("186", "Insurance Underwriting Requirements Reporting"),
+  /** Premium Audit Request and Return — X12 code "187". */
   PREMIUM_AUDIT_REQUEST("187", "Premium Audit Request and Return"),
+  /** Educational Course Inventory — X12 code "188". */
   EDUCATIONAL_COURSE_INVENTORY("188", "Educational Course Inventory"),
+  /** Application for Admission to Educational Institutions — X12 code "189". */
   ADMISSION_APPLICATION("189", "Application for Admission to Educational Institutions"),
+  /** Student Enrollment Verification — X12 code "190". */
   STUDENT_ENROLLMENT_VERIFICATION("190", "Student Enrollment Verification"),
+  /** Student Loan Pre-Claims and Claims — X12 code "191". */
   STUDENT_LOAN_CLAIMS("191", "Student Loan Pre-Claims and Claims"),
+  /** Grant or Assistance Application — X12 code "194". */
   GRANT_APPLICATION("194", "Grant or Assistance Application"),
+  /** Federal Communications Commission (FCC) License Application — X12 code "195". */
   FCC_LICENSE_APPLICATION("195", "Federal Communications Commission (FCC) License Application"),
+  /** Contractor Cost Data Reporting — X12 code "196". */
   CONTRACTOR_COST_DATA_REPORTING("196", "Contractor Cost Data Reporting"),
+  /** Real Estate Title Evidence — X12 code "197". */
   REAL_ESTATE_TITLE_EVIDENCE("197", "Real Estate Title Evidence"),
+  /** Loan Verification Information — X12 code "198". */
   LOAN_VERIFICATION_INFORMATION("198", "Loan Verification Information"),
+  /** Real Estate Settlement Information — X12 code "199". */
   REAL_ESTATE_SETTLEMENT_INFORMATION("199", "Real Estate Settlement Information"),
   // Add more codes as needed
+  /** Benefit Enrollment and Maintenance — X12 code "834". */
   BENEFIT_ENROLLMENT_AND_MAINTENANCE("834", "Benefit Enrollment and Maintenance");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionSetPurposeCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionSetPurposeCode.java
@@ -23,71 +23,137 @@ import lombok.Getter;
  */
 @Getter
 public enum TransactionSetPurposeCode implements EdiCodeEnum {
+  /** Original — X12 code "00". */
   ORIGINAL("00", "Original"),
+  /** Cancellation — X12 code "01". */
   CANCELLATION("01", "Cancellation"),
+  /** Add — X12 code "02". */
   ADD("02", "Add"),
+  /** Delete — X12 code "03". */
   DELETE("03", "Delete"),
+  /** Change — X12 code "04". */
   CHANGE("04", "Change"),
+  /** Replace — X12 code "05". */
   REPLACE("05", "Replace"),
+  /** Chargeable Resubmission — X12 code "5C". */
   CHARGEABLE_RESUBMISSION("5C", "Chargeable Resubmission"),
+  /** Confirmation — X12 code "06". */
   CONFIRMATION("06", "Confirmation"),
+  /** Duplicate — X12 code "07". */
   DUPLICATE("07", "Duplicate"),
+  /** Status — X12 code "08". */
   STATUS("08", "Status"),
+  /** Not Found — X12 code "10". */
   NOT_FOUND("10", "Not Found"),
+  /** Response — X12 code "11". */
   RESPONSE("11", "Response"),
+  /** Not Processed — X12 code "12". */
   NOT_PROCESSED("12", "Not Processed"),
+  /** Request — X12 code "13". */
   REQUEST("13", "Request"),
+  /** Advance Notification — X12 code "14". */
   ADVANCE_NOTIFICATION("14", "Advance Notification"),
+  /** Re-Submission — X12 code "15". */
   RESUBMISSION("15", "Re-Submission"),
+  /** Proposed — X12 code "16". */
   PROPOSED("16", "Proposed"),
+  /** Cancel, to be Reissued — X12 code "17". */
   CANCEL_TO_BE_REISSUED("17", "Cancel, to be Reissued"),
+  /** Reissue — X12 code "18". */
   REISSUE("18", "Reissue"),
+  /** Seller initiated change — X12 code "19". */
   SELLER_INITIATED_CHANGE("19", "Seller initiated change"),
+  /** Final Transmission — X12 code "20". */
   FINAL_TRANSMISSION("20", "Final Transmission"),
+  /** Transaction on Hold — X12 code "21". */
   TRANSACTION_ON_HOLD("21", "Transaction on Hold"),
+  /** Information Copy — X12 code "22". */
   INFORMATION_COPY("22", "Information Copy"),
+  /** Draft — X12 code "24". */
   DRAFT("24", "Draft"),
+  /** Incremental — X12 code "25". */
   INCREMENTAL("25", "Incremental"),
+  /** Replace - Specified Buyers Parts Only — X12 code "26". */
   REPLACE_SPECIFIED_BUYERS_PARTS_ONLY("26", "Replace - Specified Buyers Parts Only"),
+  /** Verify — X12 code "27". */
   VERIFY("27", "Verify"),
+  /** Query — X12 code "28". */
   QUERY("28", "Query"),
+  /** Renewal — X12 code "30". */
   RENEWAL("30", "Renewal"),
+  /** Allowance/Addition — X12 code "31". */
   ALLOWANCE_ADDITION("31", "Allowance/Addition"),
+  /** Recovery/Deduction — X12 code "32". */
   RECOVERY_DEDUCTION("32", "Recovery/Deduction"),
+  /** Request for Payment — X12 code "33". */
   REQUEST_FOR_PAYMENT("33", "Request for Payment"),
+  /** Payment Declined — X12 code "34". */
   PAYMENT_DECLINED("34", "Payment Declined"),
+  /** Request Authority — X12 code "35". */
   REQUEST_AUTHORITY("35", "Request Authority"),
+  /** Authority to Deduct (Reply) — X12 code "36". */
   AUTHORITY_TO_DEDUCT_REPLY("36", "Authority to Deduct (Reply)"),
+  /** Authority Declined (Reply) — X12 code "37". */
   AUTHORITY_DECLINED_REPLY("37", "Authority Declined (Reply)"),
+  /** No Financial Value — X12 code "38". */
   NO_FINANCIAL_VALUE("38", "No Financial Value"),
+  /** Response to Proposed Trip Plan — X12 code "39". */
   RESPONSE_TO_PROPOSED_TRIP_PLAN("39", "Response to Proposed Trip Plan"),
+  /** Commitment Advice — X12 code "40". */
   COMMITMENT_ADVICE("40", "Commitment Advice"),
+  /** Corrected and Verified — X12 code "41". */
   CORRECTED_AND_VERIFIED("41", "Corrected and Verified"),
+  /** Temporary Record — X12 code "42". */
   TEMPORARY_RECORD("42", "Temporary Record"),
+  /** Request Permission to Service — X12 code "43". */
   REQUEST_PERMISSION_TO_SERVICE("43", "Request Permission to Service"),
+  /** Rejection — X12 code "44". */
   REJECTION("44", "Rejection"),
+  /** Follow-up — X12 code "45". */
   FOLLOW_UP("45", "Follow-up"),
+  /** Cancellation with Refund — X12 code "46". */
   CANCELLATION_WITH_REFUND("46", "Cancellation with Refund"),
+  /** Transfer — X12 code "47". */
   TRANSFER("47", "Transfer"),
+  /** Suspended — X12 code "48". */
   SUSPENDED("48", "Suspended"),
+  /** Original - No Response Necessary — X12 code "49". */
   ORIGINAL_NO_RESPONSE_NECESSARY("49", "Original - No Response Necessary"),
+  /** Register — X12 code "50". */
   REGISTER("50", "Register"),
+  /** Historical Inquiry — X12 code "51". */
   HISTORICAL_INQUIRY("51", "Historical Inquiry"),
+  /** Response to Historical Inquiry — X12 code "52". */
   RESPONSE_TO_HISTORICAL_INQUIRY("52", "Response to Historical Inquiry"),
+  /** Completion — X12 code "53". */
   COMPLETION("53", "Completion"),
+  /** Approval — X12 code "54". */
   APPROVAL("54", "Approval"),
+  /** Excavation — X12 code "55". */
   EXCAVATION("55", "Excavation"),
+  /** Expiration Notification — X12 code "56". */
   EXPIRATION_NOTIFICATION("56", "Expiration Notification"),
+  /** Initial — X12 code "57". */
   INITIAL("57", "Initial"),
+  /** Simulation Exercise — X12 code "77". */
   SIMULATION_EXERCISE("77", "Simulation Exercise"),
+  /** Completion Notification — X12 code "CN". */
   COMPLETION_NOTIFICATION("CN", "Completion Notification"),
+  /** Corrected — X12 code "CO". */
   CORRECTED("CO", "Corrected"),
+  /** Final Loading Configuration — X12 code "EX". */
   FINAL_LOADING_CONFIGURATION("EX", "Final Loading Configuration"),
+  /** Granted — X12 code "GR". */
   GRANTED("GR", "Granted"),
+  /** Proposed Loading Configuration — X12 code "PR". */
   PROPOSED_LOADING_CONFIGURATION("PR", "Proposed Loading Configuration"),
+  /** Release Hold — X12 code "RH". */
   RELEASE_HOLD("RH", "Release Hold"),
+  /** Revised Loading Configuration — X12 code "RV". */
   REVISED_LOADING_CONFIGURATION("RV", "Revised Loading Configuration"),
+  /** Status Update — X12 code "SU". */
   STATUS_UPDATE("SU", "Status Update"),
+  /** Mutually Defined — X12 code "ZZ". */
   MUTUALLY_DEFINED("ZZ", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionTypeCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/TransactionTypeCode.java
@@ -23,36 +23,66 @@ import lombok.Getter;
  */
 @Getter
 public enum TransactionTypeCode implements EdiCodeEnum {
+  /** Location Address Message — X12 code "01". */
   LOCATION_ADDRESS("01", "Location Address Message"),
+  /** Unique Item Tracking Control Report — X12 code "1A". */
   UNIQUE_TRACKING_CONTROL("1A", "Unique Item Tracking Control Report"),
+  /** Unique Item Tracking Report Reconciliation — X12 code "1B". */
   UNIQUE_TRACKING_RECONCILIATION("1B", "Unique Item Tracking Report Reconciliation"),
+  /** Location Relation Information — X12 code "02". */
   LOCATION_RELATION("02", "Location Relation Information"),
+  /** Report Message — X12 code "03". */
   REPORT_MESSAGE("03", "Report Message"),
+  /** Supporting Information — X12 code "3M". */
   SUPPORTING_INFORMATION("3M", "Supporting Information"),
+  /** Electronic Mail Message — X12 code "04". */
   ELECTRONIC_MAIL("04", "Electronic Mail Message"),
+  /** Request for Co-op — X12 code "05". */
   REQUEST_FOR_COOP("05", "Request for Co-op"),
+  /** Guidelines — X12 code "06". */
   GUIDELINES("06", "Guidelines"),
+  /** Accomplishment Based Renewal — X12 code "6A". */
   ACCOMPLISHMENT_RENEWAL("6A", "Accomplishment Based Renewal"),
+  /** Competitive Renewal — X12 code "6C". */
   COMPETITIVE_RENEWAL("6C", "Competitive Renewal"),
+  /** Non-competitive Renewal — X12 code "6N". */
   NON_COMPETITIVE_RENEWAL("6N", "Non-competitive Renewal"),
+  /** Resubmission — X12 code "6R". */
   RESUBMISSION("6R", "Resubmission"),
+  /** Supplemental — X12 code "6S". */
   SUPPLEMENTAL("6S", "Supplemental"),
+  /** Budget — X12 code "07". */
   BUDGET("07", "Budget"),
+  /** Commitment — X12 code "08". */
   COMMITMENT("08", "Commitment"),
+  /** Co-op Actual — X12 code "09". */
   COOP_ACTUAL("09", "Co-op Actual"),
+  /** Distribution — X12 code "10". */
   DISTRIBUTION("10", "Distribution"),
+  /** National Property Registry System Real Estate Property Transaction — X12 code "11". */
   PROPERTY_TRANSACTION("11", "National Property Registry System Real Estate Property Transaction"),
+  /** Physician's Report — X12 code "12". */
   PHYSICIAN_REPORT("12", "Physician's Report"),
+  /** Maintenance Request — X12 code "13". */
   MAINTENANCE_REQUEST("13", "Maintenance Request"),
+  /** Maintenance Response — X12 code "14". */
   MAINTENANCE_RESPONSE("14", "Maintenance Response"),
+  /** Request with Immediate Response Required (No Follow-up) — X12 code "15". */
   REQUEST_IMMEDIATE_NO_FOLLOWUP("15", "Request with Immediate Response Required (No Follow-up)"),
+  /** Request with Immediate Response Required (Follow-up Required) — X12 code "16". */
   REQUEST_IMMEDIATE_WITH_FOLLOWUP(
       "16", "Request with Immediate Response Required (Follow-up Required)"),
+  /** Request with Immediate Response to Mailbox — X12 code "17". */
   REQUEST_RESPONSE_TO_MAILBOX("17", "Request with Immediate Response to Mailbox"),
+  /** Response - No Further Updates to Follow — X12 code "18". */
   RESPONSE_NO_UPDATES("18", "Response - No Further Updates to Follow"),
+  /** Response - Further Updates to Follow — X12 code "19". */
   RESPONSE_UPDATES_FOLLOW("19", "Response - Further Updates to Follow"),
+  /** Air Export Waybill and Invoice — X12 code "20". */
   AIR_EXPORT_WAYBILL("20", "Air Export Waybill and Invoice"),
+  /** Report sent by National Center for Education Statistics (NCES) — X12 code "T1". */
   REPORT_SENT_BY_NCES("T1", "Report sent by National Center for Education Statistics (NCES)"),
+  /** Mutually Defined — X12 code "ZZ". */
   MUTUALLY_DEFINED("ZZ", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/VersionCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/VersionCode.java
@@ -24,136 +24,306 @@ import lombok.Getter;
  */
 @Getter
 public enum VersionCode implements EdiCodeEnum {
+  /** ASC X12 Standards Approved by ANSI in 1983 — X12 code "001000". */
   VERSION_001000("001000", "ASC X12 Standards Approved by ANSI in 1983"),
+  /** ASC X12 Standards Approved by ANSI in 1986 — X12 code "002000". */
   VERSION_002000("002000", "ASC X12 Standards Approved by ANSI in 1986"),
+  /** Draft Standards Approved by ASC X12 in November 1987 — X12 code "002001". */
   VERSION_002001("002001", "Draft Standards Approved by ASC X12 in November 1987"),
+  /** Draft Standards Approved by ASC X12 through February 1988 — X12 code "002002". */
   VERSION_002002("002002", "Draft Standards Approved by ASC X12 through February 1988"),
+  /** Draft Standards Approved by ASC X12 through August 1988 — X12 code "002003". */
   VERSION_002003("002003", "Draft Standards Approved by ASC X12 through August 1988"),
+  /** Draft Standards Approved by ASC X12 through February 1989 — X12 code "002031". */
   VERSION_002031("002031", "Draft Standards Approved by ASC X12 through February 1989"),
+  /** Draft Standards Approved by ASC X12 through May 1989 — X12 code "002040". */
   VERSION_002040("002040", "Draft Standards Approved by ASC X12 through May 1989"),
+  /** Draft Standards Approved by ASC X12 through October 1989 — X12 code "002041". */
   VERSION_002041("002041", "Draft Standards Approved by ASC X12 through October 1989"),
+  /** Draft Standards Approved by ASC X12 through February 1990 — X12 code "002042". */
   VERSION_002042("002042", "Draft Standards Approved by ASC X12 through February 1990"),
+  /** ASC X12 Standards Approved by ANSI in 1992 — X12 code "003000". */
   VERSION_003000("003000", "ASC X12 Standards Approved by ANSI in 1992"),
+  /** Draft Standards Approved by ASC X12 through June 1990 — X12 code "003010". */
   VERSION_003010("003010", "Draft Standards Approved by ASC X12 through June 1990"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February
+   * 1991 — X12 code "003011".
+   */
   VERSION_003011(
       "003011",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February 1991"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1991 —
+   * X12 code "003012".
+   */
   VERSION_003012(
       "003012",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1991"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October
+   * 1991 — X12 code "003020".
+   */
   VERSION_003020(
       "003020",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October 1991"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February
+   * 1992 — X12 code "003021".
+   */
   VERSION_003021(
       "003021",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February 1992"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1992 —
+   * X12 code "003022".
+   */
   VERSION_003022(
       "003022",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1992"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October
+   * 1992 — X12 code "003030".
+   */
   VERSION_003030(
       "003030",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October 1992"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February
+   * 1993 — X12 code "003031".
+   */
   VERSION_003031(
       "003031",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February 1993"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1993 —
+   * X12 code "003032".
+   */
   VERSION_003032(
       "003032",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1993"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October
+   * 1993 — X12 code "003040".
+   */
   VERSION_003040(
       "003040",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October 1993"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February
+   * 1994 — X12 code "003041".
+   */
   VERSION_003041(
       "003041",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February 1994"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1994 —
+   * X12 code "003042".
+   */
   VERSION_003042(
       "003042",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1994"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October
+   * 1994 — X12 code "003050".
+   */
   VERSION_003050(
       "003050",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October 1994"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February
+   * 1995 — X12 code "003051".
+   */
   VERSION_003051(
       "003051",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February 1995"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1995 —
+   * X12 code "003052".
+   */
   VERSION_003052(
       "003052",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1995"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October
+   * 1995 — X12 code "003060".
+   */
   VERSION_003060(
       "003060",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October 1995"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February
+   * 1996 — X12 code "003061".
+   */
   VERSION_003061(
       "003061",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February 1996"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1996 —
+   * X12 code "003062".
+   */
   VERSION_003062(
       "003062",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1996"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October
+   * 1996 — X12 code "003070".
+   */
   VERSION_003070(
       "003070",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through October 1996"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February
+   * 1997 — X12 code "003071".
+   */
   VERSION_003071(
       "003071",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through February 1997"),
+  /**
+   * Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1997 —
+   * X12 code "003072".
+   */
   VERSION_003072(
       "003072",
       "Draft Standards Approved for Publication by ASC X12 Procedures Review Board through June 1997"),
+  /** ASC X12 Standards Approved by ANSI in 1997 — X12 code "004000". */
   VERSION_004000("004000", "ASC X12 Standards Approved by ANSI in 1997"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 1997 —
+   * X12 code "004010".
+   */
   VERSION_004010(
       "004010",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 1997"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through February 1998 —
+   * X12 code "004011".
+   */
   VERSION_004011(
       "004011",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through February 1998"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through June 1998 — X12
+   * code "004012".
+   */
   VERSION_004012(
       "004012",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through June 1998"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 1998 —
+   * X12 code "004020".
+   */
   VERSION_004020(
       "004020",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 1998"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through February 1999 —
+   * X12 code "004021".
+   */
   VERSION_004021(
       "004021",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through February 1999"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through June 1999 — X12
+   * code "004022".
+   */
   VERSION_004022(
       "004022",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through June 1999"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 1999 —
+   * X12 code "004030".
+   */
   VERSION_004030(
       "004030",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 1999"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through February 2000 —
+   * X12 code "004031".
+   */
   VERSION_004031(
       "004031",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through February 2000"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through June 2000 — X12
+   * code "004032".
+   */
   VERSION_004032(
       "004032",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through June 2000"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 2000 —
+   * X12 code "004040".
+   */
   VERSION_004040(
       "004040",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 2000"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through February 2001 —
+   * X12 code "004041".
+   */
   VERSION_004041(
       "004041",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through February 2001"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through June 2001 — X12
+   * code "004042".
+   */
   VERSION_004042(
       "004042",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through June 2001"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 2001 —
+   * X12 code "004050".
+   */
   VERSION_004050(
       "004050",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 2001"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through February 2002 —
+   * X12 code "004051".
+   */
   VERSION_004051(
       "004051",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through February 2002"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through June 2002 — X12
+   * code "004052".
+   */
   VERSION_004052(
       "004052",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through June 2002"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 2002 —
+   * X12 code "004060".
+   */
   VERSION_004060(
       "004060",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 2002"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through February 2003 —
+   * X12 code "004061".
+   */
   VERSION_004061(
       "004061",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through February 2003"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through June 2003 — X12
+   * code "004062".
+   */
   VERSION_004062(
       "004062",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through June 2003"),
+  /** ASC X12 Standards Approved by ANSI in 2003 — X12 code "005000". */
   VERSION_005000("005000", "ASC X12 Standards Approved by ANSI in 2003"),
+  /**
+   * Standards Approved for Publication by ASC X12 Procedures Review Board through October 2003 —
+   * X12 code "005010".
+   */
   VERSION_005010(
       "005010",
       "Standards Approved for Publication by ASC X12 Procedures Review Board through October 2003"),
+  /** Standards Approved for Publication by ASC X12 — X12 code "005010X220A1". */
   VERSION_005010X220A1("005010X220A1", "Standards Approved for Publication by ASC X12");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/data/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/data/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * Shared ASC X12 code-set dictionaries (action, date/time qualifiers, identifiers, yes/no, and the
+ * rest) exposed as enums; each constant carries its wire code and description. All are resolvable
+ * from code, name, description or synonym via their {@code fromString} methods.
+ */
+package com.fastChickensHR.edi.x834.data;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/dates/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/dates/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * Date and time rendering for the 834: {@link com.fastChickensHR.edi.x834.dates.DateFormat} and
+ * {@link com.fastChickensHR.edi.x834.dates.TimeFormat} are the public formatting seam, each
+ * formatting a {@code LocalDateTime} into its X12 representation.
+ */
+package com.fastChickensHR.edi.x834.dates;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/exception/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/exception/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * The checked construction-phase failure channel: {@link
+ * com.fastChickensHR.edi.x834.exception.ValidationException} is thrown by a component's own
+ * build/validate when required 834 fields are missing or malformed — distinct from the
+ * document-level accumulate-never-throw {@link com.fastChickensHR.edi.x834.GenerationResult}.
+ */
+package com.fastChickensHR.edi.x834.exception;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834FileGenerator.java
@@ -82,6 +82,9 @@ import java.util.stream.Collectors;
  */
 public final class X834FileGenerator implements FileGenerator {
 
+  /** Creates a generator. The generator is stateless; one instance can serve many files. */
+  public X834FileGenerator() {}
+
   @Override
   public String generate(FileContent file) {
     try {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/X834Location.java
@@ -22,7 +22,10 @@ public final class X834Location {
   private X834Location() {}
 
   // ---- File level: envelope + control numbers (X834Context) ----
+  /** Render-location key {@value}. */
   public static final String SENDER_ID = "senderId"; // ISA06
+
+  /** Render-location key {@value}. */
   public static final String RECEIVER_ID = "receiverId"; // ISA08
 
   /** ISA05 — interchange sender ID qualifier; absent keeps the header default ("30"). */
@@ -37,23 +40,46 @@ public final class X834Location {
   /** GS03 — application receiver's code; falls back to {@link #RECEIVER_ID} when absent. */
   public static final String APPLICATION_RECEIVER_CODE = "applicationReceiverCode";
 
+  /** Render-location key {@value}. */
   public static final String INTERCHANGE_CONTROL_NUMBER = "interchangeControlNumber";
+
+  /** Render-location key {@value}. */
   public static final String GROUP_CONTROL_NUMBER = "groupControlNumber";
+
+  /** Render-location key {@value}. */
   public static final String TRANSACTION_SET_CONTROL_NUMBER = "transactionSetControlNumber";
+
+  /** Render-location key {@value}. */
   public static final String DOCUMENT_DATE = "documentDate";
+
+  /** Render-location key {@value}. */
   public static final String ACKNOWLEDGMENT_REQUESTED =
       "acknowledgmentRequested"; // ISA14 ("1" requests a TA1/999)
 
   // ---- File level: header data (Header.Builder) ----
+  /** Render-location key {@value}. */
   public static final String TRANSACTION_SET_ID = "transactionSetId";
+
+  /** Render-location key {@value}. */
   public static final String REFERENCE_IDENTIFICATION = "referenceIdentification"; // BGN02
+
+  /** Render-location key {@value}. */
   public static final String MASTER_POLICY_NUMBER = "masterPolicyNumber"; // REF*38
+
+  /** Render-location key {@value}. */
   public static final String PLAN_SPONSOR_NAME = "planSponsorName"; // N1*P5
+
+  /** Render-location key {@value}. */
   public static final String PAYER_NAME = "payerName"; // N1*IN
 
   // ---- Member level: INS / built-in REF / DTP (Member fields) ----
+  /** Render-location key {@value}. */
   public static final String MEMBER_INDICATOR = "memberIndicator"; // INS01
+
+  /** Render-location key {@value}. */
   public static final String RELATIONSHIP_CODE = "relationshipCode"; // INS02
+
+  /** Render-location key {@value}. */
   public static final String MAINTENANCE_TYPE_CODE = "maintenanceTypeCode"; // INS03
 
   /**
@@ -70,28 +96,64 @@ public final class X834Location {
    */
   public static final String EMPLOYMENT_STATUS_CODE = "employmentStatusCode";
 
+  /** Render-location key {@value}. */
   public static final String POLICY_NUMBER = "policyNumber"; // REF*1L
+
+  /** Render-location key {@value}. */
   public static final String MEMBER_ID = "memberId"; // REF*<qual>
+
+  /** Render-location key {@value}. */
   public static final String MEMBER_ID_QUALIFIER = "memberIdQualifier"; // that REF's qualifier
+
+  /** Render-location key {@value}. */
   public static final String SUBSCRIBER_NUMBER = "subscriberNumber"; // REF*OF
+
+  /** Render-location key {@value}. */
   public static final String ENROLLMENT_DATE =
       "enrollmentDate"; // DTP*300 (Enrollment Signature Date)
+
+  /** Render-location key {@value}. */
   public static final String COVERAGE_START_DATE =
       "coverageStartDate"; // DTP*356 (Eligibility Begin)
+
+  /** Render-location key {@value}. */
   public static final String COVERAGE_END_DATE = "coverageEndDate"; // DTP*357
 
   // ---- Member level: Loop 2100A name / demographics / residence address ----
+  /** Render-location key {@value}. */
   public static final String LAST_NAME = "lastName"; // NM103
+
+  /** Render-location key {@value}. */
   public static final String FIRST_NAME = "firstName"; // NM104
+
+  /** Render-location key {@value}. */
   public static final String MIDDLE_NAME = "middleName"; // NM105
+
+  /** Render-location key {@value}. */
   public static final String NAME_ID_QUALIFIER = "nameIdQualifier"; // NM108 (e.g. 34 = SSN)
+
+  /** Render-location key {@value}. */
   public static final String NAME_ID = "nameId"; // NM109 (e.g. the SSN)
+
+  /** Render-location key {@value}. */
   public static final String BIRTH_DATE = "birthDate"; // DMG02 (D8)
+
+  /** Render-location key {@value}. */
   public static final String GENDER = "gender"; // DMG03
+
+  /** Render-location key {@value}. */
   public static final String ADDRESS_LINE_1 = "addressLine1"; // N301
+
+  /** Render-location key {@value}. */
   public static final String ADDRESS_LINE_2 = "addressLine2"; // N302
+
+  /** Render-location key {@value}. */
   public static final String CITY = "city"; // N401
+
+  /** Render-location key {@value}. */
   public static final String STATE = "state"; // N402
+
+  /** Render-location key {@value}. */
   public static final String ZIP_CODE = "zipCode"; // N403
 
   // ---- Member level: Loop 2100A PER (communications numbers) ----
@@ -141,6 +203,7 @@ public final class X834Location {
   public static final String HLH_DESCRIPTION = "hlh.description";
 
   // ---- Member level: Loop 2100A LUI (member language) ----
+  /** Render-location key {@value}. */
   public static final String LUI_PREFIX = "lui.";
 
   /** LUI01 — what kind of code {@link #LUI_CODE} is. Required with it. */
@@ -159,12 +222,17 @@ public final class X834Location {
    * "lui.1.description"}. Languages emit in ascending index order, and the un-indexed {@code LUI_*}
    * constants remain a single implicit language — the same convention {@link #hd(int, String)} uses
    * for coverage groups.
+   *
+   * @param index the occurrence index to embed in the key
+   * @param luiField the un-indexed {@code lui.*} key constant to rewrite
+   * @return the indexed key, {@code lui.<index>.<suffix>}
    */
   public static String lui(int index, String luiField) {
     return LUI_PREFIX + index + "." + luiField.substring(LUI_PREFIX.length());
   }
 
   // ---- Member level: Loop 2310 (provider) ----
+  /** Render-location key {@value}. */
   public static final String PROVIDER_PREFIX = "provider.";
 
   /** 2310 NM103 — the provider's last or organization name. */
@@ -201,12 +269,17 @@ public final class X834Location {
    * The position name for the {@code index}-th provider of one member, so a Record can carry
    * several — {@code provider(1, PROVIDER_LAST_NAME)} &rarr; {@code "provider.1.lastName"}. Same
    * indexed convention as {@link #hd(int, String)}; un-indexed keys are a single implicit provider.
+   *
+   * @param index the occurrence index to embed in the key
+   * @param providerField the un-indexed {@code provider.*} key constant to rewrite
+   * @return the indexed key, {@code provider.<index>.<suffix>}
    */
   public static String provider(int index, String providerField) {
     return PROVIDER_PREFIX + index + "." + providerField.substring(PROVIDER_PREFIX.length());
   }
 
   // ---- Member level: Loop 2320/2330 (coordination of benefits) ----
+  /** Render-location key {@value}. */
   public static final String COB_PREFIX = "cob.";
 
   /** 2320 COB01 — where the other payer sits in the payment order. Required. */
@@ -237,12 +310,17 @@ public final class X834Location {
    * The position name for the {@code index}-th other plan of one member — {@code cob(1,
    * COB_BEGIN_DATE)} &rarr; {@code "cob.1.beginDate"}. The 834 permits five; a sixth is rejected
    * when written.
+   *
+   * @param index the occurrence index to embed in the key
+   * @param cobField the un-indexed {@code cob.*} key constant to rewrite
+   * @return the indexed key, {@code cob.<index>.<suffix>}
    */
   public static String cob(int index, String cobField) {
     return COB_PREFIX + index + "." + cobField.substring(COB_PREFIX.length());
   }
 
   // ---- Member level: Loop 2200 (disability) ----
+  /** Render-location key {@value}. */
   public static final String DISABILITY_PREFIX = "disability.";
 
   /** 2200 DSB01 — what kind of disability this is. Required; the dates cannot travel without it. */
@@ -273,12 +351,17 @@ public final class X834Location {
    * The position name for the {@code index}-th disability of one member — {@code disability(1,
    * DISABILITY_START_DATE)} &rarr; {@code "disability.1.startDate"}. The same indexed convention as
    * {@link #hd(int, String)}.
+   *
+   * @param index the occurrence index to embed in the key
+   * @param disabilityField the un-indexed {@code disability.*} key constant to rewrite
+   * @return the indexed key, {@code disability.<index>.<suffix>}
    */
   public static String disability(int index, String disabilityField) {
     return DISABILITY_PREFIX + index + "." + disabilityField.substring(DISABILITY_PREFIX.length());
   }
 
   // ---- Member level: Loops 2700/2750 (member reporting categories) ----
+  /** Render-location key {@value}. */
   public static final String CATEGORY_PREFIX = "category.";
 
   /** 2750 {@code N1*75} N102 — the category label, e.g. {@code CLASS}. Required. */
@@ -301,25 +384,47 @@ public final class X834Location {
    * category(1, CATEGORY_VALUE)} &rarr; {@code "category.1.value"}. Categories emit in ascending
    * index order inside a single {@code LS*2700} … {@code LE*2700} block, and the {@code LX} number
    * is assigned at render time over the emitted occurrences.
+   *
+   * @param index the occurrence index to embed in the key
+   * @param categoryField the un-indexed {@code category.*} key constant to rewrite
+   * @return the indexed key, {@code category.<index>.<suffix>}
    */
   public static String category(int index, String categoryField) {
     return CATEGORY_PREFIX + index + "." + categoryField.substring(CATEGORY_PREFIX.length());
   }
 
   // ---- Member level: Loop 2100C mailing address ----
+  /** Render-location key {@value}. */
   public static final String MAILING_ADDRESS_LINE_1 = "mailingAddressLine1"; // 2100C N301
+
+  /** Render-location key {@value}. */
   public static final String MAILING_ADDRESS_LINE_2 = "mailingAddressLine2"; // 2100C N302
+
+  /** Render-location key {@value}. */
   public static final String MAILING_CITY = "mailingCity"; // 2100C N401
+
+  /** Render-location key {@value}. */
   public static final String MAILING_STATE = "mailingState"; // 2100C N402
+
+  /** Render-location key {@value}. */
   public static final String MAILING_ZIP_CODE = "mailingZipCode"; // 2100C N403
 
   // ---- Member level: health coverage (HD segment) ----
+  /** Render-location key {@value}. */
   public static final String HD_PREFIX = "hd.";
+
   // The 220A1 HD segment carries only HD01/HD03/HD04/HD05; HD02 and HD06+ are Not Used
   // (employment status lives on INS08, not HD09), so there are no HD_* fields for them.
+  /** Render-location key {@value}. */
   public static final String HD_MAINTENANCE_TYPE_CODE = "hd.maintenanceTypeCode"; // HD01
+
+  /** Render-location key {@value}. */
   public static final String HD_INSURANCE_LINE_CODE = "hd.insuranceLineCode"; // HD03
+
+  /** Render-location key {@value}. */
   public static final String HD_PLAN_COVERAGE_DESCRIPTION = "hd.planCoverageDescription"; // HD04
+
+  /** Render-location key {@value}. */
   public static final String HD_COVERAGE_LEVEL_CODE = "hd.coverageLevelCode"; // HD05
 
   /** Loop 2300 coverage begin date — DTP*348 (D8). */
@@ -336,6 +441,10 @@ public final class X834Location {
    * "hd.1.benefitBeginDate"}. Groups emit in ascending index order, each with its own begin/end
    * DTPs. The un-indexed {@code HD_*} constants remain a single implicit group, so existing
    * single-coverage callers are unaffected.
+   *
+   * @param index the occurrence index to embed in the key
+   * @param hdField the un-indexed {@code hd.*} key constant to rewrite
+   * @return the indexed key, {@code hd.<index>.<suffix>}
    */
   public static String hd(int index, String hdField) {
     return HD_PREFIX + index + "." + hdField.substring(HD_PREFIX.length());

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/generate/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/generate/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * The String-seam entry point: {@link com.fastChickensHR.edi.x834.generate.X834FileGenerator}
+ * builds an 834 from a flat key/value map whose keys are the frozen {@link
+ * com.fastChickensHR.edi.x834.generate.X834Location} literals. Structured callers drive {@link
+ * com.fastChickensHR.edi.x834.X834Document} directly instead.
+ */
+package com.fastChickensHR.edi.x834.generate;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/Header.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/Header.java
@@ -57,6 +57,8 @@ public class Header {
    * Generates all the segments for this header
    *
    * @return List of segments in the correct order
+   * @throws ValidationException if the transaction set identifier code is missing, or a header
+   *     segment builder rejects its inputs
    */
   public List<Segment> generateSegments() throws ValidationException {
     validate();

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/header/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/header/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * The 834 envelope opening: {@link com.fastChickensHR.edi.x834.header.Header} renders ISA/GS/ST/BGN
+ * and the file-level names — {@link com.fastChickensHR.edi.x834.header.SponsorName} (1000A) and
+ * {@link com.fastChickensHR.edi.x834.header.Payer} (1000B).
+ */
+package com.fastChickensHR.edi.x834.header;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/Address.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/Address.java
@@ -10,7 +10,6 @@ package com.fastChickensHR.edi.x834.loop2000;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
  * A single typed postal address for a member (residence, mailing, work, ...).
@@ -20,7 +19,6 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class Address {
   private AddressType type;
@@ -30,7 +28,12 @@ public class Address {
   private String state;
   private String zipCode;
 
+  /** Creates an empty address; callers set the {@link AddressType} and lines afterwards. */
+  public Address() {}
+
   /**
+   * Whether the address is complete enough for its street segment.
+   *
    * @return true when this address carries a street line (the minimum needed to emit an N3).
    */
   public boolean hasStreet() {
@@ -38,6 +41,8 @@ public class Address {
   }
 
   /**
+   * Whether the address is complete enough for its city/state/postal segment.
+   *
    * @return true when city, state and postal code are all present (the minimum to emit an N4).
    */
   public boolean hasCityStateZip() {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -41,12 +41,35 @@ import lombok.Setter;
 @Getter
 @Setter
 public abstract class BaseMember {
+
+  /** Creates a member with no fields initialized; used by concrete member subclasses. */
+  protected BaseMember() {}
+
+  /**
+   * The member's own identifier, emitted as a member-level {@code REF} whose qualifier is {@code
+   * memberIdQualifier}.
+   */
   protected String memberId;
+
+  /** REF01 for the {@code memberId} REF — states what kind of identifier it is. */
   protected String memberIdQualifier;
+
+  /**
+   * REF02 under {@code REF*0F} (zero-F, Subscriber Number) — the subscriber identifier this member
+   * enrolls under.
+   */
   protected String subscriberNumber;
+
+  /** REF02 under {@code REF*1L} — the group or policy number for this member's enrollment. */
   protected String policyNumber;
+
+  /** NM104 — the member's first name (Loop 2100A NM1). */
   protected String firstName;
+
+  /** NM103 — the member's last name (Loop 2100A NM1). */
   protected String lastName;
+
+  /** NM105 — the member's middle name (Loop 2100A NM1). Optional. */
   protected String middleName;
 
   /**
@@ -61,12 +84,16 @@ public abstract class BaseMember {
    */
   protected String nameId;
 
+  /** DMG02 — the member's birth date, emitted in {@code D8} (CCYYMMDD) format. */
   protected LocalDateTime birthDate;
 
   /** DMG03 — the member's gender, drawn from the element-1068 code list. */
   protected GenderCode gender;
 
+  /** INS01 — whether this member is the subscriber ({@code Y}) or a dependent ({@code N}). */
   protected MemberIndicator memberIndicator;
+
+  /** INS03 — what kind of maintenance this is (element 875), e.g. addition or termination. */
   protected MaintenanceTypeCode maintenanceTypeCode;
 
   /**
@@ -81,9 +108,16 @@ public abstract class BaseMember {
    */
   protected EmploymentStatusCode employmentStatusCode;
 
+  /** DTP*300 — the enrollment signature date for this member's maintenance. */
   protected LocalDateTime enrollmentDate;
+
+  /** DTP*356 — the member's eligibility begin date. */
   protected LocalDateTime coverageStartDate;
+
+  /** DTP*357 — the member's eligibility end date. */
   protected LocalDateTime coverageEndDate;
+
+  /** INS02 — how this member relates to the subscriber (element 1069), e.g. self or spouse. */
   protected IndividualRelationshipCode relationshipCode;
 
   /**
@@ -143,6 +177,8 @@ public abstract class BaseMember {
   }
 
   /**
+   * Looks up this member's address of the given kind.
+   *
    * @param type the address kind to look up
    * @return this member's address of that type, if any
    */
@@ -165,42 +201,92 @@ public abstract class BaseMember {
   // Retained so existing callers (setAddressLine1/setCity/...) keep working; each reads/writes
   // the member's RESIDENCE address within {@link #addresses}.
 
+  /**
+   * Returns the first address line of the member's residence address.
+   *
+   * @return residence line 1, or null when the member has no residence address
+   */
   public String getAddressLine1() {
     return getAddress(AddressType.RESIDENCE).map(Address::getLine1).orElse(null);
   }
 
+  /**
+   * Returns the second address line of the member's residence address.
+   *
+   * @return residence line 2, or null when the member has no residence address
+   */
   public String getAddressLine2() {
     return getAddress(AddressType.RESIDENCE).map(Address::getLine2).orElse(null);
   }
 
+  /**
+   * Returns the city of the member's residence address.
+   *
+   * @return residence city, or null when the member has no residence address
+   */
   public String getCity() {
     return getAddress(AddressType.RESIDENCE).map(Address::getCity).orElse(null);
   }
 
+  /**
+   * Returns the state of the member's residence address.
+   *
+   * @return residence state, or null when the member has no residence address
+   */
   public String getState() {
     return getAddress(AddressType.RESIDENCE).map(Address::getState).orElse(null);
   }
 
+  /**
+   * Returns the ZIP code of the member's residence address.
+   *
+   * @return residence ZIP code, or null when the member has no residence address
+   */
   public String getZipCode() {
     return getAddress(AddressType.RESIDENCE).map(Address::getZipCode).orElse(null);
   }
 
+  /**
+   * Sets the first address line of the member's residence address, creating one if absent.
+   *
+   * @param value residence line 1
+   */
   public void setAddressLine1(String value) {
     residenceOrCreate().setLine1(value);
   }
 
+  /**
+   * Sets the second address line of the member's residence address, creating one if absent.
+   *
+   * @param value residence line 2
+   */
   public void setAddressLine2(String value) {
     residenceOrCreate().setLine2(value);
   }
 
+  /**
+   * Sets the city of the member's residence address, creating one if absent.
+   *
+   * @param value residence city
+   */
   public void setCity(String value) {
     residenceOrCreate().setCity(value);
   }
 
+  /**
+   * Sets the state of the member's residence address, creating one if absent.
+   *
+   * @param value residence state
+   */
   public void setState(String value) {
     residenceOrCreate().setState(value);
   }
 
+  /**
+   * Sets the ZIP code of the member's residence address, creating one if absent.
+   *
+   * @param value residence ZIP code
+   */
   public void setZipCode(String value) {
     residenceOrCreate().setZipCode(value);
   }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/DependentMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/DependentMember.java
@@ -21,6 +21,7 @@ import lombok.Setter;
 public class DependentMember extends BaseMember {
   private Member primaryMember;
 
+  /** Creates a dependent with no fields set; callers populate it afterwards. */
   public DependentMember() {
     // No-arg constructor; the X12 834 context is no longer a concern of the domain model.
   }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/Member.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/Member.java
@@ -25,6 +25,7 @@ import lombok.Setter;
 public class Member extends BaseMember {
   private final List<DependentMember> dependents = new ArrayList<>();
 
+  /** Creates a member with no fields set; callers populate it afterwards. */
   public Member() {
     // No-arg constructor; the X12 834 context is no longer a concern of the domain model.
   }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/BenefitStatusCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/BenefitStatusCode.java
@@ -23,11 +23,17 @@ import lombok.Getter;
  */
 @Getter
 public enum BenefitStatusCode implements EdiCodeEnum {
+  /** Active — X12 code "A". */
   ACTIVE("A", "Active"),
+  /** Consolidated Omnibus Budget Reconciliation Act (COBRA) — X12 code "C". */
   COBRA("C", "Consolidated Omnibus Budget Reconciliation Act (COBRA)"),
+  /** Involuntary — X12 code "I". */
   INVOLUNTARY("I", "Involuntary"),
+  /** Surviving Insured — X12 code "S". */
   SURVIVING_INSURED("S", "Surviving Insured"),
+  /** Tax Equity and Fiscal Responsibility Act (TEFRA) — X12 code "T". */
   TEFRA("T", "Tax Equity and Fiscal Responsibility Act (TEFRA)"),
+  /** Voluntary — X12 code "V". */
   VOLUNTARY("V", "Voluntary");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/COBRAQualifyingEventCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/COBRAQualifyingEventCode.java
@@ -23,16 +23,27 @@ import lombok.Getter;
  */
 @Getter
 public enum COBRAQualifyingEventCode implements EdiCodeEnum {
+  /** Termination of Employment — X12 code "1". */
   TERMINATION_OF_EMPLOYMENT("1", "Termination of Employment"),
+  /** Reduction of work hours — X12 code "2". */
   REDUCTION_OF_WORK_HOURS("2", "Reduction of work hours"),
+  /** Medicare — X12 code "3". */
   MEDICARE("3", "Medicare"),
+  /** Death — X12 code "4". */
   DEATH("4", "Death"),
+  /** Divorce — X12 code "5". */
   DIVORCE("5", "Divorce"),
+  /** Separation — X12 code "6". */
   SEPARATION("6", "Separation"),
+  /** Ineligible Child — X12 code "7". */
   INELIGIBLE_CHILD("7", "Ineligible Child"),
+  /** Bankruptcy of Retiree's Former Employer (26 U.S.C. 4980B(f)(3)(F)) — X12 code "8". */
   BANKRUPTCY("8", "Bankruptcy of Retiree's Former Employer (26 U.S.C. 4980B(f)(3)(F))"),
+  /** Layoff — X12 code "9". */
   LAYOFF("9", "Layoff"),
+  /** Leave of Absence — X12 code "10". */
   LEAVE_OF_ABSENCE("10", "Leave of Absence"),
+  /** Mutually Defined — X12 code "ZZ". */
   MUTUALLY_DEFINED("ZZ", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/ConfidentialityCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/ConfidentialityCode.java
@@ -22,8 +22,11 @@ import lombok.Getter;
  */
 @Getter
 public enum ConfidentialityCode implements EdiCodeEnum {
+  /** Other Restrictions — X12 code "O". */
   OTHER_RESTRICTIONS("O", "Other Restrictions"),
+  /** Restricted Access — X12 code "R". */
   RESTRICTED("R", "Restricted Access"),
+  /** Unrestricted Access — X12 code "U". */
   UNRESTRICTED("U", "Unrestricted Access");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/CoverageLevelCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/CoverageLevelCode.java
@@ -20,15 +20,25 @@ import lombok.Getter;
  */
 @Getter
 public enum CoverageLevelCode implements EdiCodeEnum {
+  /** Children Only — X12 code "CHD". */
   CHILDREN_ONLY("CHD", "Children Only"),
+  /** Dependents Only — X12 code "DEP". */
   DEPENDENTS_ONLY("DEP", "Dependents Only"),
+  /** Employee and Children — X12 code "ECH". */
   EMPLOYEE_AND_CHILDREN("ECH", "Employee and Children"),
+  /** Employee Only — X12 code "EMP". */
   EMPLOYEE_ONLY("EMP", "Employee Only"),
+  /** Employee and Spouse — X12 code "ESP". */
   EMPLOYEE_AND_SPOUSE("ESP", "Employee and Spouse"),
+  /** Family — X12 code "FAM". */
   FAMILY("FAM", "Family"),
+  /** Individual — X12 code "IND". */
   INDIVIDUAL("IND", "Individual"),
+  /** Spouse and Children — X12 code "SPC". */
   SPOUSE_AND_CHILDREN("SPC", "Spouse and Children"),
+  /** Spouse Only — X12 code "SPO". */
   SPOUSE_ONLY("SPO", "Spouse Only"),
+  /** Two Party — X12 code "TWO". */
   TWO_PARTY("TWO", "Two Party");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/EmploymentStatusCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/EmploymentStatusCode.java
@@ -23,97 +23,188 @@ import lombok.Getter;
  */
 @Getter
 public enum EmploymentStatusCode implements EdiCodeEnum {
+  /** Substitute — X12 code "00". */
   SUBSTITUTE("00", "Substitute"),
+  /** Leave of Absence with Pay — X12 code "AA". */
   LEAVE_OF_ABSENCE_WITH_PAY("AA", "Leave of Absence with Pay"),
+  /** Leave of Absence without Pay — X12 code "AB". */
   LEAVE_OF_ABSENCE_WITHOUT_PAY("AB", "Leave of Absence without Pay"),
+  /** Active — X12 code "AC". */
   ACTIVE("AC", "Active"),
+  /** Apprenticeship Full-time — X12 code "AD". */
   APPRENTICESHIP_FULL_TIME("AD", "Apprenticeship Full-time"),
+  /** Active Reserve — X12 code "AE". */
   ACTIVE_RESERVE("AE", "Active Reserve"),
+  /** Flexible Work Plan — X12 code "AF". */
   FLEXIBLE_WORK_PLAN("AF", "Flexible Work Plan"),
+  /** Alerted — X12 code "AG". */
   ALERTED("AG", "Alerted"),
+  /** Assigned — X12 code "AH". */
   ASSIGNED("AH", "Assigned"),
+  /** Affiliated with Outside Organization — X12 code "AI". */
   AFFILIATED_WITH_OUTSIDE_ORGANIZATION("AI", "Affiliated with Outside Organization"),
+  /** Adjunct — X12 code "AJ". */
   ADJUNCT("AJ", "Adjunct"),
+  /** Active Military - Overseas — X12 code "AO". */
   ACTIVE_MILITARY_OVERSEAS("AO", "Active Military - Overseas"),
+  /** Apprenticeship Part-time — X12 code "AP". */
   APPRENTICESHIP_PART_TIME("AP", "Apprenticeship Part-time"),
+  /** Apprenticeship — X12 code "AQ". */
   APPRENTICESHIP("AQ", "Apprenticeship"),
+  /** Academy Student — X12 code "AS". */
   ACADEMY_STUDENT("AS", "Academy Student"),
+  /** Presidential Appointee — X12 code "AT". */
   PRESIDENTIAL_APPOINTEE("AT", "Presidential Appointee"),
+  /** Active Military - USA — X12 code "AU". */
   ACTIVE_MILITARY_USA("AU", "Active Military - USA"),
+  /** Non-applicable Employment Status Category — X12 code "CA". */
   NON_APPLICABLE_EMPLOYMENT_STATUS_CATEGORY("CA", "Non-applicable Employment Status Category"),
+  /** Contractor — X12 code "CC". */
   CONTRACTOR("CC", "Contractor"),
+  /** Consolidated Omnibus Budget Reconciliation Act (COBRA) — X12 code "CO". */
   COBRA("CO", "Consolidated Omnibus Budget Reconciliation Act (COBRA)"),
+  /** Continued — X12 code "CT". */
   CONTINUED("CT", "Continued"),
+  /** Discharged or Terminated for Cause — X12 code "DC". */
   DISCHARGED_OR_TERMINATED_FOR_CAUSE("DC", "Discharged or Terminated for Cause"),
+  /** Dishonorably Discharged — X12 code "DD". */
   DISHONORABLY_DISCHARGED("DD", "Dishonorably Discharged"),
+  /** Deceased — X12 code "DI". */
   DECEASED("DI", "Deceased"),
+  /** Disqualified: Medical or Physical Condition — X12 code "DQ". */
   DISQUALIFIED_MEDICAL_OR_PHYSICAL_CONDITION("DQ", "Disqualified: Medical or Physical Condition"),
+  /** Disqualified: Other — X12 code "DR". */
   DISQUALIFIED_OTHER("DR", "Disqualified: Other"),
+  /** Disabled — X12 code "DS". */
   DISABLED("DS", "Disabled"),
+  /** Employed by Outside Organization — X12 code "EO". */
   EMPLOYED_BY_OUTSIDE_ORGANIZATION("EO", "Employed by Outside Organization"),
+  /** Furloughed: Job Abolished, Force Reduction — X12 code "FA". */
   FURLOUGHED_JOB_ABOLISHED("FA", "Furloughed: Job Abolished, Force Reduction"),
+  /** Furloughed: Bumped or Displaced — X12 code "FB". */
   FURLOUGHED_BUMPED_OR_DISPLACED("FB", "Furloughed: Bumped or Displaced"),
+  /** Furloughed: Facility Closed — X12 code "FC". */
   FURLOUGHED_FACILITY_CLOSED("FC", "Furloughed: Facility Closed"),
+  /** Furloughed: Other — X12 code "FO". */
   FURLOUGHED_OTHER("FO", "Furloughed: Other"),
+  /** Full-time — X12 code "FT". */
   FULL_TIME("FT", "Full-time"),
+  /** Honorably Discharged — X12 code "HD". */
   HONORABLY_DISCHARGED("HD", "Honorably Discharged"),
+  /** Inactive — X12 code "IA". */
   INACTIVE("IA", "Inactive"),
+  /** Inactive Reserves — X12 code "IR". */
   INACTIVE_RESERVES("IR", "Inactive Reserves"),
+  /** Leave of Absence — X12 code "L1". */
   LEAVE_OF_ABSENCE("L1", "Leave of Absence"),
+  /** Administrative Leave of Absence — X12 code "L2". */
   ADMINISTRATIVE_LEAVE_OF_ABSENCE("L2", "Administrative Leave of Absence"),
+  /** Annual Leave of Absence — X12 code "L3". */
   ANNUAL_LEAVE_OF_ABSENCE("L3", "Annual Leave of Absence"),
+  /** Leave of Absence due to Bereavement — X12 code "L4". */
   BEREAVEMENT_LEAVE_OF_ABSENCE("L4", "Leave of Absence due to Bereavement"),
+  /** Jury Duty — X12 code "L5". */
   JURY_DUTY("L5", "Jury Duty"),
+  /** Suspension — X12 code "L6". */
   SUSPENSION("L6", "Suspension"),
+  /** Sabbatical Leave of Absence — X12 code "L7". */
   SABBATICAL_LEAVE_OF_ABSENCE("L7", "Sabbatical Leave of Absence"),
+  /** Leave of Absence: Personal — X12 code "LA". */
   PERSONAL_LEAVE_OF_ABSENCE("LA", "Leave of Absence: Personal"),
+  /** Leave of Absence: Education — X12 code "LE". */
   EDUCATION_LEAVE_OF_ABSENCE("LE", "Leave of Absence: Education"),
+  /** Leave of Absence: Family Medical Leave Act (FMLA) — X12 code "LF". */
   FMLA_LEAVE_OF_ABSENCE("LF", "Leave of Absence: Family Medical Leave Act (FMLA)"),
+  /** Leave of Absence: Maternity — X12 code "LM". */
   MATERNITY_LEAVE_OF_ABSENCE("LM", "Leave of Absence: Maternity"),
+  /** Leave of Absence for Non-Military Government Request Other Than Jury Duty — X12 code "LO". */
   GOVERNMENT_LEAVE_OF_ABSENCE(
       "LO", "Leave of Absence for Non-Military Government Request Other Than Jury Duty"),
+  /** Leave of Absence: Sickness — X12 code "LS". */
   SICKNESS_LEAVE_OF_ABSENCE("LS", "Leave of Absence: Sickness"),
+  /** Leave of Absence: Union — X12 code "LU". */
   UNION_LEAVE_OF_ABSENCE("LU", "Leave of Absence: Union"),
+  /** Leave of Absence: Without Permission, Unauthorized — X12 code "LW". */
   UNAUTHORIZED_LEAVE_OF_ABSENCE("LW", "Leave of Absence: Without Permission, Unauthorized"),
+  /** Leave of Absence: Military — X12 code "LX". */
   MILITARY_LEAVE_OF_ABSENCE("LX", "Leave of Absence: Military"),
+  /** Not Employed — X12 code "NE". */
   NOT_EMPLOYED("NE", "Not Employed"),
+  /** On Strike — X12 code "OS". */
   ON_STRIKE("OS", "On Strike"),
+  /** Other — X12 code "OT". */
   OTHER("OT", "Other"),
+  /** Promoted — X12 code "PA". */
   PROMOTED("PA", "Promoted"),
+  /** Part-time Contractual — X12 code "PC". */
   PART_TIME_CONTRACTUAL("PC", "Part-time Contractual"),
+  /** Plan to Enlist — X12 code "PE". */
   PLAN_TO_ENLIST("PE", "Plan to Enlist"),
+  /** Permanent — X12 code "PM". */
   PERMANENT("PM", "Permanent"),
+  /** Part-time Noncontractual — X12 code "PN". */
   PART_TIME_NONCONTRACTUAL("PN", "Part-time Noncontractual"),
+  /** Probationary — X12 code "PR". */
   PROBATIONARY("PR", "Probationary"),
+  /** Part-time — X12 code "PT". */
   PART_TIME("PT", "Part-time"),
+  /** Previous — X12 code "PV". */
   PREVIOUS("PV", "Previous"),
+  /** Piece Worker — X12 code "PW". */
   PIECE_WORKER("PW", "Piece Worker"),
+  /** Resigned: Retired — X12 code "RA". */
   RESIGNED_RETIRED("RA", "Resigned: Retired"),
+  /** Relocated — X12 code "RB". */
   RELOCATED("RB", "Relocated"),
+  /** Reassigned — X12 code "RC". */
   REASSIGNED("RC", "Reassigned"),
+  /** Resigned: Moved — X12 code "RD". */
   RESIGNED_MOVED("RD", "Resigned: Moved"),
+  /** Recommissioned — X12 code "RE". */
   RECOMMISSIONED("RE", "Recommissioned"),
+  /** Resigned: Injury — X12 code "RI". */
   RESIGNED_INJURY("RI", "Resigned: Injury"),
+  /** Retired Military - Overseas — X12 code "RM". */
   RETIRED_MILITARY_OVERSEAS("RM", "Retired Military - Overseas"),
+  /** Resigned: Personal Reasons — X12 code "RP". */
   RESIGNED_PERSONAL_REASONS("RP", "Resigned: Personal Reasons"),
+  /** Retired Without Recall — X12 code "RR". */
   RETIRED_WITHOUT_RECALL("RR", "Retired Without Recall"),
+  /** Retired — X12 code "RT". */
   RETIRED("RT", "Retired"),
+  /** Retired Military - USA — X12 code "RU". */
   RETIRED_MILITARY_USA("RU", "Retired Military - USA"),
+  /** Dual Retired Status — X12 code "RW". */
   DUAL_RETIRED_STATUS("RW", "Dual Retired Status"),
+  /** Resigned: Accepted Separation Allowance — X12 code "SA". */
   RESIGNED_SEPARATION_ALLOWANCE("SA", "Resigned: Accepted Separation Allowance"),
+  /** Separated — X12 code "SB". */
   SEPARATED("SB", "Separated"),
+  /** Self-Employed — X12 code "SE". */
   SELF_EMPLOYED("SE", "Self-Employed"),
+  /** Seasonal — X12 code "SL". */
   SEASONAL("SL", "Seasonal"),
+  /** Suspended — X12 code "SU". */
   SUSPENDED("SU", "Suspended"),
+  /** Terminated — X12 code "TE". */
   TERMINATED("TE", "Terminated"),
+  /** Temporary Full-Time — X12 code "TF". */
   TEMPORARY_FULL_TIME("TF", "Temporary Full-Time"),
+  /** Temporary — X12 code "TM". */
   TEMPORARY("TM", "Temporary"),
+  /** Tenured — X12 code "TN". */
   TENURED("TN", "Tenured"),
+  /** Temporary Part-Time — X12 code "TP". */
   TEMPORARY_PART_TIME("TP", "Temporary Part-Time"),
+  /** Transferred — X12 code "TR". */
   TRANSFERRED("TR", "Transferred"),
+  /** Unknown — X12 code "UK". */
   UNKNOWN("UK", "Unknown"),
+  /** Volunteer — X12 code "VO". */
   VOLUNTEER("VO", "Volunteer"),
+  /** Extra Duties Not Requiring Certification — X12 code "XD". */
   EXTRA_DUTIES("XD", "Extra Duties Not Requiring Certification"),
+  /** Mutually Defined — X12 code "ZZ". */
   MUTUALLY_DEFINED("ZZ", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/GenderCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/GenderCode.java
@@ -18,10 +18,15 @@ import lombok.Getter;
  */
 @Getter
 public enum GenderCode implements EdiCodeEnum {
+  /** Male — X12 code "M". */
   MALE("M", "Male"),
+  /** Female — X12 code "F". */
   FEMALE("F", "Female"),
+  /** Unknown — X12 code "U". */
   UNKNOWN("U", "Unknown"),
+  /** Non-Binary — X12 code "N". */
   NON_BINARY("N", "Non-Binary"),
+  /** Not Specified — X12 code "X". */
   NOT_SPECIFIED("X", "Not Specified");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/HandicapIndicator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/HandicapIndicator.java
@@ -18,8 +18,11 @@ import lombok.Getter;
  */
 @Getter
 public enum HandicapIndicator implements EdiCodeEnum {
+  /** Yes - Individual has a handicap — X12 code "Y". */
   YES("Y", "Yes - Individual has a handicap"),
+  /** No - Individual does not have a handicap — X12 code "N". */
   NO("N", "No - Individual does not have a handicap"),
+  /** Unknown handicap status — X12 code "U". */
   UNKNOWN("U", "Unknown handicap status");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/HealthCoverageDateQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/HealthCoverageDateQualifier.java
@@ -18,12 +18,19 @@ import lombok.Getter;
  */
 @Getter
 public enum HealthCoverageDateQualifier implements EdiCodeEnum {
+  /** Plan Begin Date — X12 code "348". */
   EFFECTIVE_DATE("348", "Plan Begin Date"),
+  /** Plan End Date — X12 code "349". */
   EXPIRATION_DATE("349", "Plan End Date"),
+  /** Eligibility Begin Date — X12 code "356". */
   ELIGIBILITY_BEGIN("356", "Eligibility Begin Date"),
+  /** Eligibility End Date — X12 code "357". */
   ELIGIBILITY_END("357", "Eligibility End Date"),
+  /** COBRA Begin Date — X12 code "340". */
   COBRA_BEGIN("340", "COBRA Begin Date"),
+  /** COBRA End Date — X12 code "341". */
   COBRA_END("341", "COBRA End Date"),
+  /** Premium Paid To Date — X12 code "289". */
   PREMIUM_PAID_TO_DATE("289", "Premium Paid To Date");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/IndividualRelationshipCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/IndividualRelationshipCode.java
@@ -18,12 +18,19 @@ import lombok.Getter;
  */
 @Getter
 public enum IndividualRelationshipCode implements EdiCodeEnum {
+  /** Spouse — X12 code "01". */
   SPOUSE("01", "Spouse"),
+  /** Child — X12 code "19". */
   CHILD("19", "Child"),
+  /** Employee — X12 code "20". */
   EMPLOYEE("20", "Employee"),
+  /** Disabled Dependent — X12 code "22". */
   DISABLED_DEPENDENT("22", "Disabled Dependent"),
+  /** Self — X12 code "18". */
   SELF("18", "Self"),
+  /** Life Partner — X12 code "53". */
   LIFE_PARTNER("53", "Life Partner"),
+  /** Other Related — X12 code "29". */
   OTHER_RELATED("29", "Other Related");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/InsuranceLineCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/InsuranceLineCode.java
@@ -25,62 +25,120 @@ import lombok.Getter;
  */
 @Getter
 public enum InsuranceLineCode implements EdiCodeEnum {
+  /** 403(B) Tax Sheltered Annuity — X12 code "403". */
   TAX_SHELTERED_ANNUITY_403B("403", "403(B) Tax Sheltered Annuity"),
+  /** Durable Medical Equipment — X12 code "AAA". */
   DURABLE_MEDICAL_EQUIPMENT("AAA", "Durable Medical Equipment"),
+  /** Foot Care — X12 code "AAB". */
   FOOT_CARE("AAB", "Foot Care"),
+  /** Substance Abuse — X12 code "AAC". */
   SUBSTANCE_ABUSE("AAC", "Substance Abuse"),
+  /** Basic Life — X12 code "AC". */
   BASIC_LIFE("AC", "Basic Life"),
+  /** Accidental Death or Dismemberment — X12 code "ADD". */
   ACCIDENTAL_DEATH_OR_DISMEMBERMENT("ADD", "Accidental Death or Dismemberment"),
+  /** Supplemental Life — X12 code "AF". */
   SUPPLEMENTAL_LIFE("AF", "Supplemental Life"),
+  /** Preventative Care/Wellness — X12 code "AG". */
   PREVENTATIVE_CARE_WELLNESS("AG", "Preventative Care/Wellness"),
+  /** 24 Hour Care — X12 code "AH". */
   TWENTY_FOUR_HOUR_CARE("AH", "24 Hour Care"),
+  /** Workers Compensation — X12 code "AI". */
   WORKERS_COMPENSATION("AI", "Workers Compensation"),
+  /** Medicare Risk — X12 code "AJ". */
   MEDICARE_RISK("AJ", "Medicare Risk"),
+  /** Mental Health — X12 code "AK". */
   MENTAL_HEALTH("AK", "Mental Health"),
+  /** Alternative Medicine — X12 code "AM". */
   ALTERNATIVE_MEDICINE("AM", "Alternative Medicine"),
+  /** Paid Up Life — X12 code "AP". */
   PAID_UP_LIFE("AP", "Paid Up Life"),
+  /** Dependent Life — X12 code "AR". */
   DEPENDENT_LIFE("AR", "Dependent Life"),
+  /** Acupuncture — X12 code "AU". */
   ACUPUNCTURE("AU", "Acupuncture"),
+  /** Death and Dismemberment — X12 code "BC". */
   DEATH_AND_DISMEMBERMENT("BC", "Death and Dismemberment"),
+  /** Supplemental Death and Dismemberment — X12 code "BE". */
   SUPPLEMENTAL_DEATH_AND_DISMEMBERMENT("BE", "Supplemental Death and Dismemberment"),
+  /** Weekly Indemnity — X12 code "BH". */
   WEEKLY_INDEMNITY("BH", "Weekly Indemnity"),
+  /** Weekly Indemnity - New York Employees — X12 code "BK". */
   WEEKLY_INDEMNITY_NEW_YORK("BK", "Weekly Indemnity - New York Employees"),
+  /** Chiropractic Care — X12 code "CC". */
   CHIROPRACTIC_CARE("CC", "Chiropractic Care"),
+  /** 403(C) Church Exempt Annuity Plans Covered by ERISA — X12 code "CHU". */
   CHURCH_EXEMPT_ANNUITY_403C("CHU", "403(C) Church Exempt Annuity Plans Covered by ERISA"),
+  /** Contributory Life — X12 code "CLF". */
   CONTRIBUTORY_LIFE("CLF", "Contributory Life"),
+  /** Employee Comprehensive — X12 code "CV". */
   EMPLOYEE_COMPREHENSIVE("CV", "Employee Comprehensive"),
+  /** Dental Capitation — X12 code "DCP". */
   DENTAL_CAPITATION("DCP", "Dental Capitation"),
+  /** Dental — X12 code "DEN". */
   DENTAL("DEN", "Dental"),
+  /**
+   * 408(K) Employer Sponsored Qualified Defined Distribution Plans Funded with Individual IRA's —
+   * X12 code "EMP".
+   */
   EMPLOYER_SPONSORED_408K(
       "EMP",
       "408(K) Employer Sponsored Qualified Defined Distribution Plans Funded with Individual IRA's"),
+  /** Exclusive Provider Organization — X12 code "EPO". */
   EXCLUSIVE_PROVIDER_ORGANIZATION("EPO", "Exclusive Provider Organization"),
+  /** Facility — X12 code "FAC". */
   FACILITY("FAC", "Facility"),
+  /** Flexible Spending — X12 code "FSA". */
   FLEXIBLE_SPENDING("FSA", "Flexible Spending"),
+  /** 457(B) Government Deferred Compensation — X12 code "GDC". */
   GOVERNMENT_DEFERRED_COMPENSATION_457B("GDC", "457(B) Government Deferred Compensation"),
+  /** Hearing — X12 code "HE". */
   HEARING("HE", "Hearing"),
+  /** Health — X12 code "HLT". */
   HEALTH("HLT", "Health"),
+  /** Health Maintenance Organization — X12 code "HMO". */
   HEALTH_MAINTENANCE_ORGANIZATION("HMO", "Health Maintenance Organization"),
+  /** Group Individual Retirement Account — X12 code "IRA". */
   GROUP_IRA("IRA", "Group Individual Retirement Account"),
+  /** 408(B) Individual Retirement Account (IRA) Annuity Contract — X12 code "IRC". */
   IRA_ANNUITY_CONTRACT_408B("IRC", "408(B) Individual Retirement Account (IRA) Annuity Contract"),
+  /** Lifestyle Life (Individualized Basic Life) — X12 code "LL". */
   LIFESTYLE_LIFE("LL", "Lifestyle Life (Individualized Basic Life)"),
+  /** Long-Term Care — X12 code "LTC". */
   LONG_TERM_CARE("LTC", "Long-Term Care"),
+  /** Long-Term Disability — X12 code "LTD". */
   LONG_TERM_DISABILITY("LTD", "Long-Term Disability"),
+  /** Major Medical — X12 code "MM". */
   MAJOR_MEDICAL("MM", "Major Medical"),
+  /** Mail Order Drug — X12 code "MOD". */
   MAIL_ORDER_DRUG("MOD", "Mail Order Drug"),
+  /** 457(F) Non-Government Deferred Compensation — X12 code "NGD". */
   NON_GOVERNMENT_DEFERRED_COMPENSATION_457F("NGD", "457(F) Non-Government Deferred Compensation"),
+  /** Non-Qualified — X12 code "NQ". */
   NON_QUALIFIED("NQ", "Non-Qualified"),
+  /** Prescription Drug — X12 code "PDG". */
   PRESCRIPTION_DRUG("PDG", "Prescription Drug"),
+  /** Point of Service — X12 code "POS". */
   POINT_OF_SERVICE("POS", "Point of Service"),
+  /** Preferred Provider Organization — X12 code "PPO". */
   PREFERRED_PROVIDER_ORGANIZATION("PPO", "Preferred Provider Organization"),
+  /** Practitioners — X12 code "PRA". */
   PRACTITIONERS("PRA", "Practitioners"),
+  /** Profit-Sharing Plan — X12 code "PSP". */
   PROFIT_SHARING_PLAN("PSP", "Profit-Sharing Plan"),
+  /** 401(K) Qualified Cash or Deferred Arrangement — X12 code "QDA". */
   QUALIFIED_CASH_DEFERRED_401K("QDA", "401(K) Qualified Cash or Deferred Arrangement"),
+  /** 401(A) Qualified Defined Contribution — X12 code "QDC". */
   QUALIFIED_DEFINED_CONTRIBUTION_401A("QDC", "401(A) Qualified Defined Contribution"),
+  /** Short-Term Disability — X12 code "STD". */
   SHORT_TERM_DISABILITY("STD", "Short-Term Disability"),
+  /** Universal Life — X12 code "UL". */
   UNIVERSAL_LIFE("UL", "Universal Life"),
+  /** Utilization Review — X12 code "UR". */
   UTILIZATION_REVIEW("UR", "Utilization Review"),
+  /** Vision — X12 code "VIS". */
   VISION("VIS", "Vision"),
+  /** Mutually Defined — X12 code "ZZZ". */
   MUTUALLY_DEFINED("ZZZ", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MaintenanceReasonCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MaintenanceReasonCode.java
@@ -24,124 +24,242 @@ import lombok.Getter;
  */
 @Getter
 public enum MaintenanceReasonCode implements EdiCodeEnum {
+  /** Divorce — X12 code "01". */
   DIVORCE("01", "Divorce"),
+  /** Birth — X12 code "02". */
   BIRTH("02", "Birth"),
+  /** Death — X12 code "03". */
   DEATH("03", "Death"),
+  /** Retirement — X12 code "04". */
   RETIREMENT("04", "Retirement"),
+  /** Business Name Change — X12 code "4A". */
   BUSINESS_NAME_CHANGE("4A", "Business Name Change"),
+  /** Business Name Correction — X12 code "4B". */
   BUSINESS_NAME_CORRECTION("4B", "Business Name Correction"),
+  /** Physical or Mailing Address Correction — X12 code "4C". */
   ADDRESS_CORRECTION("4C", "Physical or Mailing Address Correction"),
+  /** Adoption — X12 code "05". */
   ADOPTION("05", "Adoption"),
+  /** Strike — X12 code "06". */
   STRIKE("06", "Strike"),
+  /** Termination of Benefits — X12 code "07". */
   TERMINATION_OF_BENEFITS("07", "Termination of Benefits"),
+  /** Termination of Employment — X12 code "08". */
   TERMINATION_OF_EMPLOYMENT("08", "Termination of Employment"),
+  /** Consolidation Omnibus Budget Reconciliation Act (COBRA) — X12 code "09". */
   COBRA("09", "Consolidation Omnibus Budget Reconciliation Act (COBRA)"),
+  /** Consolidation Omnibus Budget Reconciliation Act (COBRA) Premium Paid — X12 code "10". */
   COBRA_PREMIUM_PAID("10", "Consolidation Omnibus Budget Reconciliation Act (COBRA) Premium Paid"),
+  /** Surviving Spouse — X12 code "11". */
   SURVIVING_SPOUSE("11", "Surviving Spouse"),
+  /** Lay Off — X12 code "12". */
   LAY_OFF("12", "Lay Off"),
+  /** Leave of Absence — X12 code "13". */
   LEAVE_OF_ABSENCE("13", "Leave of Absence"),
+  /** Voluntary Withdrawal — X12 code "14". */
   VOLUNTARY_WITHDRAWAL("14", "Voluntary Withdrawal"),
+  /** Primary Care Provider (PCP) Change — X12 code "15". */
   PCP_CHANGE("15", "Primary Care Provider (PCP) Change"),
+  /** Quit — X12 code "16". */
   QUIT("16", "Quit"),
+  /** Fired — X12 code "17". */
   FIRED("17", "Fired"),
+  /** Suspended — X12 code "18". */
   SUSPENDED("18", "Suspended"),
+  /** Sabbatical — X12 code "19". */
   SABBATICAL("19", "Sabbatical"),
+  /** Active — X12 code "20". */
   ACTIVE("20", "Active"),
+  /** Disability — X12 code "21". */
   DISABILITY("21", "Disability"),
+  /** Plan Change — X12 code "22". */
   PLAN_CHANGE("22", "Plan Change"),
+  /** Furloughed — X12 code "23". */
   FURLOUGHED("23", "Furloughed"),
+  /** Resigned — X12 code "24". */
   RESIGNED("24", "Resigned"),
+  /** Change in Identifying Data Elements — X12 code "25". */
   CHANGE_IN_IDENTIFYING_DATA_ELEMENTS("25", "Change in Identifying Data Elements"),
+  /** Declined Coverage — X12 code "26". */
   DECLINED_COVERAGE("26", "Declined Coverage"),
+  /** Pre-Enrollment — X12 code "27". */
   PRE_ENROLLMENT("27", "Pre-Enrollment"),
+  /** Initial Enrollment — X12 code "28". */
   INITIAL_ENROLLMENT("28", "Initial Enrollment"),
+  /** Benefit Selection — X12 code "29". */
   BENEFIT_SELECTION("29", "Benefit Selection"),
+  /** Discrimination Test — X12 code "30". */
   DISCRIMINATION_TEST("30", "Discrimination Test"),
+  /** Legal Separation — X12 code "31". */
   LEGAL_SEPARATION("31", "Legal Separation"),
+  /** Marriage — X12 code "32". */
   MARRIAGE("32", "Marriage"),
+  /** Personnel Data — X12 code "33". */
   PERSONNEL_DATA("33", "Personnel Data"),
+  /** Investment Elections and Contribution Rates — X12 code "34". */
   INVESTMENT_ELECTIONS("34", "Investment Elections and Contribution Rates"),
+  /** Loan Repayment — X12 code "35". */
   LOAN_REPAYMENT("35", "Loan Repayment"),
+  /** Contribution or Plan Allocation — X12 code "36". */
   CONTRIBUTION_OR_PLAN_ALLOCATION("36", "Contribution or Plan Allocation"),
+  /** Leave of Absence with Benefits — X12 code "37". */
   LEAVE_OF_ABSENCE_WITH_BENEFITS("37", "Leave of Absence with Benefits"),
+  /** Leave of Absence without Benefits — X12 code "38". */
   LEAVE_OF_ABSENCE_WITHOUT_BENEFITS("38", "Leave of Absence without Benefits"),
+  /** Lay Off with Benefits — X12 code "39". */
   LAY_OFF_WITH_BENEFITS("39", "Lay Off with Benefits"),
+  /** Lay Off without Benefits — X12 code "40". */
   LAY_OFF_WITHOUT_BENEFITS("40", "Lay Off without Benefits"),
+  /** Re-enrollment — X12 code "41". */
   RE_ENROLLMENT("41", "Re-enrollment"),
+  /** New Entity — X12 code "42". */
   NEW_ENTITY("42", "New Entity"),
+  /** Change of Location — X12 code "43". */
   CHANGE_OF_LOCATION("43", "Change of Location"),
+  /** Change of Telephone Number — X12 code "44". */
   CHANGE_OF_TELEPHONE_NUMBER("44", "Change of Telephone Number"),
+  /** Went Out of Business — X12 code "45". */
   WENT_OUT_OF_BUSINESS("45", "Went Out of Business"),
+  /** Current Customer Information File in Error — X12 code "46". */
   CUSTOMER_INFO_FILE_IN_ERROR("46", "Current Customer Information File in Error"),
+  /** Account Balance Reporting — X12 code "47". */
   ACCOUNT_BALANCE_REPORTING("47", "Account Balance Reporting"),
+  /** Fees Processing — X12 code "48". */
   FEES_PROCESSING("48", "Fees Processing"),
+  /** Interfund Transfer — X12 code "49". */
   INTERFUND_TRANSFER("49", "Interfund Transfer"),
+  /** Loan Request — X12 code "50". */
   LOAN_REQUEST("50", "Loan Request"),
+  /** Enrollment in Subsequent Benefit Plan — X12 code "51". */
   ENROLLMENT_IN_SUBSEQUENT_BENEFIT_PLAN("51", "Enrollment in Subsequent Benefit Plan"),
+  /** Health Care Facility Change — X12 code "52". */
   HEALTH_CARE_FACILITY_CHANGE("52", "Health Care Facility Change"),
+  /** Name Synonym Add — X12 code "53". */
   NAME_SYNONYM_ADD("53", "Name Synonym Add"),
+  /** Sub Location Add — X12 code "54". */
   SUB_LOCATION_ADD("54", "Sub Location Add"),
+  /** Sub Location Change — X12 code "55". */
   SUB_LOCATION_CHANGE("55", "Sub Location Change"),
+  /** Sub Location Expire — X12 code "56". */
   SUB_LOCATION_EXPIRE("56", "Sub Location Expire"),
+  /** Buyout — X12 code "57". */
   BUYOUT("57", "Buyout"),
+  /** Merger — X12 code "58". */
   MERGER("58", "Merger"),
+  /** Non Payment — X12 code "59". */
   NON_PAYMENT("59", "Non Payment"),
+  /** Coverage Placed Elsewhere — X12 code "60". */
   COVERAGE_PLACED_ELSEWHERE("60", "Coverage Placed Elsewhere"),
+  /** Duplicate Coverage — X12 code "61". */
   DUPLICATE_COVERAGE("61", "Duplicate Coverage"),
+  /** Change in Ownership — X12 code "62". */
   CHANGE_IN_OWNERSHIP("62", "Change in Ownership"),
+  /** Business Sold — X12 code "63". */
   BUSINESS_SOLD("63", "Business Sold"),
+  /** Underwriting Reason — X12 code "64". */
   UNDERWRITING_REASON("64", "Underwriting Reason"),
+  /** No Employees, Exposure or Operations — X12 code "65". */
   NO_EMPLOYEES_EXPOSURE_OR_OPERATIONS("65", "No Employees, Exposure or Operations"),
+  /** Revocation of Voluntary Market Acceptance — X12 code "66". */
   REVOCATION_OF_VOLUNTARY_MARKET_ACCEPTANCE("66", "Revocation of Voluntary Market Acceptance"),
+  /** Include Primary Business Management — X12 code "67". */
   INCLUDE_PRIMARY_BUSINESS_MANAGEMENT("67", "Include Primary Business Management"),
+  /** Exclude Primary Business Management — X12 code "68". */
   EXCLUDE_PRIMARY_BUSINESS_MANAGEMENT("68", "Exclude Primary Business Management"),
+  /** Failure to Pay Deductible — X12 code "69". */
   FAILURE_TO_PAY_DEDUCTIBLE("69", "Failure to Pay Deductible"),
+  /** Misrepresented Information — X12 code "70". */
   MISREPRESENTED_INFORMATION("70", "Misrepresented Information"),
+  /** Rewritten — X12 code "71". */
   REWRITTEN("71", "Rewritten"),
+  /** Adding a Jurisdiction — X12 code "72". */
   ADDING_A_JURISDICTION("72", "Adding a Jurisdiction"),
+  /** Deleting a Jurisdiction — X12 code "73". */
   DELETING_A_JURISDICTION("73", "Deleting a Jurisdiction"),
+  /** Occupational Illness — X12 code "75". */
   OCCUPATIONAL_ILLNESS("75", "Occupational Illness"),
+  /** Change Insured Federal Employer Identification Number (FEIN) — X12 code "76". */
   CHANGE_INSURED_FEIN("76", "Change Insured Federal Employer Identification Number (FEIN)"),
+  /** Change Employer Federal Employer Identification Number (FEIN) — X12 code "77". */
   CHANGE_EMPLOYER_FEIN("77", "Change Employer Federal Employer Identification Number (FEIN)"),
+  /** Change Employer Unemployment Insurance (UI) Code — X12 code "78". */
   CHANGE_EMPLOYER_UI_CODE("78", "Change Employer Unemployment Insurance (UI) Code"),
+  /** Change Policy Number — X12 code "79". */
   CHANGE_POLICY_NUMBER("79", "Change Policy Number"),
+  /** Modification without a Specific Operating Unit Location in Jurisdiction — X12 code "80". */
   MODIFICATION_WITHOUT_SPECIFIC_LOCATION(
       "80", "Modification without a Specific Operating Unit Location in Jurisdiction"),
+  /** Change Policy Effective Date — X12 code "81". */
   CHANGE_POLICY_EFFECTIVE_DATE("81", "Change Policy Effective Date"),
+  /** Change Policy Expiration Date — X12 code "82". */
   CHANGE_POLICY_EXPIRATION_DATE("82", "Change Policy Expiration Date"),
+  /** Change Insurer Federal Employer Identification Number (FEIN) — X12 code "83". */
   CHANGE_INSURER_FEIN("83", "Change Insurer Federal Employer Identification Number (FEIN)"),
+  /** No Eligible Employees — X12 code "84". */
   NO_ELIGIBLE_EMPLOYEES("84", "No Eligible Employees"),
+  /** Reinstatement - Canceled in Error — X12 code "85". */
   REINSTATEMENT_CANCELED_IN_ERROR("85", "Reinstatement - Canceled in Error"),
+  /** Change in Insured Information — X12 code "86". */
   CHANGE_IN_INSURED_INFORMATION("86", "Change in Insured Information"),
+  /** Change in Employer Information — X12 code "87". */
   CHANGE_IN_EMPLOYER_INFORMATION("87", "Change in Employer Information"),
+  /** Parent Identification Change — X12 code "88". */
   PARENT_IDENTIFICATION_CHANGE("88", "Parent Identification Change"),
+  /** Change to Expiration Date — X12 code "89". */
   CHANGE_TO_EXPIRATION_DATE("89", "Change to Expiration Date"),
+  /** Phone Verify Only — X12 code "90". */
   PHONE_VERIFY_ONLY("90", "Phone Verify Only"),
+  /** Name Synonym Delete — X12 code "91". */
   NAME_SYNONYM_DELETE("91", "Name Synonym Delete"),
+  /** Duplicate Entry on Customer Identification File — X12 code "92". */
   DUPLICATE_ENTRY_ON_CUSTOMER_ID_FILE("92", "Duplicate Entry on Customer Identification File"),
+  /** Removal of the Customer Identification File Merge ID — X12 code "93". */
   REMOVAL_OF_CUSTOMER_ID_MERGE("93", "Removal of the Customer Identification File Merge ID"),
+  /** Removal of the Customer Identification File Buyout ID — X12 code "94". */
   REMOVAL_OF_CUSTOMER_ID_BUYOUT("94", "Removal of the Customer Identification File Buyout ID"),
+  /** Removal of the Customer Identification File in Error ID — X12 code "95". */
   REMOVAL_OF_CUSTOMER_ID_IN_ERROR("95", "Removal of the Customer Identification File in Error ID"),
+  /** Re-activation of an Out-of-Business Customer — X12 code "96". */
   REACTIVATION_OF_OUT_OF_BUSINESS_CUSTOMER("96", "Re-activation of an Out-of-Business Customer"),
+  /** Sub-location Reinstatement — X12 code "97". */
   SUB_LOCATION_REINSTATEMENT("97", "Sub-location Reinstatement"),
+  /** Dissatisfaction with Office Staff — X12 code "AA". */
   DISSATISFACTION_OFFICE_STAFF("AA", "Dissatisfaction with Office Staff"),
+  /** Dissatisfaction with Medical Care/Services Rendered — X12 code "AB". */
   DISSATISFACTION_MEDICAL_CARE("AB", "Dissatisfaction with Medical Care/Services Rendered"),
+  /** Inconvenient Office Location — X12 code "AC". */
   INCONVENIENT_OFFICE_LOCATION("AC", "Inconvenient Office Location"),
+  /** Dissatisfaction with Office Hours — X12 code "AD". */
   DISSATISFACTION_OFFICE_HOURS("AD", "Dissatisfaction with Office Hours"),
+  /** Unable to Schedule Appointments in a Timely Manner — X12 code "AE". */
   UNABLE_TO_SCHEDULE_APPOINTMENTS("AE", "Unable to Schedule Appointments in a Timely Manner"),
+  /** Dissatisfaction with Physician's Referral Policy — X12 code "AF". */
   DISSATISFACTION_REFERRAL_POLICY("AF", "Dissatisfaction with Physician's Referral Policy"),
+  /** Less Respect and Attention Time Given than to Other Patients — X12 code "AG". */
   LESS_RESPECT_AND_ATTENTION("AG", "Less Respect and Attention Time Given than to Other Patients"),
+  /** Patient Moved to a New Location — X12 code "AH". */
   PATIENT_MOVED("AH", "Patient Moved to a New Location"),
+  /** No Reason Given — X12 code "AI". */
   NO_REASON_GIVEN("AI", "No Reason Given"),
+  /** Appointment Times not Met in a Timely Manner — X12 code "AJ". */
   APPOINTMENT_TIMES_NOT_MET("AJ", "Appointment Times not Met in a Timely Manner"),
+  /** Algorithm Assigned Benefit Selection — X12 code "AL". */
   ALGORITHM_ASSIGNED_BENEFIT_SELECTION("AL", "Algorithm Assigned Benefit Selection"),
+  /** Member Benefit Selection — X12 code "EC". */
   MEMBER_BENEFIT_SELECTION("EC", "Member Benefit Selection"),
+  /** Became Medical Only — X12 code "XB". */
   BECAME_MEDICAL_ONLY("XB", "Became Medical Only"),
+  /** Indemnity — X12 code "XI". */
   INDEMNITY("XI", "Indemnity"),
+  /** Became Lost Time — X12 code "XL". */
   BECAME_LOST_TIME("XL", "Became Lost Time"),
+  /** Medical Only — X12 code "XM". */
   MEDICAL_ONLY("XM", "Medical Only"),
+  /** Notification Only — X12 code "XN". */
   NOTIFICATION_ONLY("XN", "Notification Only"),
+  /** Transfer — X12 code "XT". */
   TRANSFER("XT", "Transfer"),
+  /** Mutually Defined — X12 code "ZZ". */
   MUTUALLY_DEFINED("ZZ", "Mutually Defined");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MaintenanceTypeCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MaintenanceTypeCode.java
@@ -18,16 +18,27 @@ import lombok.Getter;
  */
 @Getter
 public enum MaintenanceTypeCode implements EdiCodeEnum {
+  /** Addition — X12 code "001". */
   ADDITION("001", "Addition"),
+  /** Change — X12 code "002". */
   CHANGE("002", "Change"),
+  /** Cancellation — X12 code "003". */
   CANCELLATION("003", "Cancellation"),
+  /** Reinstatement — X12 code "004". */
   REINSTATEMENT("004", "Reinstatement"),
+  /** Change with Member ID Change — X12 code "021". */
   CHANGE_WITH_MEMBER_ID("021", "Change with Member ID Change"),
+  /** Change Address — X12 code "022". */
   CHANGE_ADDRESS("022", "Change Address"),
+  /** Change Demographic Data — X12 code "023". */
   CHANGE_DEMOGRAPHIC("023", "Change Demographic Data"),
+  /** Change Benefit/Coverage Data — X12 code "024". */
   CHANGE_BENEFIT_COVERAGE("024", "Change Benefit/Coverage Data"),
+  /** Change Billing/Payment Data — X12 code "025". */
   CHANGE_BILLING("025", "Change Billing/Payment Data"),
+  /** Change Employment Data — X12 code "026". */
   CHANGE_EMPLOYMENT("026", "Change Employment Data"),
+  /** COBRA Election — X12 code "030". */
   COBRA_ELECTION("030", "COBRA Election");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MedicarePlanCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MedicarePlanCode.java
@@ -23,10 +23,15 @@ import lombok.Getter;
  */
 @Getter
 public enum MedicarePlanCode implements EdiCodeEnum {
+  /** Medicare Part A — X12 code "A". */
   PART_A("A", "Medicare Part A"),
+  /** Medicare Part B — X12 code "B". */
   PART_B("B", "Medicare Part B"),
+  /** Medicare Part A and B — X12 code "C". */
   PART_A_AND_B("C", "Medicare Part A and B"),
+  /** Medicare — X12 code "D". */
   MEDICARE("D", "Medicare"),
+  /** No Medicare — X12 code "E". */
   NO_MEDICARE("E", "No Medicare");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MemberDateQualifier.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MemberDateQualifier.java
@@ -19,30 +19,51 @@ import lombok.Getter;
  */
 @Getter
 public enum MemberDateQualifier implements EdiCodeEnum {
+  /** Benefit begin — maps to {@link DateTimeQualifier#BENEFIT_BEGIN}. */
   BENEFIT_BEGIN(DateTimeQualifier.BENEFIT_BEGIN),
+  /** Benefit end — maps to {@link DateTimeQualifier#BENEFIT_END}. */
   BENEFIT_END(DateTimeQualifier.BENEFIT_END),
+  /** Birth — maps to {@link DateTimeQualifier#EFFECTIVE}. */
   BIRTH(DateTimeQualifier.EFFECTIVE),
+  /** Coverage begin — maps to {@link DateTimeQualifier#ELIGIBILITY_BEGIN}. */
   COVERAGE_BEGIN(DateTimeQualifier.ELIGIBILITY_BEGIN),
+  /** Coverage end — maps to {@link DateTimeQualifier#ELIGIBILITY_END}. */
   COVERAGE_END(DateTimeQualifier.ELIGIBILITY_END),
+  /** Effective — maps to {@link DateTimeQualifier#MAINTENANCE_EFFECTIVE}. */
   EFFECTIVE(DateTimeQualifier.MAINTENANCE_EFFECTIVE),
+  /** Eligibility begin — maps to {@link DateTimeQualifier#EMPLOYMENT_BEGIN}. */
   ELIGIBILITY_BEGIN(DateTimeQualifier.EMPLOYMENT_BEGIN),
+  /** Eligibility end — maps to {@link DateTimeQualifier#EMPLOYMENT_END}. */
   ELIGIBILITY_END(DateTimeQualifier.EMPLOYMENT_END),
   // 300 "Enrollment Signature Date" — the member-level (Loop 2000) enrollment date the 834
   // 005010X220A1 TR3 permits. The generic 382 "Enrollment" is NOT an allowed member-level DTP01
   // code, so this maps to 300 rather than 382 (grounded in edi #167). Distinct from
   // COVERAGE_BEGIN's 356 (Eligibility Begin), which carries coverageStartDate.
+  /** Enrollment — maps to {@link DateTimeQualifier#ENROLLMENT_SIGNATURE_DATE}. */
   ENROLLMENT(DateTimeQualifier.ENROLLMENT_SIGNATURE_DATE),
+  /** Expiration — maps to {@link DateTimeQualifier#EXPIRATION_DATE}. */
   EXPIRATION(DateTimeQualifier.EXPIRATION_DATE),
+  /** Hire — maps to {@link DateTimeQualifier#EMPLOYMENT_OR_HIRE}. */
   HIRE(DateTimeQualifier.EMPLOYMENT_OR_HIRE),
+  /** Maintenance effective — maps to {@link DateTimeQualifier#MAINTENANCE_EFFECTIVE}. */
   MAINTENANCE_EFFECTIVE(DateTimeQualifier.MAINTENANCE_EFFECTIVE),
+  /** Retirement — maps to {@link DateTimeQualifier#RETIREMENT}. */
   RETIREMENT(DateTimeQualifier.RETIREMENT),
+  /** Signature — maps to {@link DateTimeQualifier#APPLICANT_SIGNED}. */
   SIGNATURE(DateTimeQualifier.APPLICANT_SIGNED),
+  /** Status change — maps to {@link DateTimeQualifier#CHANGED}. */
   STATUS_CHANGE(DateTimeQualifier.CHANGED),
+  /** Termination — maps to {@link DateTimeQualifier#EXPIRATION_DATE}. */
   TERMINATION(DateTimeQualifier.EXPIRATION_DATE), // Same code as EXPIRATION
+  /** Cobra qualifying event — maps to {@link DateTimeQualifier#COBRA_QUALIFYING_EVENT}. */
   COBRA_QUALIFYING_EVENT(DateTimeQualifier.COBRA_QUALIFYING_EVENT),
+  /** Cobra election — maps to {@link DateTimeQualifier#COBRA}. */
   COBRA_ELECTION(DateTimeQualifier.COBRA),
+  /** Cobra begin — maps to {@link DateTimeQualifier#COBRA_BEGIN}. */
   COBRA_BEGIN(DateTimeQualifier.COBRA_BEGIN),
+  /** Cobra end — maps to {@link DateTimeQualifier#COBRA_END}. */
   COBRA_END(DateTimeQualifier.COBRA_END),
+  /** Premium paid to date — maps to {@link DateTimeQualifier#PREMIUM_PAID_TO_DATE}. */
   PREMIUM_PAID_TO_DATE(DateTimeQualifier.PREMIUM_PAID_TO_DATE);
 
   private final DateTimeQualifier dateTimeQualifier;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MemberIndicator.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/MemberIndicator.java
@@ -18,7 +18,9 @@ import lombok.Getter;
  */
 @Getter
 public enum MemberIndicator implements EdiCodeEnum {
+  /** Insured — X12 code "Y". */
   INSURED("Y", "Insured"),
+  /** Not Insured — X12 code "N". */
   NOT_INSURED("N", "Not Insured");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/StudentStatusCode.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/StudentStatusCode.java
@@ -22,8 +22,11 @@ import lombok.Getter;
  */
 @Getter
 public enum StudentStatusCode implements EdiCodeEnum {
+  /** Full-time — X12 code "F". */
   FULL_TIME("F", "Full-time"),
+  /** Not a Student — X12 code "N". */
   NOT_A_STUDENT("N", "Not a Student"),
+  /** Part-time — X12 code "P". */
   PART_TIME("P", "Part-time");
 
   private final String code;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/data/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * Member-level X12 code sets (relationship, maintenance, employment status, benefit status and the
+ * rest), same dictionary-enum shape as {@code x834.data}.
+ */
+package com.fastChickensHR.edi.x834.loop2000.data;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/HealthInformation.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/HealthInformation.java
@@ -43,9 +43,12 @@ public class HealthInformation {
   /** Why the weight changed (HLH05). */
   private String description;
 
+  /** Creates an empty health-information entry; callers set fields afterwards. */
   public HealthInformation() {}
 
   /**
+   * Creates a health-information entry stating just the health-related status.
+   *
    * @param healthRelatedCode the member's tobacco/substance status (HLH01)
    */
   public HealthInformation(HealthRelatedCode healthRelatedCode) {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/Income.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/Income.java
@@ -53,9 +53,12 @@ public class Income {
   /** The currency {@link #amount} is in (ICM06), e.g. {@code USD}. */
   private String currencyCode;
 
+  /** Creates an empty income; callers set the required frequency and amount afterwards. */
   public Income() {}
 
   /**
+   * Creates an income from the mandatory frequency/amount pair.
+   *
    * @param frequency the period the amount covers (ICM01)
    * @param amount what the member earns in that period (ICM02)
    */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/Language.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/Language.java
@@ -34,9 +34,12 @@ public class Language {
   /** The language named in words (LUI03). */
   private String description;
 
+  /** Creates an empty language; callers set a code and/or description afterwards. */
   public Language() {}
 
   /**
+   * Names a language by a code under its scheme.
+   *
    * @param codeQualifier what kind of code follows (LUI01)
    * @param code the language code (LUI02)
    */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberCommunication.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/MemberCommunication.java
@@ -42,9 +42,12 @@ public class MemberCommunication {
   /** The number itself (PER04/06/08) — required. */
   private String number;
 
+  /** Creates an empty communication; callers set the qualifier and number afterwards. */
   public MemberCommunication() {}
 
   /**
+   * Creates a communication from its qualifier/number pair.
+   *
    * @param qualifier what kind of number this is (PER03/05/07)
    * @param number the number itself (PER04/06/08)
    */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2100A/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * Member-name-loop (2100A) extras: communication numbers (PER), language (LUI), income (ICM) and
+ * health information (HLH).
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2100A;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2200/Disability.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2200/Disability.java
@@ -52,9 +52,12 @@ public class Disability {
   /** When it ended ({@code DTP*361}). */
   private LocalDateTime endDate;
 
+  /** Creates an empty disability; callers set the required {@code type} afterwards. */
   public Disability() {}
 
   /**
+   * Creates a disability of the given kind.
+   *
    * @param type what kind of disability this is (DSB01)
    */
   public Disability(DisabilityTypeCode type) {

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2200/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2200/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/** Member disability information (loop 2200, DSB with its date pair). */
+package com.fastChickensHR.edi.x834.loop2000.loop2200;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2300/HealthCoverage.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2300/HealthCoverage.java
@@ -46,9 +46,12 @@ public class HealthCoverage {
   /** When it ends ({@code DTP*349}). */
   private LocalDateTime endDate;
 
+  /** Creates an empty coverage; callers set the required HD01/HD03 codes afterwards. */
   public HealthCoverage() {}
 
   /**
+   * Creates a coverage from the two codes the HD segment requires.
+   *
    * @param maintenanceTypeCode the maintenance action being applied (HD01)
    * @param insuranceLineCode the insurance line (HD03)
    */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2300/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2300/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * Member health coverage (loop 2300): {@link
+ * com.fastChickensHR.edi.x834.loop2000.loop2300.HealthCoverage} is the value object the member
+ * writer renders as HD plus its DTP 348/349 date pair.
+ */
+package com.fastChickensHR.edi.x834.loop2000.loop2300;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/Provider.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/Provider.java
@@ -62,9 +62,12 @@ public class Provider {
   /** Why the change is happening (PLA05); optional. */
   private MaintenanceReasonCode changeReason;
 
+  /** Creates an empty provider assignment; callers set fields afterwards. */
   public Provider() {}
 
   /**
+   * Creates a provider assignment naming only the provider.
+   *
    * @param lastName the provider's last or organization name (NM103)
    */
   public Provider(String lastName) {
@@ -72,6 +75,8 @@ public class Provider {
   }
 
   /**
+   * Creates a provider assignment naming the provider and its identifier.
+   *
    * @param lastName the provider's last or organization name (NM103)
    * @param identifierQualifier what kind of identifier follows (NM108)
    * @param identifier the provider's identifier (NM109)

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2310/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/** Member provider information (loop 2310, NM1/N3/N4 for the member's provider). */
+package com.fastChickensHR.edi.x834.loop2000.loop2310;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/CoordinationOfBenefits.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/CoordinationOfBenefits.java
@@ -65,9 +65,12 @@ public class CoordinationOfBenefits {
   /** The other plan's name (2330 {@code NM1} NM103), e.g. {@code MEDICARE PART A}. */
   private String relatedEntityName;
 
+  /** Creates an empty coordination-of-benefits entry; callers set fields afterwards. */
   public CoordinationOfBenefits() {}
 
   /**
+   * Creates a coordination-of-benefits entry stating just the payment-order facts.
+   *
    * @param payerResponsibility where the other payer sits in the payment order (COB01)
    * @param benefitsCoordination whether benefits are coordinated, and for whom (COB03)
    */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2320/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/** Member coordination of benefits (loop 2320, COB and related payer data). */
+package com.fastChickensHR.edi.x834.loop2000.loop2320;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2700/ReportingCategory.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2700/ReportingCategory.java
@@ -45,9 +45,12 @@ public class ReportingCategory {
    */
   private String dateQualifier;
 
+  /** Creates an empty reporting category; callers set the name and value afterwards. */
   public ReportingCategory() {}
 
   /**
+   * Creates a reporting category from its name/value pair.
+   *
    * @param name the category label (2750 {@code N1*75})
    * @param value the reported value (2750 {@code REF})
    */

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2700/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/loop2700/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/** Member reporting categories (loop 2700, LX/N1/REF/DTP category detail). */
+package com.fastChickensHR.edi.x834.loop2000.loop2700;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * The member loop (2000/2100A): {@link com.fastChickensHR.edi.x834.loop2000.BaseMember} carries the
+ * INS/REF/DTP/NM1/PER/N3/N4/DMG data shared by {@link com.fastChickensHR.edi.x834.loop2000.Member}
+ * (subscribers) and {@link com.fastChickensHR.edi.x834.loop2000.DependentMember} (dependents);
+ * nested loop packages hold the member's coverage-adjacent details.
+ */
+package com.fastChickensHR.edi.x834.loop2000;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * The X12 834 (005010X220A1) document model. {@link com.fastChickensHR.edi.x834.X834Document}
+ * assembles a benefit enrollment file from {@link com.fastChickensHR.edi.x834.X834Context} plus
+ * header, member loop and trailer, and renders it through the accumulate-never-throw {@link
+ * com.fastChickensHR.edi.x834.GenerationResult} contract; construction-phase failures throw {@link
+ * com.fastChickensHR.edi.x834.exception.ValidationException} at each component's own
+ * build/validate. Start at {@link com.fastChickensHR.edi.x834.X834Document}.
+ */
+package com.fastChickensHR.edi.x834;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/spec/CharacterClass.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/spec/CharacterClass.java
@@ -80,18 +80,30 @@ public enum CharacterClass {
     return builder.toString();
   }
 
-  /** Every character in this set, in a stable order: letters, digits, space, then punctuation. */
+  /**
+   * Every character in this set, in a stable order: letters, digits, space, then punctuation.
+   *
+   * @return the set's members as a string
+   */
   public String getCharacters() {
     return characters;
   }
 
-  /** Whether this set contains {@code candidate}. */
+  /**
+   * Whether this set contains {@code candidate}.
+   *
+   * @param candidate the character to test
+   * @return true when the character is a member of this set
+   */
   public boolean permits(char candidate) {
     return candidate < 128 && members.get(candidate);
   }
 
   /**
    * Whether every character of {@code value} is a member of this set. An empty value trivially is.
+   *
+   * @param value the text to test; null is treated as empty
+   * @return true when no character of the value falls outside this set
    */
   public boolean permitsAll(CharSequence value) {
     return firstViolation(value).isEmpty();
@@ -101,6 +113,9 @@ public enum CharacterClass {
    * The index of the first character of {@code value} that this set does not contain, or empty when
    * every character is a member. The index — not just the character — so a caller can report where
    * in a long value the offending character sits.
+   *
+   * @param value the text to test; null is treated as empty
+   * @return the index of the first non-member character, or empty when all are members
    */
   public OptionalInt firstViolation(CharSequence value) {
     if (value == null) {
@@ -117,6 +132,8 @@ public enum CharacterClass {
   /**
    * The characters {@link #EXTENDED} adds to {@link #BASIC}: lower-case letters and its
    * punctuation.
+   *
+   * @return the members of {@code EXTENDED} that are not members of {@code BASIC}
    */
   public static String extendedOnlyCharacters() {
     return lowerCase() + EXTENDED_ONLY_SPECIALS;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/spec/CodeValue.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/spec/CodeValue.java
@@ -11,9 +11,13 @@ package com.fastChickensHR.edi.x834.spec;
  * One member of a published code list: the code that goes on the wire and the standard's
  * description of it. Descriptions exist so a consumer can render a pick list without copying the
  * list itself.
+ *
+ * @param code the code as it goes on the wire
+ * @param description the standard's description of the code
  */
 public record CodeValue(String code, String description) {
 
+  /** Validates that both the code and its description are present and non-blank. */
   public CodeValue {
     if (code == null || code.isBlank()) {
       throw new IllegalArgumentException("Code cannot be null or blank");

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/spec/DataType.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/spec/DataType.java
@@ -34,7 +34,11 @@ public enum DataType {
     this.description = description;
   }
 
-  /** The standard's name for this type, e.g. {@code "Identifier"} for {@link #ID}. */
+  /**
+   * The standard's name for this type, e.g. {@code "Identifier"} for {@link #ID}.
+   *
+   * @return the human-readable type name
+   */
   public String getDescription() {
     return description;
   }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/spec/ElementPosition.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/spec/ElementPosition.java
@@ -27,6 +27,13 @@ import java.util.regex.Pattern;
  * the common hyphenated variant {@code "2100A NM1-08"}. Because an X12 element reference glues a
  * two-digit ordinal onto a segment identifier that may itself end in a digit, the ordinal is always
  * taken as the <em>last two digits</em>: {@code "2100A N401"} is N4 element 01, not N40 element 1.
+ *
+ * @param loop the loop name as the transaction set spells it, e.g. {@code "2000"}, {@code "2100A"},
+ *     or the envelope regions {@code "HEADER"}/{@code "TRAILER"}
+ * @param segment the 1-3 character X12 segment identifier, e.g. {@code "INS"}
+ * @param ordinal the element ordinal within the segment, 1-99
+ * @param component the component ordinal within a composite element, 1-9, or {@link #NO_COMPONENT}
+ *     for an ordinary element
  */
 public record ElementPosition(String loop, String segment, int ordinal, int component) {
 
@@ -38,6 +45,7 @@ public record ElementPosition(String loop, String segment, int ordinal, int comp
   private static final Pattern TEXT =
       Pattern.compile("(\\S+)\\s+([A-Z][A-Z0-9]*?)-?(\\d{2})(?:-(\\d))?");
 
+  /** Validates the address parts; see the record javadoc for each part's legal form. */
   public ElementPosition {
     if (loop == null || !LOOP.matcher(loop).matches()) {
       throw new IllegalArgumentException(
@@ -56,7 +64,14 @@ public record ElementPosition(String loop, String segment, int ordinal, int comp
     }
   }
 
-  /** An ordinary element position, e.g. {@code of("2000", "INS", 8)} ⇔ {@code "2000 INS08"}. */
+  /**
+   * An ordinary element position, e.g. {@code of("2000", "INS", 8)} ⇔ {@code "2000 INS08"}.
+   *
+   * @param loop the loop name, e.g. {@code "2000"} or {@code "HEADER"}
+   * @param segment the X12 segment identifier, e.g. {@code "INS"}
+   * @param ordinal the element ordinal within the segment, 1-99
+   * @return the position addressing that element
+   */
   public static ElementPosition of(String loop, String segment, int ordinal) {
     return new ElementPosition(loop, segment, ordinal, NO_COMPONENT);
   }
@@ -64,6 +79,12 @@ public record ElementPosition(String loop, String segment, int ordinal, int comp
   /**
    * One component of a composite element, e.g. {@code of("2000", "INS", 6, 1)} ⇔ {@code "2000
    * INS06-1"}.
+   *
+   * @param loop the loop name, e.g. {@code "2000"} or {@code "HEADER"}
+   * @param segment the X12 segment identifier, e.g. {@code "INS"}
+   * @param ordinal the element ordinal within the segment, 1-99
+   * @param component the component ordinal within the composite, 1-9
+   * @return the position addressing that component
    */
   public static ElementPosition of(String loop, String segment, int ordinal, int component) {
     return new ElementPosition(loop, segment, ordinal, component);
@@ -73,6 +94,8 @@ public record ElementPosition(String loop, String segment, int ordinal, int comp
    * Parses the canonical spelling, e.g. {@code "2000 INS08"}, {@code "HEADER BGN01"}, {@code "2000
    * INS06-1"}, {@code "2100A NM1-08"}.
    *
+   * @param text the element position text to parse
+   * @return the parsed position
    * @throws IllegalArgumentException if the text is not a loop followed by an element reference
    */
   public static ElementPosition parse(String text) {
@@ -92,12 +115,20 @@ public record ElementPosition(String loop, String segment, int ordinal, int comp
         matcher.group(4) == null ? NO_COMPONENT : Integer.parseInt(matcher.group(4)));
   }
 
-  /** Whether this position addresses one component of a composite element. */
+  /**
+   * Whether this position addresses one component of a composite element.
+   *
+   * @return true when {@link #component()} is not {@link #NO_COMPONENT}
+   */
   public boolean isComponent() {
     return component != NO_COMPONENT;
   }
 
-  /** The canonical spelling, e.g. {@code "2000 INS08"} or {@code "2000 INS06-1"}. */
+  /**
+   * The canonical spelling, e.g. {@code "2000 INS08"} or {@code "2000 INS06-1"}.
+   *
+   * @return the spelling {@code "<loop> <SEG><nn>"}, with a {@code "-<c>"} suffix for a component
+   */
   public String display() {
     String reference = "%s%02d".formatted(segment, ordinal);
     return loop + " " + (isComponent() ? reference + "-" + component : reference);

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/spec/ElementSpec.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/spec/ElementSpec.java
@@ -39,6 +39,16 @@ import java.util.Set;
  * and colloquial aliases, so that {@code "fired"} finds a code — is deliberately unreachable from
  * here. Resolving user input and checking conformance are different jobs, and only the second one
  * belongs to the spec.
+ *
+ * @param position the element position this spec describes
+ * @param elementId the X12 element number as the standard writes it, e.g. {@code "584"} or {@code
+ *     "I05"}
+ * @param name the standard's name for the element at this position
+ * @param type the element's X12 data type
+ * @param minLength the minimum length of a value at this position, at least 1
+ * @param maxLength the maximum length of a value at this position, at least {@code minLength}
+ * @param codes the permitted codes in the order the standard lists them; empty for a non-coded
+ *     position (only a {@link DataType#ID} position may carry a non-empty list)
  */
 public record ElementSpec(
     ElementPosition position,
@@ -49,6 +59,7 @@ public record ElementSpec(
     int maxLength,
     List<CodeValue> codes) {
 
+  /** Validates the spec parts and defensively copies the code list. */
   public ElementSpec {
     if (position == null) {
       throw new IllegalArgumentException("Position cannot be null");
@@ -78,7 +89,11 @@ public record ElementSpec(
     }
   }
 
-  /** Whether this position is coded — i.e. its legal values are a closed list. */
+  /**
+   * Whether this position is coded — i.e. its legal values are a closed list.
+   *
+   * @return true when this spec publishes a non-empty code list
+   */
   public boolean isCoded() {
     return !codes.isEmpty();
   }
@@ -89,12 +104,19 @@ public record ElementSpec(
    * spelled with upper-case letters and digits and so never need more than {@link
    * CharacterClass#BASIC}. What an individual interchange permits is narrower still — that is the
    * trading partner's pick, not the element's property.
+   *
+   * @return {@link CharacterClass#EXTENDED} for a string element, {@link CharacterClass#BASIC}
+   *     otherwise
    */
   public CharacterClass characterClass() {
     return type == DataType.AN ? CharacterClass.EXTENDED : CharacterClass.BASIC;
   }
 
-  /** The permitted codes as a set, in the order the standard lists them. Empty when not coded. */
+  /**
+   * The permitted codes as a set, in the order the standard lists them. Empty when not coded.
+   *
+   * @return the codes of {@code codes()}, in declaration order
+   */
   public Set<String> codeSet() {
     Set<String> set = new LinkedHashSet<>(codes.size());
     for (CodeValue value : codes) {
@@ -112,6 +134,8 @@ public record ElementSpec(
    * unknown rather than ignored, since neither is a code. An empty proposal trivially passes: it
    * narrows nothing.
    *
+   * @param proposed the codes the caller wants to narrow this position's list to
+   * @return the outcome, naming any proposed codes the standard does not permit here
    * @throws IllegalStateException if this position is not coded — proposing a code list for a
    *     free-text element is a mistake in the caller's data, not a failed check, and silently
    *     answering "not permitted" would hide it

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/spec/SubsetResult.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/spec/SubsetResult.java
@@ -17,9 +17,14 @@ import java.util.List;
  * <p>The unknown codes are reported in the order they were proposed, so a caller narrowing a code
  * list (a trading-partner restriction, say) can point at the offending entries in the order it
  * holds them.
+ *
+ * @param position the element position the proposal was checked against
+ * @param unknownCodes the proposed codes the standard does not permit at that position, in proposal
+ *     order; empty when the proposal is a subset
  */
 public record SubsetResult(ElementPosition position, List<String> unknownCodes) {
 
+  /** Validates the position and defensively copies the unknown-code list. */
   public SubsetResult {
     if (position == null) {
       throw new IllegalArgumentException("Position cannot be null");
@@ -27,12 +32,20 @@ public record SubsetResult(ElementPosition position, List<String> unknownCodes) 
     unknownCodes = List.copyOf(unknownCodes);
   }
 
-  /** Whether every proposed code is permitted at {@link #position()}. */
+  /**
+   * Whether every proposed code is permitted at {@link #position()}.
+   *
+   * @return true when {@link #unknownCodes()} is empty
+   */
   public boolean ok() {
     return unknownCodes.isEmpty();
   }
 
-  /** A one-line explanation suitable for a failed check's message. */
+  /**
+   * A one-line explanation suitable for a failed check's message.
+   *
+   * @return the position and, when the check failed, the codes it does not permit
+   */
   public String describe() {
     if (ok()) {
       return position.display() + " permits every proposed code";

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/spec/X834Spec.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/spec/X834Spec.java
@@ -112,7 +112,12 @@ public final class X834Spec {
 
   private X834Spec() {}
 
-  /** The spec at {@code position}, or empty when this library publishes nothing there. */
+  /**
+   * The spec at {@code position}, or empty when this library publishes nothing there.
+   *
+   * @param position the element position to look up
+   * @return the published spec, or empty when the position is not published
+   */
   public static Optional<ElementSpec> at(ElementPosition position) {
     return Optional.ofNullable(TABLE.get(position));
   }
@@ -120,6 +125,8 @@ public final class X834Spec {
   /**
    * The spec at a position spelled canonically, e.g. {@code "2000 INS08"}.
    *
+   * @param position the position text, parsed via {@link ElementPosition#parse(String)}
+   * @return the published spec, or empty when the position is not published
    * @throws IllegalArgumentException if the text is not an element position at all — a malformed
    *     address is a caller bug, distinct from a well-formed address with no spec
    */
@@ -141,6 +148,11 @@ public final class X834Spec {
    *
    * <p>A composite element answers with its first component ({@code INS06} → the spec at {@code
    * INS06-1}), which is what the segment renders into that slot while the 834 uses only C052-01.
+   *
+   * @param segment the X12 segment identifier, e.g. {@code "INS"}
+   * @param ordinal the element ordinal within the segment
+   * @return the spec every publishing loop agrees on, or empty when none is published or the loops
+   *     disagree
    */
   public static Optional<ElementSpec> atSegment(String segment, int ordinal) {
     List<ElementSpec> candidates =
@@ -171,12 +183,20 @@ public final class X834Spec {
         && one.position().component() == other.position().component();
   }
 
-  /** Every published spec, in transaction-set order: envelope, header, loops, trailer. */
+  /**
+   * Every published spec, in transaction-set order: envelope, header, loops, trailer.
+   *
+   * @return an immutable list of every published spec
+   */
   public static List<ElementSpec> all() {
     return List.copyOf(TABLE.values());
   }
 
-  /** Every published position, in the same order as {@link #all()}. */
+  /**
+   * Every published position, in the same order as {@link #all()}.
+   *
+   * @return an immutable list of every published position
+   */
   public static List<ElementPosition> positions() {
     return List.copyOf(TABLE.keySet());
   }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/Trailer.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/Trailer.java
@@ -78,6 +78,7 @@ public class Trailer {
    * Generates all the segments for this trailer
    *
    * @return List of segments in the correct order
+   * @throws ValidationException if any of the three trailer segments is missing
    */
   public List<Segment> generateSegments() throws ValidationException {
     validate();

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/trailer/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * The 834 envelope closing: {@link com.fastChickensHR.edi.x834.trailer.Trailer} renders SE/GE/IEA
+ * with the counts and control numbers matching the header.
+ */
+package com.fastChickensHR.edi.x834.trailer;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/util/EdiEnumLookup.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/util/EdiEnumLookup.java
@@ -34,6 +34,8 @@ import java.util.Map;
  *   <li><b>Additional mappings (aliases) are best-effort</b> — likewise free-keys-only, so an alias
  *       can never displace a constant's own name, code or description.
  * </ol>
+ *
+ * @param <T> the enum type this lookup resolves, which must carry X12 codes via {@link EdiCodeEnum}
  */
 public final class EdiEnumLookup<T extends Enum<T> & EdiCodeEnum> {
 
@@ -100,7 +102,12 @@ public final class EdiEnumLookup<T extends Enum<T> & EdiCodeEnum> {
         + " — one of them would be unreachable";
   }
 
-  /** Creates an EdiEnumLookup with standard mappings only. */
+  /**
+   * Creates an EdiEnumLookup with standard mappings only.
+   *
+   * @param enumClass the Class object of the enum type
+   * @param enumName the name of the enum type (for error messages)
+   */
   public EdiEnumLookup(Class<T> enumClass, String enumName) {
     this(enumClass, enumName, null);
   }

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/util/package-info.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/util/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * Dictionary-enum machinery: {@link com.fastChickensHR.edi.x834.util.EdiCodeEnum} is the
+ * code-plus-description contract every dictionary enum implements, and {@link
+ * com.fastChickensHR.edi.x834.util.EdiEnumLookup} resolves a value from code, name, description or
+ * synonym.
+ */
+package com.fastChickensHR.edi.x834.util;

--- a/x999/src/main/java/com/fastChickensHR/edi/x999/X999FileParser.java
+++ b/x999/src/main/java/com/fastChickensHR/edi/x999/X999FileParser.java
@@ -33,6 +33,9 @@ import java.util.List;
  */
 public final class X999FileParser implements FileParser {
 
+  /** Creates a parser; the parser is stateless and reusable across files. */
+  public X999FileParser() {}
+
   private static final char DEFAULT_ELEMENT_SEPARATOR = '*';
   private static final char DEFAULT_SEGMENT_TERMINATOR = '~';
   private static final int ISA_LENGTH = 106;

--- a/x999/src/main/java/com/fastChickensHR/edi/x999/package-info.java
+++ b/x999/src/main/java/com/fastChickensHR/edi/x999/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2025 FastChickensHR <contact@fastchickenshr.com>
+ *
+ * This file is part of the FastChickensHR project.
+ *
+ * For license information see the LICENSE file in the root of this project.
+ */
+
+/**
+ * X12 999 (implementation acknowledgment) parsing: {@link
+ * com.fastChickensHR.edi.x999.X999FileParser} reads the envelope and the AK1/IK5/AK9 verdict
+ * segments into the core kernel's {@link com.fastChickensHR.edi.core.FileContent}.
+ */
+package com.fastChickensHR.edi.x999;


### PR DESCRIPTION
Closes #245 (execution of the #212 docs bar, map #202).

The "100 doclint warnings" baseline was the `-Xmaxwarns` cap; the true inventory was ~2,300 member-level warnings. All fixed:

- **Scripted**: per-constant javadoc for every dictionary enum — 2,030 `NAME("code", "Description")` constants rendered as `/** Description — X12 code "…". */`, plus MemberDateQualifier's 21 delegating constants and X834Location's 55 undocumented render keys (`{@value}`) and 6 index helpers.
- **Hand-written**: core's kernel records/interfaces (with `@param`/`@return` grounded in the null-means-OMIT convention), flatfile's DelimitedFormat builder, x999's parser ctor, and 157 member-level fixes across 30 x834 files (BaseMember's wire-mapping field docs, RefSegment's builder, the spec/ records, GenerationResult/Error record params).
- **package-info.java** on all 19 promised packages that lacked one (2 already existed).
- **Gate**: maven-javadoc-plugin 3.12.0 `jar` at `verify` with `-Xdoclint:all` + `failOnWarnings` — rides #240's verify move, after #241's reformat as preferred.

Notable deviations, both safe: two `{@link}`s in X834Context pointed at Lombok-generated accessors (unresolvable by javadoc on raw source) → reworded to `{@code}`; `Address`'s `@NoArgsConstructor` → explicit documented no-arg ctor, behavior-identical, because doclint flags undocumented implicit ctors and Lombok can't carry the comment.

Proof: full `mvn -B verify` green locally — tests, Spotless, Error Prone, JaCoCo floors, and all four doclint-clean javadoc jars with the gate enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)