### PR TITLE
build: GitHub Packages publishing — Central-grade pom, publish workflow, Install rewrite (#231)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to GitHub Packages
+
+# Tags-only publishing (#209/#231): every artifact is a deliberate
+# 1.0.0-beta.N release; no snapshots. setup-java writes a settings.xml
+# whose server id "github" matches <distributionManagement> in the pom,
+# authenticating with the workflow's own GITHUB_TOKEN.
+on:
+  push:
+    tags: ['v1.0.0-beta.*']
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish tagged beta
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+          cache: maven
+
+      # japicmp is a PR/master gate, not a release-time gate: at cut time the
+      # tagged version equals (or predates) the baseline, so the comparison is
+      # self-referential; the tagged content already passed the gate on master.
+      - name: Deploy with Maven
+        run: mvn -B deploy -Djapicmp.skip=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,14 +61,27 @@ here so consumers can find it.
 
 - none
 
+## [1.0.0-beta.1] - 2026-08-02
+
+The first tagged release: the curated 1.0 candidate surface, published to
+GitHub Packages.
+
+### Breaking
+
+- none (first release)
+
 ### Added
 
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
+- `core` — the format-neutral file kernel: `FileContent`/`Record`/`Field`/
+  `Location` and the `FileGenerator`/`FileParser` seam.
+- `x834` — the X12 834 (005010X220A1) benefit-enrollment document model:
+  builder-based envelope and member loop, the accumulate-never-throw
+  `GenerationResult` contract, frozen `X834Location` render keys, the
+  `spec/` element dictionary and X12 code-set enums.
+- `x999` — X12 999 implementation-acknowledgment parsing (envelope and
+  AK1/IK5/AK9 verdict segments).
+- `flatfile` — delimited flat-file generate/parse round-trip with a pinned
+  CSV convention; `fixedwidth` ships as an empty placeholder package.
+- Build gates enforced at `verify`: Spotless (google-java-format), Error
+  Prone (errors-only), JaCoCo regression floors, doclint-clean javadoc
+  jars, and the japicmp binary-compatibility gate this release baselines.

--- a/README.md
+++ b/README.md
@@ -13,21 +13,39 @@ A Java toolkit for benefit-enrollment EDI: generate X12 834 files and delimited 
 
 ## Install
 
-Not yet published. Build and install to your local Maven repository:
-
-```bash
-mvn install
-```
-
-Then depend on the module you need:
+Tagged beta releases are published to GitHub Packages. Add the repository and
+depend on the module you need:
 
 ```xml
+<repositories>
+  <repository>
+    <id>github</id>
+    <url>https://maven.pkg.github.com/FastChickensHR/edi</url>
+  </repository>
+</repositories>
+
 <dependency>
   <groupId>com.fastchickenshr</groupId>
   <artifactId>x834</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0-beta.1</version>
 </dependency>
 ```
+
+GitHub Packages requires authentication even for public downloads: put a
+personal access token with the `read:packages` scope in your
+`~/.m2/settings.xml` under a server whose id matches the repository id above:
+
+```xml
+<servers>
+  <server>
+    <id>github</id>
+    <username>YOUR_GITHUB_USERNAME</username>
+    <password>YOUR_READ_PACKAGES_PAT</password>
+  </server>
+</servers>
+```
+
+Alternatively, build from a clone with `mvn install`.
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,15 @@
 
     <name>FastChickensHR EDI</name>
     <description>Open-source toolkit for generating X12 EDI benefit enrollment documents</description>
+    <url>https://github.com/FastChickensHR/edi</url>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/license/mit</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
     <developers>
         <developer>
@@ -29,6 +38,37 @@
             <organizationUrl>https://fastchickenshr.com</organizationUrl>
         </developer>
     </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/FastChickensHR/edi.git</connection>
+        <developerConnection>scm:git:git@github.com:FastChickensHR/edi.git</developerConnection>
+        <url>https://github.com/FastChickensHR/edi</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/FastChickensHR/edi</url>
+        </repository>
+    </distributionManagement>
+
+    <!-- Where the japicmp baseline (our own released artifacts) resolves from.
+         GitHub Packages requires auth even for public reads; without a
+         credentialed settings.xml the compat gate's lenient default skips. -->
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/FastChickensHR/edi</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <modules>
         <module>core</module>
@@ -151,6 +191,19 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.12.0</version>
                 <configuration>
@@ -185,6 +238,12 @@
                     <parameter>
                         <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                         <ignoreMissingOldVersion>${edi.compat.ignoreMissingOldVersion}</ignoreMissingOldVersion>
+                        <!-- Lombok's provided-scope jar packs its internals as .SCL.lombok
+                             (not loadable classes) and drags phantom refs (ant, eclipse, …),
+                             so missing-class loading cannot be strict here. Our own
+                             dependencies resolve normally, and the gate compares OUR
+                             classes — this does not soften the binary-compat verdict. -->
+                        <ignoreMissingClasses>true</ignoreMissingClasses>
                         <accessModifier>protected</accessModifier>
                         <!--
                             Acknowledgment block (#256): every exclude is a fully-qualified


### PR DESCRIPTION
Execution of #231 (the #209 publishing ruling, map #202). The tag itself is cut after this merges; the issue stays open until the artifact is verified on GH Packages.

- **Central-grade pom metadata now**: `url`/`licenses`/`scm` (developers landed with #247); `maven-source-plugin` 3.3.1 attaches sources jars — with #245's javadoc jars, `deploy` ships binary+sources+javadoc per module, so the Central cutover (#232) is plugin-and-credentials only.
- **`distributionManagement`** → `maven.pkg.github.com/FastChickensHR/edi` (id `github`, matching setup-java's generated settings), plus the **`repositories`** entry the japicmp baseline will resolve from.
- **Publish workflow** on `v1.0.0-beta.*` tags: `mvn -B deploy` with the workflow's own `GITHUB_TOKEN`, `packages: write`. Tags-only — no snapshot publishing. japicmp is skipped in the release run: at cut time the comparison is self-referential, and the tagged content already passed the gate on master.
- **Release flow discovered in execution** (deviation worth reading): bumping master itself to `1.0.0-beta.1` made japicmp resolve the baseline from the reactor — a permanent self-compare that both crashes on Lombok's `.SCL.lombok` packing and would leave the gate inert between releases. So master **stays `1.0.0-SNAPSHOT`** and the version bump lives only in the tagged release commit (release-from-tag). The Lombok classpath issue is real for future registry comparisons too → `ignoreMissingClasses` on the gate, with the tradeoff documented in place.
- **README Install** rewritten for GH Packages (repository block + `read:packages` PAT instructions); **CHANGELOG** gains its `[1.0.0-beta.1]` entry (Breaking: none — first release).

After merge: cut `v1.0.0-beta.1` from master + the version-set commit, push the tag, verify the publish run and the packages, then a follow-up PR flips CI's japicmp strict override (`ignoreMissingOldVersion=false` + `GITHUB_TOKEN` auth for baseline resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)