### PR TITLE
docs: land docs/STYLE.md — the idiom guide, plus the code alignments it implies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,10 +95,10 @@ heading.
 
 ## Idioms
 
-The code idiom guide (builders, Lombok charter, nullness, `X834*` naming,
-records vs beans) is being settled in
-[#243](https://github.com/FastChickensHR/edi/issues/243); its resolution will
-produce the guide that replaces this line.
+New code follows the idiom guide in [docs/STYLE.md](docs/STYLE.md) —
+builders, the Lombok charter, nullness, `X834*` naming, and records vs
+beans, as settled in
+[#243](https://github.com/FastChickensHR/edi/issues/243).
 
 ## Licensing
 

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1,0 +1,112 @@
+# Style guide
+
+The idioms this library holds itself to. Formatting is not covered here: it
+is owned entirely by [google-java-format] via Spotless, enforced at `verify`
+(see [#210](https://github.com/FastChickensHR/edi/issues/210)) — run
+`mvn spotless:apply` and the mechanical layer is settled. This document only
+records what a formatter cannot decide: the shapes new code should take.
+Each ruling was settled in
+[#243](https://github.com/FastChickensHR/edi/issues/243) (with the error
+channel and naming freezes inherited from
+[#216](https://github.com/FastChickensHR/edi/issues/216) and
+[#210](https://github.com/FastChickensHR/edi/issues/210)).
+
+[google-java-format]: https://github.com/google/google-java-format
+
+## Records vs beans: role, not era
+
+Whether a value type is a record or a mutable bean follows its *role*:
+
+- **Record** when instances are constructed whole and never patched
+  afterwards — core's value types, the `spec/` rows, `GenerationError`.
+  If it is complete at birth, it is a record.
+- **Mutable bean** when instances are populated progressively from sparse
+  sources — the x834 member domain model (`Member`, `Income`, `Address`,
+  `HealthCoverage`, …), built up field-by-field by callers translating
+  HR data under the null-means-omit convention below. These are beans *by
+  design*, not legacy awaiting conversion.
+
+## Lombok charter
+
+Lombok is used in **x834 only**; `core`, `x999`, and `flatfile` stay
+Lombok-free. Within x834 the sanctioned uses are:
+
+- **Class-level `@Getter` and `@Setter` on the progressive domain beans** —
+  the bean idiom above.
+- **`@Setter @Accessors(chain = true)` on the internal segment builders** —
+  the mechanism behind the frozen `AbstractBuilder` layer (see Builders
+  below). Frozen with that layer: no new uses.
+
+Everything else is banned for new code — in particular `@Data` (bundles
+`equals`/`hashCode` onto mutable types), `@Value` (those types should be
+records), `@Builder` (builders are hand-written), `@SneakyThrows`, and
+`@EqualsAndHashCode` on mutable types.
+
+## Builders
+
+A public type that needs a builder gets a **hand-written nested
+`Builder`** — the `DelimitedFormat` shape — with static preset factories
+where a common configuration has a name (`DelimitedFormat.csv()`).
+Hand-written because it needs no Lombok (so it works in every module), its
+javadoc is first-class (the doclint gate covers every public method), and
+`build()` is the natural home for validation.
+
+Builders are for types constructed whole with enough optional knobs to make
+constructors awkward. Progressive beans never get builders — callers set
+fields as the data arrives.
+
+The self-typed `AbstractBuilder<T>` pattern in the hidden segment layer is
+frozen legacy: it serves that inheritance hierarchy and nothing else. No new
+`AbstractBuilder`s, and none on the public surface.
+
+## Null vs `Optional`
+
+`Optional` is a **query-method return type only**, used where absence is an
+expected answer — `Field.valueIfPresent()`, `BaseMember.getAddress(type)`.
+Never `Optional` fields, never `Optional` parameters.
+
+Everywhere else, absence is a bare `null` field: the domain convention is
+**null-means-omit** — an unset field means "don't emit this element" — with
+`hasX()` guard methods (`Address.hasStreet()`) as the named companion
+pattern where emission needs a multi-field completeness check.
+
+Nullness annotations (JSpecify) are deliberately deferred until after the
+beta: annotations are binary-compatible additions, so the API lock loses
+nothing by waiting.
+
+## Naming: the `X834` prefix
+
+The prefix marks **transaction-set machinery** — types that name the 834
+interaction itself and sit beside core's kernel vocabulary (or a sibling
+transaction set's seam) in a consumer's imports: `X834Document`,
+`X834Context`, `X834FileGenerator`, `X834Location`, `X834Spec`. The
+disambiguation is real: core exports bare `FileGenerator` and `Location`.
+
+Everything that lives *inside* an 834 stays bare — `Header`, `Trailer`,
+`Member`, `Income`, `GenerationResult` — the package qualifies it. The test
+for a new type: *does it name the 834 machinery (prefix) or a thing inside
+an 834 (bare)?*
+
+These names are frozen as of the first beta, as is the root package
+`com.fastChickensHR` (capitals and all — consumer imports outlive tidiness).
+
+## Error channel
+
+The document-level contract is **`GenerationResult`: accumulate, never
+throw** — from the document inward, generation collects every
+`GenerationError` rather than failing fast. Construction of individual
+components is the other half: a component's own `build()`/`validate()`
+throws checked `ValidationException`. The split is deliberate and
+documented on the types themselves.
+
+Code-enum `fromString` lookups keep throwing `IllegalArgumentException` —
+an unknown code is a caller bug, not a document condition.
+
+## Miscellany (settled, do not re-litigate)
+
+- Utility classes are `final` with a private constructor.
+- Tests: wildcard static import of `Assertions.*` is fine; new test methods
+  get behavior-sentence names (`rejectsNullEmptyAndUnknown`), not
+  `testXxx`/`_Should` styles.
+- The golden-file pattern (`TestFixtures`, `-Dupdate.goldens=true`) is the
+  required idiom for any new emitted surface.

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/Address.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/Address.java
@@ -7,9 +7,8 @@
  */
 package com.fastChickensHR.edi.x834.loop2000;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * A single typed postal address for a member (residence, mailing, work, ...).
@@ -17,9 +16,8 @@ import lombok.Data;
  * <p>This is a pure domain object; how (and whether) a given {@link AddressType} is serialized into
  * the X12 834 wire format is decided by the writer — see {@link AddressType} for the mapping.
  */
-@Data
-@Builder
-@AllArgsConstructor
+@Getter
+@Setter
 public class Address {
   private AddressType type;
   private String line1;

--- a/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
+++ b/x834/src/main/java/com/fastChickensHR/edi/x834/loop2000/BaseMember.java
@@ -28,6 +28,7 @@ import com.fastChickensHR.edi.x834.loop2000.loop2700.ReportingCategory;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -182,7 +183,7 @@ public abstract class BaseMember {
    * @param type the address kind to look up
    * @return this member's address of that type, if any
    */
-  public java.util.Optional<Address> getAddress(AddressType type) {
+  public Optional<Address> getAddress(AddressType type) {
     return addresses.stream().filter(a -> a.getType() == type).findFirst();
   }
 

--- a/x834/src/test/java/com/fastChickensHR/edi/x834/X834MemberWriterTest.java
+++ b/x834/src/test/java/com/fastChickensHR/edi/x834/X834MemberWriterTest.java
@@ -244,14 +244,13 @@ class X834MemberWriterTest {
     member.setState("IL");
     member.setZipCode("62704");
     // mailing (2100C) — a distinct PO box
-    member.addAddress(
-        Address.builder()
-            .type(AddressType.MAILING)
-            .line1("PO BOX 99")
-            .city("SPRINGFIELD")
-            .state("IL")
-            .zipCode("62705")
-            .build());
+    Address mailing = new Address();
+    mailing.setType(AddressType.MAILING);
+    mailing.setLine1("PO BOX 99");
+    mailing.setCity("SPRINGFIELD");
+    mailing.setState("IL");
+    mailing.setZipCode("62705");
+    member.addAddress(mailing);
 
     String out = render(writer.toSegments(member));
 


### PR DESCRIPTION
Execution of [#262](https://github.com/FastChickensHR/edi/issues/262) (the #243 idiom rulings; map #202). **Merge before cutting `v1.0.0-beta.1`** — with the tag uncut, the `Address` change ships inside the first release, so no Breaking entry is needed (a first release has no predecessor to break) and beta.1's "none (first release)" stays truthful.

## docs/STYLE.md

The five #243 rulings (records vs beans by role · Lombok charter · hand-written nested builders · null-means-omit vs `Optional`, JSpecify deferred · the `X834*` machinery-vs-contents test), plus the #216 error-channel contract and #210's inline rulings. CONTRIBUTING's #243 placeholder now links the guide.

## Code alignments

- **`Address`** drops `@Data @Builder @AllArgsConstructor` for the family's `@Getter @Setter` bean shape; its one in-repo `Address.builder()` call site (`X834MemberWriterTest`) migrated to bean style. mono's two call sites migrate on its next pin bump (noted on mono#849).
- **`BaseMember`**: fully-qualified `java.util.Optional` → normal import.

## ⚠️ One deviation from the ticket, flagged for review

The ticket's "remove the no-op `AbstractBuilder` `@Setter`s" was based on the 0207 survey (2026-07-26). Since the #220 hide sweep (2026-07-27), those `@Setter`s carry `@Accessors(chain = true)` and generate the segment builders' **live fluent API** — tests call them and the domain-named setters delegate to them. Nothing is dead; removing them would demolish the segment layer. STYLE.md instead documents `@Setter @Accessors(chain = true)` as the frozen internal legacy mechanism of the `AbstractBuilder` layer (no new uses). Same outcome as `Segment.setContext` in the ticket: resolved by history, recorded honestly.

Full `mvn -B verify` gate stack green locally (japicmp lenient — baseline unpublished until the tag).

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)